### PR TITLE
GLSL source code cleaning

### DIFF
--- a/src/Renderer/Effects/Cylinder.js
+++ b/src/Renderer/Effects/Cylinder.js
@@ -46,6 +46,10 @@ function(      WebGL,         Texture,          glMatrix,        Client,        
 	 * @var {string} Vertex Shader
 	 */
 	var _vertexShader   = `
+		#version 100
+		#pragma vscode_glsllint_stage : vert
+		precision highp float;
+
 		attribute vec3 aPosition;
 		attribute vec2 aTextureCoord;
 		
@@ -92,10 +96,14 @@ function(      WebGL,         Texture,          glMatrix,        Client,        
 	 * @var {string} Fragment Shader
 	 */
 	var _fragmentShader = `
+		#version 100
+		#pragma vscode_glsllint_stage : frag
+
+		precision highp float;
+
 		varying vec2 vTextureCoord;
-		
+
 		uniform sampler2D uDiffuse;
-		
 		uniform vec4 uSpriteRendererColor;
 		
 		uniform bool  uFogUse;
@@ -109,7 +117,7 @@ function(      WebGL,         Texture,          glMatrix,        Client,        
 				discard; 
 			}
 			
-			vec4 texture = texture2D( uDiffuse,  vTextureCoord.st );
+		 vec4 texture = texture2D( uDiffuse,  vTextureCoord.st );
 			
 			if (texture.a == 0.0) {
 				discard;
@@ -122,8 +130,8 @@ function(      WebGL,         Texture,          glMatrix,        Client,        
 			gl_FragColor   = texture * uSpriteRendererColor;
 			
 			if (uFogUse) {
-				float depth = gl_FragCoord.z / gl_FragCoord.w;
-				float fogFactor = smoothstep( uFogNear, uFogFar, depth );
+			 float depth = gl_FragCoord.z / gl_FragCoord.w;
+			 float fogFactor = smoothstep( uFogNear, uFogFar, depth );
 				gl_FragColor    = mix( gl_FragColor, vec4( uFogColor, gl_FragColor.w ), fogFactor );
 			}
 		}

--- a/src/Renderer/Effects/GroundEffect.js
+++ b/src/Renderer/Effects/GroundEffect.js
@@ -9,6 +9,10 @@ function (WebGL,        glMatrix,          SkillID,                Client,      
     var _matrix = mat4.create();
 	
     var _vertexShader = `
+        #version 100
+		#pragma vscode_glsllint_stage : vert
+		precision highp float;
+
 		attribute vec3 aPosition;
 		attribute vec2 aTextureCoord;
 		varying vec2 vTextureCoord;
@@ -23,6 +27,10 @@ function (WebGL,        glMatrix,          SkillID,                Client,      
 	`;
 	
     var _fragmentShader = `
+        #version 100
+        #pragma vscode_glsllint_stage : frag
+        precision highp float;
+        
 		varying vec2 vTextureCoord;
 		uniform sampler2D uDiffuse;
 		uniform vec4 uSpriteRendererColor;

--- a/src/Renderer/Effects/LPEffect.js
+++ b/src/Renderer/Effects/LPEffect.js
@@ -14,6 +14,10 @@ define(["exports", "Utils/WebGL", "Renderer/Effects/Tiles"], function (exports, 
   }
 
   var _LPVertexShader = `
+        #version 100
+        #pragma vscode_glsllint_stage : vert
+        precision highp float;
+
         attribute vec2 aPosition;
         attribute vec2 aTextureCoord;
         varying vec2 vTextureCoord;
@@ -30,6 +34,10 @@ define(["exports", "Utils/WebGL", "Renderer/Effects/Tiles"], function (exports, 
         }
 `;
   var _LPFragmentShader = `
+        #version 100
+        #pragma vscode_glsllint_stage : frag
+        precision highp float;
+
         varying vec2 vTextureCoord;
         uniform sampler2D uDiffuse;
         void main(void) {

--- a/src/Renderer/Effects/LockOnTarget.js
+++ b/src/Renderer/Effects/LockOnTarget.js
@@ -52,63 +52,69 @@ define(function( require ) {
 	/**
 	 * @var {string} Vertex Shader
 	 */
-	var _vertexShader   = [
-		'attribute vec2 aPosition;',
-		'attribute vec2 aTextureCoord;',
+	var _vertexShader   = `
+		#version 100
+		#pragma vscode_glsllint_stage : vert
+		precision highp float;
 
-		'varying vec2 vTextureCoord;',
+		attribute vec2 aPosition;
+		attribute vec2 aTextureCoord;
 
-		'uniform mat4 uModelViewMat;',
-		'uniform mat4 uProjectionMat;',
-		'uniform mat4 uRotationMat;',
+		varying vec2 vTextureCoord;
 
-		'uniform vec3 uPosition;',
-		'uniform float uSize;',
+		uniform mat4 uModelViewMat;
+		uniform mat4 uProjectionMat;
+		uniform mat4 uRotationMat;
 
-		'void main(void) {',
-			'vec4 position  = vec4(uPosition.x + 0.5, -uPosition.z, uPosition.y + 0.5, 1.0);',
-			'position      += vec4(aPosition.x * uSize, 0.0, aPosition.y * uSize, 0.0) * uRotationMat;',
+		uniform vec3 uPosition;
+		uniform float uSize;
 
-			'gl_Position    = uProjectionMat * uModelViewMat * position;',
-			'gl_Position.z -= 0.02;',
+		void main(void) {
+			vec4 position  = vec4(uPosition.x + 0.5, -uPosition.z, uPosition.y + 0.5, 1.0);
+			position      += vec4(aPosition.x * uSize, 0.0, aPosition.y * uSize, 0.0) * uRotationMat;
 
-			'vTextureCoord  = aTextureCoord;',
-		'}'
-	].join('\n');
+			gl_Position    = uProjectionMat * uModelViewMat * position;
+			gl_Position.z -= 0.02;
 
+			vTextureCoord  = aTextureCoord;
+		}
+	`;
 
 	/**
 	 * @var {string} Fragment Shader
 	 */
-	var _fragmentShader = [
-		'varying vec2 vTextureCoord;',
+	var _fragmentShader = `
+		#version 100
+		#pragma vscode_glsllint_stage : frag
+		precision highp float;
 
-		'uniform sampler2D uDiffuse;',
-		'uniform float uColor;',
+		varying vec2 vTextureCoord;
 
-		'uniform bool  uFogUse;',
-		'uniform float uFogNear;',
-		'uniform float uFogFar;',
-		'uniform vec3  uFogColor;',
+		uniform sampler2D uDiffuse;
+		uniform float uColor;
 
-		'void main(void) {',
-			'vec4 texture = texture2D( uDiffuse,  vTextureCoord.st );',
+		uniform bool  uFogUse;
+		uniform float uFogNear;
+		uniform float uFogFar;
+		uniform vec3  uFogColor;
 
-			'if (texture.a == 0.0) {',
-			'	discard;',
-			'}',
+		void main(void) {
+			vec4 texture = texture2D( uDiffuse,  vTextureCoord.st );
 
-			'gl_FragColor     = texture;',
-			'gl_FragColor.gb *= uColor;',
+			if (texture.a == 0.0) {
+				discard;
+			}
 
-			'if (uFogUse) {',
-				'float depth     = gl_FragCoord.z / gl_FragCoord.w;',
-				'float fogFactor = smoothstep( uFogNear, uFogFar, depth );',
-				'gl_FragColor    = mix( gl_FragColor, vec4( uFogColor, gl_FragColor.w ), fogFactor );',
-			'}',
-		'}'
-	].join('\n');
+			gl_FragColor     = texture;
+			gl_FragColor.gb *= uColor;
 
+			if (uFogUse) {
+				float depth     = gl_FragCoord.z / gl_FragCoord.w;
+				float fogFactor = smoothstep( uFogNear, uFogFar, depth );
+				gl_FragColor    = mix( gl_FragColor, vec4( uFogColor, gl_FragColor.w ), fogFactor );
+			}
+		}
+	`;
 
 	/**
 	 * LockOnTarget constructor

--- a/src/Renderer/Effects/MagicRing.js
+++ b/src/Renderer/Effects/MagicRing.js
@@ -46,76 +46,85 @@ function(      WebGL,         Texture,          glMatrix,        Client) {
 	/**
 	 * @var {string} Vertex Shader
 	 */
-	var _vertexShader   = [
-		'attribute vec3 aPosition;',
-		'attribute vec2 aTextureCoord;',
+	var _vertexShader   = `
+		#version 100
+		#pragma vscode_glsllint_stage : vert
+		precision highp float;
 
-		'varying vec2 vTextureCoord;',
+		attribute vec3 aPosition;
+		attribute vec2 aTextureCoord;
 
-		'uniform mat4 uModelViewMat;',
-		'uniform mat4 uProjectionMat;',
-		'uniform mat4 uRotationMat;',
+		varying vec2 vTextureCoord;
 
-		'uniform vec3 uPosition;',
-		'uniform float uTopSize;',
-		'uniform float uBottomSize;',
-		'uniform float uHeight;',
+		uniform mat4 uModelViewMat;
+		uniform mat4 uProjectionMat;
+		uniform mat4 uRotationMat;
 
-		'void main(void) {',
-			'float size, height;',
+		uniform vec3 uPosition;
+		uniform float uTopSize;
+		uniform float uBottomSize;
+		uniform float uHeight;
 
-			'if (aPosition.z == 1.0) {',
-				'size   = uTopSize;',
-				'height = uHeight;',
-			'}',
-			'else {',
-				'size   = uBottomSize;',
-				'height = 0.0;',
-			'}',
+		void main(void) {
+			float size, height;
 
-			'vec4 position  = vec4(uPosition.x + 0.5, -uPosition.z - height, uPosition.y + 0.5, 1.0);',
-			'position      += vec4(aPosition.x * size, 0.0, aPosition.y * size, 0.0) * uRotationMat;',
+			if (aPosition.z == 1.0) {
+				size   = uTopSize;
+				height = uHeight;
+			}
+			else {
+				size   = uBottomSize;
+				height = 0.0;
+			}
 
-			'gl_Position    = uProjectionMat * uModelViewMat * position;',
-			'vTextureCoord  = aTextureCoord;',
-		'}'
-	].join('\n');
+			vec4 position  = vec4(uPosition.x + 0.5, -uPosition.z - height, uPosition.y + 0.5, 1.0);
+			position      += vec4(aPosition.x * size, 0.0, aPosition.y * size, 0.0) * uRotationMat;
+
+			gl_Position    = uProjectionMat * uModelViewMat * position;
+			vTextureCoord  = aTextureCoord;
+		}
+	`;
+		
+	
 
 
 	/**
 	 * @var {string} Fragment Shader
 	 */
-	var _fragmentShader = [
-		'varying vec2 vTextureCoord;',
+	var _fragmentShader = `
+		#version 100
+		#pragma vscode_glsllint_stage : frag
+		precision highp float;
 
-		'uniform sampler2D uDiffuse;',
+		varying vec2 vTextureCoord;
 
-		'uniform bool  uFogUse;',
-		'uniform float uFogNear;',
-		'uniform float uFogFar;',
-		'uniform vec3  uFogColor;',
+		uniform sampler2D uDiffuse;
 
-		'void main(void) {',
-			'vec4 texture = texture2D( uDiffuse,  vTextureCoord.st );',
+		uniform bool  uFogUse;
+		uniform float uFogNear;
+		uniform float uFogFar;
+		uniform vec3  uFogColor;
 
-			'if (texture.a == 0.0) {',
-			'	discard;',
-			'}',
+		void main(void) {
+			vec4 texture = texture2D( uDiffuse,  vTextureCoord.st );
 
-            'if (texture.r < 0.5 || texture.g < 0.5 || texture.b < 0.5) {',
-            '   discard;',
-            '}',
-			'texture.a = 0.7;',
-			'gl_FragColor = texture;',
+			if (texture.a == 0.0) {
+				discard;
+			}
 
-			'if (uFogUse) {',
-				'float depth     = gl_FragCoord.z / gl_FragCoord.w;',
-				'float fogFactor = smoothstep( uFogNear, uFogFar, depth );',
-				'gl_FragColor    = mix( gl_FragColor, vec4( uFogColor, gl_FragColor.w ), fogFactor );',
-			'}',
-		'}'
-	].join('\n');
+            if (texture.r < 0.5 || texture.g < 0.5 || texture.b < 0.5) {
+               discard;
+            }
+			texture.a = 0.7;
+			gl_FragColor = texture;
 
+			if (uFogUse) {
+				float depth     = gl_FragCoord.z / gl_FragCoord.w;
+				float fogFactor = smoothstep( uFogNear, uFogFar, depth );
+				gl_FragColor    = mix( gl_FragColor, vec4( uFogColor, gl_FragColor.w ), fogFactor );
+			}
+		}
+	`;
 
 	/**
 	 * Generate a generic MagicRing

--- a/src/Renderer/Effects/MagicTarget.js
+++ b/src/Renderer/Effects/MagicTarget.js
@@ -156,6 +156,10 @@ define(function( require ) {
 	 * @var {string} Vertex Shader
 	 */
 	var _vertexShader   = `
+		#version 100
+		#pragma vscode_glsllint_stage : vert
+		precision highp float;
+		
 		attribute vec3 aPosition;
 		attribute vec2 aTextureCoord;
 
@@ -179,37 +183,40 @@ define(function( require ) {
 	/**
 	 * @var {string} Fragment Shader
 	 */
-	var _fragmentShader = [
-		'varying vec2 vTextureCoord;',
+	var _fragmentShader = `
+		#version 100
+		#pragma vscode_glsllint_stage : frag
+		precision highp float;
 
-		'uniform sampler2D uDiffuse;',
+		varying vec2 vTextureCoord;
 
-		'uniform bool  uFogUse;',
-		'uniform float uFogNear;',
-		'uniform float uFogFar;',
-		'uniform vec3  uFogColor;',
+		uniform sampler2D uDiffuse;
 
-		'void main(void) {',
-			'vec4 texture = texture2D( uDiffuse,  vTextureCoord.st );',
+		uniform bool  uFogUse;
+		uniform float uFogNear;
+		uniform float uFogFar;
+		uniform vec3  uFogColor;
 
-			'if (texture.a == 0.0) {',
-			'	discard;',
-			'}',
+		void main(void) {
+			vec4 texture = texture2D( uDiffuse,  vTextureCoord.st );
 
-            'if (texture.r < 0.1 || texture.g < 0.1 || texture.b < 0.1) {',
-            '   discard;',
-            '}',
+			if (texture.a == 0.0) {
+				discard;
+			}
 
-			'gl_FragColor = texture;',
+            if (texture.r < 0.1 || texture.g < 0.1 || texture.b < 0.1) {
+               discard;
+            }
 
-			'if (uFogUse) {',
-				'float depth     = gl_FragCoord.z / gl_FragCoord.w;',
-				'float fogFactor = smoothstep( uFogNear, uFogFar, depth );',
-				'gl_FragColor    = mix( gl_FragColor, vec4( uFogColor, gl_FragColor.w ), fogFactor );',
-			'}',
-		'}'
-	].join('\n');
+			gl_FragColor = texture;
 
+			if (uFogUse) {
+				float depth     = gl_FragCoord.z / gl_FragCoord.w;
+				float fogFactor = smoothstep( uFogNear, uFogFar, depth );
+				gl_FragColor    = mix( gl_FragColor, vec4( uFogColor, gl_FragColor.w ), fogFactor );
+			}
+		}
+	`;
 
 	/**
 	 * MagicTarget constructor

--- a/src/Renderer/Effects/MagnumBreak.js
+++ b/src/Renderer/Effects/MagnumBreak.js
@@ -46,76 +46,83 @@ function(      WebGL,         Texture,          glMatrix,        Client) {
 	/**
 	 * @var {string} Vertex Shader
 	 */
-	var _vertexShader   = [
-		'attribute vec3 aPosition;',
-		'attribute vec2 aTextureCoord;',
+	var _vertexShader   = `
+		#version 100
+		#pragma vscode_glsllint_stage : vert
+		precision highp float;
 
-		'varying vec2 vTextureCoord;',
+		attribute vec3 aPosition;
+		attribute vec2 aTextureCoord;
 
-		'uniform mat4 uModelViewMat;',
-		'uniform mat4 uProjectionMat;',
-		'uniform mat4 uRotationMat;',
+		varying vec2 vTextureCoord;
 
-		'uniform vec3 uPosition;',
-		'uniform float uTopSize;',
-		'uniform float uBottomSize;',
-		'uniform float uHeight;',
+		uniform mat4 uModelViewMat;
+		uniform mat4 uProjectionMat;
+		uniform mat4 uRotationMat;
 
-		'void main(void) {',
-			'float size, height;',
+		uniform vec3 uPosition;
+		uniform float uTopSize;
+		uniform float uBottomSize;
+		uniform float uHeight;
 
-			'if (aPosition.z == 1.0) {',
-				'size   = uTopSize;',
-				'height = uHeight;',
-			'}',
-			'else {',
-				'size   = uBottomSize;',
-				'height = 0.0;',
-			'}',
+		void main(void) {
+			float size, height;
 
-			'vec4 position  = vec4(uPosition.x + 0.5, -uPosition.z - height, uPosition.y + 0.5, 1.0);',
-			'position      += vec4(aPosition.x * size, 0.0, aPosition.y * size, 0.0) * uRotationMat;',
+			if (aPosition.z == 1.0) {
+				size   = uTopSize;
+				height = uHeight;
+			}
+			else {
+				size   = uBottomSize;
+				height = 0.0;
+			}
 
-			'gl_Position    = uProjectionMat * uModelViewMat * position;',
-			'vTextureCoord  = aTextureCoord;',
-		'}'
-	].join('\n');
+			vec4 position  = vec4(uPosition.x + 0.5, -uPosition.z - height, uPosition.y + 0.5, 1.0);
+			position      += vec4(aPosition.x * size, 0.0, aPosition.y * size, 0.0) * uRotationMat;
 
+			gl_Position    = uProjectionMat * uModelViewMat * position;
+			vTextureCoord  = aTextureCoord;
+		}
+	`;
+		
 
 	/**
 	 * @var {string} Fragment Shader
 	 */
-	var _fragmentShader = [
-		'varying vec2 vTextureCoord;',
+	var _fragmentShader = `
+		#version 100
+		#pragma vscode_glsllint_stage : frag
+		precision highp float;
 
-		'uniform sampler2D uDiffuse;',
+		varying vec2 vTextureCoord;
 
-		'uniform bool  uFogUse;',
-		'uniform float uFogNear;',
-		'uniform float uFogFar;',
-		'uniform vec3  uFogColor;',
+		uniform sampler2D uDiffuse;
 
-		'void main(void) {',
-			'vec4 texture = texture2D( uDiffuse,  vTextureCoord.st );',
+		uniform bool  uFogUse;
+		uniform float uFogNear;
+		uniform float uFogFar;
+		uniform vec3  uFogColor;
 
-			'if (texture.a == 0.0) {',
-			'	discard;',
-			'}',
+		void main(void) {
+			vec4 texture = texture2D( uDiffuse,  vTextureCoord.st );
 
-            'if (texture.r < 0.5 || texture.g < 0.5 || texture.b < 0.5) {',
-            '   discard;',
-            '}',
-			'texture.a = 0.65;',
-			'gl_FragColor = texture;',
+			if (texture.a == 0.0) {
+				discard;
+			}
 
-			'if (uFogUse) {',
-				'float depth     = gl_FragCoord.z / gl_FragCoord.w;',
-				'float fogFactor = smoothstep( uFogNear, uFogFar, depth );',
-				'gl_FragColor    = mix( gl_FragColor, vec4( uFogColor, gl_FragColor.w ), fogFactor );',
-			'}',
-		'}'
-	].join('\n');
+            if (texture.r < 0.5 || texture.g < 0.5 || texture.b < 0.5) {
+               discard;
+            }
+			texture.a = 0.65;
+			gl_FragColor = texture;
 
+			if (uFogUse) {
+				float depth     = gl_FragCoord.z / gl_FragCoord.w;
+				float fogFactor = smoothstep( uFogNear, uFogFar, depth );
+				gl_FragColor    = mix( gl_FragColor, vec4( uFogColor, gl_FragColor.w ), fogFactor );
+			}
+		}
+	`;
 
 	/**
 	 * Generate a generic MagnumBreak

--- a/src/Renderer/Effects/PropertyGround.js
+++ b/src/Renderer/Effects/PropertyGround.js
@@ -50,76 +50,82 @@ function(      WebGL,         Texture,          glMatrix,        Client) {
 	/**
 	 * @var {string} Vertex Shader
 	 */
-	var _vertexShader   = [
-		'attribute vec3 aPosition;',
-		'attribute vec2 aTextureCoord;',
+	var _vertexShader   = `
+		#version 100
+		#pragma vscode_glsllint_stage : vert
+		precision highp float;
 
-		'varying vec2 vTextureCoord;',
+		attribute vec3 aPosition;
+		attribute vec2 aTextureCoord;
 
-		'uniform mat4 uModelViewMat;',
-		'uniform mat4 uProjectionMat;',
-		'uniform mat4 uRotationMat;',
+		varying vec2 vTextureCoord;
 
-		'uniform vec3 uPosition;',
-		'uniform float uTopSize;',
-		'uniform float uBottomSize;',
-		'uniform float uHeight;',
+		uniform mat4 uModelViewMat;
+		uniform mat4 uProjectionMat;
+		uniform mat4 uRotationMat;
 
-		'void main(void) {',
-			'float size, height;',
+		uniform vec3 uPosition;
+		uniform float uTopSize;
+		uniform float uBottomSize;
+		uniform float uHeight;
 
-			'if (aPosition.z == 1.0) {',
-				'size   = uTopSize;',
-				'height = uHeight;',
-			'}',
-			'else {',
-				'size   = uBottomSize;',
-				'height = 0.0;',
-			'}',
+		void main(void) {
+			float size, height;
 
-			'vec4 position  = vec4(uPosition.x + 0.5, -uPosition.z - height, uPosition.y + 0.5, 1.0);',
-			'position      += vec4(aPosition.x * size, 0.0, aPosition.y * size, 0.0) * uRotationMat;',
+			if (aPosition.z == 1.0) {
+				size   = uTopSize;
+				height = uHeight;
+			}
+			else {
+				size   = uBottomSize;
+				height = 0.0;
+			}
 
-			'gl_Position    = uProjectionMat * uModelViewMat * position;',
-			'vTextureCoord  = aTextureCoord;',
-		'}'
-	].join('\n');
+			vec4 position  = vec4(uPosition.x + 0.5, -uPosition.z - height, uPosition.y + 0.5, 1.0);
+			position      += vec4(aPosition.x * size, 0.0, aPosition.y * size, 0.0) * uRotationMat;
 
-
+			gl_Position    = uProjectionMat * uModelViewMat * position;
+			vTextureCoord  = aTextureCoord;
+		}
+	`;
+		
 	/**
 	 * @var {string} Fragment Shader
 	 */
-	var _fragmentShader = [
-		'varying vec2 vTextureCoord;',
+	var _fragmentShader = `
+		#version 100
+		#pragma vscode_glsllint_stage : frag
+		precision highp float;
 
-		'uniform sampler2D uDiffuse;',
+		varying vec2 vTextureCoord;
 
-		'uniform bool  uFogUse;',
-		'uniform float uFogNear;',
-		'uniform float uFogFar;',
-		'uniform vec3  uFogColor;',
+		uniform sampler2D uDiffuse;
 
-		'void main(void) {',
-			'vec4 texture = texture2D( uDiffuse,  vTextureCoord.st );',
+		uniform bool  uFogUse;
+		uniform float uFogNear;
+		uniform float uFogFar;
+		uniform vec3  uFogColor;
 
-			'if (texture.a == 0.0) {',
-			'	discard;',
-			'}',
+		void main(void) {
+			vec4 texture = texture2D( uDiffuse,  vTextureCoord.st );
 
-            'if (texture.r < 0.5 || texture.g < 0.5 || texture.b < 0.5) {',
-            '   discard;',
-            '}',
-			'texture.a = 0.42;',
-			'gl_FragColor = texture;',
+			if (texture.a == 0.0) {
+				discard;
+			}
 
-			'if (uFogUse) {',
-				'float depth     = gl_FragCoord.z / gl_FragCoord.w;',
-				'float fogFactor = smoothstep( uFogNear, uFogFar, depth );',
-				'gl_FragColor    = mix( gl_FragColor, vec4( uFogColor, gl_FragColor.w ), fogFactor );',
-			'}',
-		'}'
-	].join('\n');
+            if (texture.r < 0.5 || texture.g < 0.5 || texture.b < 0.5) {
+               discard;
+            }
+			texture.a = 0.42;
+			gl_FragColor = texture;
 
+			if (uFogUse) {
+				float depth     = gl_FragCoord.z / gl_FragCoord.w;
+				float fogFactor = smoothstep( uFogNear, uFogFar, depth );
+				gl_FragColor    = mix( gl_FragColor, vec4( uFogColor, gl_FragColor.w ), fogFactor );
+			}
+		}
+	`;
 
 	/**
 	 * Generate a generic PropertyGround

--- a/src/Renderer/Effects/SpiderWeb.js
+++ b/src/Renderer/Effects/SpiderWeb.js
@@ -16,13 +16,20 @@ define(["exports", "Utils/WebGL", "Renderer/Effects/Tiles"], function (exports, 
   }
 
   var _SpiderWebVertexShader = `
+        #version 100
+        #pragma vscode_glsllint_stage : vert
+        precision highp float;
+
         attribute vec2 aPosition;
         attribute vec2 aTextureCoord;
+
         varying vec2 vTextureCoord;
+
         uniform mat4 uModelViewMat;
         uniform mat4 uProjectionMat;
         uniform vec3 uPosition;
         uniform float uSize;
+
         void main(void) {
             vec4 position  = vec4(uPosition.x + 0.5, -uPosition.z, uPosition.y + 0.5, 1.0);
             position      += vec4(aPosition.x * uSize, 0.0, aPosition.y * uSize, 0.0);
@@ -32,8 +39,14 @@ define(["exports", "Utils/WebGL", "Renderer/Effects/Tiles"], function (exports, 
         }
 `;
   var _SpiderWebFragmentShader = `
+        #version 100
+        #pragma vscode_glsllint_stage : frag
+        precision highp float;
+
         varying vec2 vTextureCoord;
+
         uniform sampler2D uDiffuse;
+
         void main(void) {
             vec4 texture = texture2D( uDiffuse,  vTextureCoord.st );
             if (texture.r < 0.5 || texture.g < 0.5 || texture.b < 0.5) {

--- a/src/Renderer/Effects/SpiritSphere.js
+++ b/src/Renderer/Effects/SpiritSphere.js
@@ -51,8 +51,12 @@ define(function( require ) {
     /**
      * @var {string} Vertex Shader
      */
-    var _vertexShader   = 
-        `attribute vec2 aPosition;
+    var _vertexShader   = `
+        #version 100
+        #pragma vscode_glsllint_stage : vert
+        precision highp float;
+
+        attribute vec2 aPosition;
         attribute vec2 aTextureCoord;
 
         varying vec2 vTextureCoord;
@@ -86,8 +90,12 @@ define(function( require ) {
     /**
      * @var {string} Fragment Shader
      */
-    var _fragmentShader = 
-        `varying vec2 vTextureCoord;
+    var _fragmentShader = `
+        #version 100
+        #pragma vscode_glsllint_stage : frag
+        precision highp float;    
+
+        varying vec2 vTextureCoord;
 
         uniform vec4 uColor;
         uniform sampler2D uDiffuse;

--- a/src/Renderer/Effects/StrEffect.js
+++ b/src/Renderer/Effects/StrEffect.js
@@ -19,86 +19,92 @@ define(['Utils/WebGL', 'Utils/gl-matrix', 'Core/Client'], function( WebGL, glMat
 	 * Generic Vertex Shader
 	 * @var {string}
 	 */
-	var _vertexShader = [
-		'attribute vec2 aPosition;',
-		'attribute vec2 aTextureCoord;',
+	var _vertexShader = `
+		#version 100
+		#pragma vscode_glsllint_stage : vert
+		precision highp float;
 
-		'varying vec2 vTextureCoord;',
+		attribute vec2 aPosition;
+		attribute vec2 aTextureCoord;
 
-		'uniform mat4 uModelViewMat;',
-		'uniform mat4 uProjectionMat;',
+		varying vec2 vTextureCoord;
 
-		'uniform mat4 uSpriteAngle;',
-		'uniform vec3 uSpritePosition;',
-		'uniform vec2 uSpriteOffset;',
+		uniform mat4 uModelViewMat;
+		uniform mat4 uProjectionMat;
 
-		'const float pixelRatio = 1.0 / 35.0;',
+		uniform mat4 uSpriteAngle;
+		uniform vec3 uSpritePosition;
+		uniform vec2 uSpriteOffset;
 
-		'mat4 Project( mat4 mat, vec3 pos) {',
+		const float pixelRatio = 1.0 / 35.0;
+
+		mat4 Project( mat4 mat, vec3 pos) {
 
 			// xyz = x(-z)y + middle of cell (0.5)
-			'float x =  pos.x + 0.5;',
-			'float y = -pos.z;',
-			'float z =  pos.y + 0.5;',
+			float x =  pos.x + 0.5;
+			float y = -pos.z;
+			float z =  pos.y + 0.5;
 
 			// Matrix translation
-			'mat[3].x += mat[0].x * x + mat[1].x * y + mat[2].x * z;',
-			'mat[3].y += mat[0].y * x + mat[1].y * y + mat[2].y * z;',
-			'mat[3].z += mat[0].z * x + mat[1].z * y + mat[2].z * z;',
-			'mat[3].w += mat[0].w * x + mat[1].w * y + mat[2].w * z;',
+			mat[3].x += mat[0].x * x + mat[1].x * y + mat[2].x * z;
+			mat[3].y += mat[0].y * x + mat[1].y * y + mat[2].y * z;
+			mat[3].z += mat[0].z * x + mat[1].z * y + mat[2].z * z;
+			mat[3].w += mat[0].w * x + mat[1].w * y + mat[2].w * z;
 
 			// Spherical billboard
-			'mat[0].xyz = vec3( 1.0, 0.0, 0.0 );',
-			'mat[1].xyz = vec3( 0.0, 1.0, 0.0 );',
-			'mat[2].xyz = vec3( 0.0, 0.0, 1.0 );',
+			mat[0].xyz = vec3( 1.0, 0.0, 0.0 );
+			mat[1].xyz = vec3( 0.0, 1.0, 0.0 );
+			mat[2].xyz = vec3( 0.0, 0.0, 1.0 );
 
-			'return mat;',
-		'}',
+			return mat;
+		}
 
-		'void main(void) {',
-			'vTextureCoord = aTextureCoord;',
+		void main(void) {
+			vTextureCoord = aTextureCoord;
 
 			// Calculate position base on angle and sprite offset/size
-			'vec4 position = uSpriteAngle * vec4( aPosition.x * pixelRatio, -aPosition.y * pixelRatio, 0.0, 1.0 );',
-			'position.x   += uSpriteOffset.x * pixelRatio;',
-			'position.y   -= uSpriteOffset.y * pixelRatio + 0.5;',
+			vec4 position = uSpriteAngle * vec4( aPosition.x * pixelRatio, -aPosition.y * pixelRatio, 0.0, 1.0 );
+			position.x   += uSpriteOffset.x * pixelRatio;
+			position.y   -= uSpriteOffset.y * pixelRatio + 0.5;
 
 			// Project to camera plane
-			'gl_Position    = uProjectionMat * Project(uModelViewMat, uSpritePosition) * position;',
-			'gl_Position.z -= 0.1;',
-		'}'
-	].join('\n');
-
+			gl_Position    = uProjectionMat * Project(uModelViewMat, uSpritePosition) * position;
+			gl_Position.z -= 0.1;
+		}
+	`;
 
 	/**
 	 * Generic Fragment Shader
 	 * @var {string}
 	 */
-	var _fragmentShader = [
-		'varying vec2 vTextureCoord;',
+	var _fragmentShader = `
+		#version 100
+		#pragma vscode_glsllint_stage : frag
+		precision highp float;
 
-		'uniform vec4 uSpriteColor;',
-		'uniform sampler2D uDiffuse;',
+		varying vec2 vTextureCoord;
 
-		'uniform bool  uFogUse;',
-		'uniform float uFogNear;',
-		'uniform float uFogFar;',
-		'uniform vec3  uFogColor;',
+		uniform vec4 uSpriteColor;
+		uniform sampler2D uDiffuse;
 
-		'void main(void) {',
-			'gl_FragColor = texture2D( uDiffuse, vTextureCoord.st ) * uSpriteColor;',
-			'if ( gl_FragColor.a == 0.0 ) {',
-				'discard;',
-			'}',
+		uniform bool  uFogUse;
+		uniform float uFogNear;
+		uniform float uFogFar;
+		uniform vec3  uFogColor;
 
-			'if ( uFogUse ) {',
-				'float depth     = gl_FragCoord.z / gl_FragCoord.w;',
-				'float fogFactor = smoothstep( uFogNear, uFogFar, depth );',
-				'gl_FragColor    = mix( gl_FragColor, vec4( uFogColor, gl_FragColor.w ), fogFactor );',
-			'}',
-		'}'
-	].join('\n');
+		void main(void) {
+			gl_FragColor = texture2D( uDiffuse, vTextureCoord.st ) * uSpriteColor;
+			if ( gl_FragColor.a == 0.0 ) {
+				discard;
+			}
 
+			if ( uFogUse ) {
+				float depth     = gl_FragCoord.z / gl_FragCoord.w;
+				float fogFactor = smoothstep( uFogNear, uFogFar, depth );
+				gl_FragColor    = mix( gl_FragColor, vec4( uFogColor, gl_FragColor.w ), fogFactor );
+			}
+		}
+	`;
 
 	/**
 	 * Look up table D3DX => OPENGL

--- a/src/Renderer/Effects/Tiles.js
+++ b/src/Renderer/Effects/Tiles.js
@@ -25,13 +25,17 @@ define(["exports", "Utils/WebGL", "Utils/Texture", "Utils/gl-matrix", "Core/Clie
 
   const mat4 = _glMatrix2.default.mat4;
   var flatTextureVertexShader = exports.flatTextureVertexShader = `
+        #version 100
+        #pragma vscode_glsllint_stage : vert
+        precision highp float;
+
         attribute vec2 aPosition;
         attribute vec2 aTextureCoord;
         varying vec2 vTextureCoord;
         uniform mat4 uModelViewMat;
         uniform mat4 uProjectionMat;
         uniform vec3 uPosition;
-		uniform float uSize;
+		    uniform float uSize;
 		
 
         void main(void) {
@@ -42,29 +46,34 @@ define(["exports", "Utils/WebGL", "Utils/Texture", "Utils/gl-matrix", "Core/Clie
             vTextureCoord  = aTextureCoord;
         }
 `;
+
   var flatTextureFragmentShader = exports.flatTextureFragmentShader = `
+        #version 100
+        #pragma vscode_glsllint_stage : frag
+        precision highp float;
+        
         varying vec2 vTextureCoord;
         uniform sampler2D uDiffuse;
-		uniform float alpha;
-		
-		uniform bool  uFogUse;
-		uniform float uFogNear;
-		uniform float uFogFar;
-		uniform vec3  uFogColor;
-		
-        void main(void) {
-            vec4 texture = texture2D( uDiffuse,  vTextureCoord.st );
-            if (texture.r < 0.1 || texture.g < 0.1 || texture.b < 0.1) {
-               discard;
-            }
-            texture.a = alpha;
-            gl_FragColor = texture;
-			
-			if (uFogUse) {
-				float depth     = gl_FragCoord.z / gl_FragCoord.w;
-				float fogFactor = smoothstep( uFogNear, uFogFar, depth );
-				gl_FragColor    = mix( gl_FragColor, vec4( uFogColor, gl_FragColor.w ), fogFactor );
-			}
+        uniform float alpha;
+        
+        uniform bool  uFogUse;
+        uniform float uFogNear;
+        uniform float uFogFar;
+        uniform vec3  uFogColor;
+        
+            void main(void) {
+                vec4 texture = texture2D( uDiffuse,  vTextureCoord.st );
+                if (texture.r < 0.1 || texture.g < 0.1 || texture.b < 0.1) {
+                  discard;
+                }
+                texture.a = alpha;
+                gl_FragColor = texture;
+          
+          if (uFogUse) {
+            float depth     = gl_FragCoord.z / gl_FragCoord.w;
+            float fogFactor = smoothstep( uFogNear, uFogFar, depth );
+            gl_FragColor    = mix( gl_FragColor, vec4( uFogColor, gl_FragColor.w ), fogFactor );
+          }
         }
 `;
 

--- a/src/Renderer/Effects/WarlockSphere.js
+++ b/src/Renderer/Effects/WarlockSphere.js
@@ -51,8 +51,12 @@ define(function( require ) {
     /**
      * @var {string} Vertex Shader
      */
-    var _vertexShader   = 
-        `attribute vec2 aPosition;
+    var _vertexShader   = `
+        #version 100
+        #pragma vscode_glsllint_stage : vert
+        precision highp float;
+
+        attribute vec2 aPosition;
         attribute vec2 aTextureCoord;
 
         varying vec2 vTextureCoord;
@@ -86,8 +90,12 @@ define(function( require ) {
     /**
      * @var {string} Fragment Shader
      */
-    var _fragmentShader = 
-        `varying vec2 vTextureCoord;
+    var _fragmentShader = `
+        #version 100
+        #pragma vscode_glsllint_stage : frag
+        precision highp float;
+
+        varying vec2 vTextureCoord;
 
         uniform vec4 uColor;
         uniform sampler2D uDiffuse;

--- a/src/Renderer/Map/GridSelector.js
+++ b/src/Renderer/Map/GridSelector.js
@@ -53,6 +53,10 @@ function(              Altitude,        Client,         WebGL,         Texture )
 	 * @var {string} vertex shader
 	 */
 	var _vertexShader   = `
+		#version 100
+		#pragma vscode_glsllint_stage : vert
+		precision highp float;
+
 		attribute vec3 aPosition;
 		attribute vec2 aTextCoord;
 
@@ -75,6 +79,10 @@ function(              Altitude,        Client,         WebGL,         Texture )
 	 * @var {string} fragment shader
 	 */
 	var _fragmentShader = `
+		#version 100
+		#pragma vscode_glsllint_stage : frag
+		precision highp float;
+
 		varying vec2 vTextureCoord;
 		uniform sampler2D uDiffuse;
 

--- a/src/Renderer/Map/Models.js
+++ b/src/Renderer/Map/Models.js
@@ -33,77 +33,83 @@ define( ['Utils/WebGL'], function( WebGL )
 	/**
 	 * @var {string} vertex shader
 	 */
-	var _vertexShader   = [
-		'attribute vec3 aPosition;',
-		'attribute vec3 aVertexNormal;',
-		'attribute vec2 aTextureCoord;',
-		'attribute float aAlpha;',
+	var _vertexShader   = `
+		#version 100
+		#pragma vscode_glsllint_stage : vert
+		precision highp float;
 
-		'varying vec2 vTextureCoord;',
-		'varying float vLightWeighting;',
-		'varying float vAlpha;',
+		attribute vec3 aPosition;
+		attribute vec3 aVertexNormal;
+		attribute vec2 aTextureCoord;
+		attribute float aAlpha;
 
-		'uniform mat4 uModelViewMat;',
-		'uniform mat4 uProjectionMat;',
+		varying vec2 vTextureCoord;
+		varying float vLightWeighting;
+		varying float vAlpha;
 
-		'uniform vec3 uLightDirection;',
-		'uniform mat3 uNormalMat;',
+		uniform mat4 uModelViewMat;
+		uniform mat4 uProjectionMat;
 
-		'void main(void) {',
-			'gl_Position     = uProjectionMat * uModelViewMat * vec4( aPosition, 1.0);',
+		uniform vec3 uLightDirection;
+		uniform mat3 uNormalMat;
 
-			'vTextureCoord   = aTextureCoord;',
-			'vAlpha          = aAlpha;',
+		void main(void) {
+			gl_Position     = uProjectionMat * uModelViewMat * vec4( aPosition, 1.0);
 
-			'vec4 lDirection  = uModelViewMat * vec4( uLightDirection, 0.0);',
-			'vec3 dirVector   = normalize(lDirection.xyz);',
-			'float dotProduct = dot( uNormalMat * aVertexNormal, dirVector );',
-			'vLightWeighting  = max( dotProduct, 0.5 );',
-		'}'
-	].join('\n');
+			vTextureCoord   = aTextureCoord;
+			vAlpha          = aAlpha;
 
-
+			vec4 lDirection  = uModelViewMat * vec4( uLightDirection, 0.0);
+			vec3 dirVector   = normalize(lDirection.xyz);
+			float dotProduct = dot( uNormalMat * aVertexNormal, dirVector );
+			vLightWeighting  = max( dotProduct, 0.5 );
+		}
+	`;
+		
 	/**
 	 * @var {string} fragment shader
 	 */
-	var _fragmentShader = [
-		'varying vec2 vTextureCoord;',
-		'varying float vLightWeighting;',
-		'varying float vAlpha;',
+	var _fragmentShader = `
+		#version 100
+		#pragma vscode_glsllint_stage : vert
+		precision highp float;
 
-		'uniform sampler2D uDiffuse;',
+		varying vec2 vTextureCoord;
+		varying float vLightWeighting;
+		varying float vAlpha;
 
-		'uniform bool  uFogUse;',
-		'uniform float uFogNear;',
-		'uniform float uFogFar;',
-		'uniform vec3  uFogColor;',
+		uniform sampler2D uDiffuse;
 
-		'uniform vec3  uLightAmbient;',
-		'uniform vec3  uLightDiffuse;',
-		'uniform float uLightOpacity;',
+		uniform bool  uFogUse;
+		uniform float uFogNear;
+		uniform float uFogFar;
+		uniform vec3  uFogColor;
 
-		'void main(void) {',
-			'vec4 texture  = texture2D( uDiffuse,  vTextureCoord.st );',
+		uniform vec3  uLightAmbient;
+		uniform vec3  uLightDiffuse;
+		uniform float uLightOpacity;
 
-			'if (texture.a == 0.0) {',
-				'discard;',
-			'}',
+		void main(void) {
+			vec4 texture  = texture2D( uDiffuse,  vTextureCoord.st );
 
-			'vec3 Ambient    = uLightAmbient * uLightOpacity;',
-			'vec3 Diffuse    = uLightDiffuse * vLightWeighting;',
-			'vec4 LightColor = vec4( Ambient + Diffuse, 1.0);',
+			if (texture.a == 0.0) {
+				discard;
+			}
 
-			'gl_FragColor    = texture * clamp(LightColor, 0.0, 1.0);',
-			'gl_FragColor.a *= vAlpha;',
+			vec3 Ambient    = uLightAmbient * uLightOpacity;
+			vec3 Diffuse    = uLightDiffuse * vLightWeighting;
+			vec4 LightColor = vec4( Ambient + Diffuse, 1.0);
 
-			'if (uFogUse) {',
-				'float depth     = gl_FragCoord.z / gl_FragCoord.w;',
-				'float fogFactor = smoothstep( uFogNear, uFogFar, depth );',
-				'gl_FragColor    = mix( gl_FragColor, vec4( uFogColor, gl_FragColor.w ), fogFactor );',
-			'}',
-		'}'
-	].join('\n');
+			gl_FragColor    = texture * clamp(LightColor, 0.0, 1.0);
+			gl_FragColor.a *= vAlpha;
 
+			if (uFogUse) {
+				float depth     = gl_FragCoord.z / gl_FragCoord.w;
+				float fogFactor = smoothstep( uFogNear, uFogFar, depth );
+				gl_FragColor    = mix( gl_FragColor, vec4( uFogColor, gl_FragColor.w ), fogFactor );
+			}
+		}
+	`;
 
 	/**
 	 * Initialize models

--- a/src/Renderer/Map/Models.js
+++ b/src/Renderer/Map/Models.js
@@ -71,7 +71,7 @@ define( ['Utils/WebGL'], function( WebGL )
 	 */
 	var _fragmentShader = `
 		#version 100
-		#pragma vscode_glsllint_stage : vert
+		#pragma vscode_glsllint_stage : frag
 		precision highp float;
 
 		varying vec2 vTextureCoord;

--- a/src/Renderer/Map/Water.js
+++ b/src/Renderer/Map/Water.js
@@ -76,6 +76,10 @@ define( ['Utils/WebGL'], function( WebGL )
 	 * @var {string} vertex shader
 	 */
 	var _vertexShader   = `
+		#version 100
+		#pragma vscode_glsllint_stage : vert
+		precision highp float;
+
 		attribute vec3 aPosition;
 		attribute vec2 aTextureCoord;
 
@@ -106,6 +110,10 @@ define( ['Utils/WebGL'], function( WebGL )
 	 * @var {string} fragment shader
 	 */
 	var _fragmentShader = `
+		#version 100
+		#pragma vscode_glsllint_stage : frag
+		precision highp float;
+		
 		varying vec2 vTextureCoord;
 
 		uniform sampler2D uDiffuse;

--- a/src/Renderer/SpriteRenderer.js
+++ b/src/Renderer/SpriteRenderer.js
@@ -24,6 +24,10 @@ function(      WebGL,         glMatrix,      Camera )
 	 * @var {string}
 	 */
 	var _vertexShader = `
+		#version 100
+		#pragma vscode_glsllint_stage : vert
+		precision highp float;
+	
 		attribute vec2 aPosition;
 		attribute vec2 aTextureCoord;
 	
@@ -85,6 +89,10 @@ function(      WebGL,         glMatrix,      Camera )
 	 * @var {string}
 	 */
 	var _fragmentShader = `
+		#version 100
+		#pragma vscode_glsllint_stage : frag
+		precision highp float;
+
 		varying vec2 vTextureCoord;
 
 		uniform sampler2D uDiffuse;

--- a/src/Utils/WebGL.js
+++ b/src/Utils/WebGL.js
@@ -74,7 +74,7 @@ define( ['Utils/Texture'], function( Texture )
 
 		// Compile shader
 		shader = gl.createShader(type);
-		gl.shaderSource(shader, 'precision highp float;' + source);
+		gl.shaderSource(shader, source);
 		gl.compileShader(shader);
 
 		// Is there an error ?


### PR DESCRIPTION
Refactoring GLSL source code to make it more standard and benefit of linting in VSCode and also can use a newer version of GLSLang.
- some refactoring and cleaning of FlatColorTile.js
