### PR TITLE
Fix how frenzy looks

### DIFF
--- a/src/Renderer/Entity/EntityRender.js
+++ b/src/Renderer/Entity/EntityRender.js
@@ -330,7 +330,7 @@ define( function( require )
 
 		return function renderElement( entity, files, type, position, is_main )
 		{
-			var isEffectSprite = false;
+			var isBlendModeOne = false;
 			
 			// Nothing to render
 			if (!files.spr || !files.act)
@@ -420,18 +420,17 @@ define( function( require )
 			   }
 			}
 
-			// Check if berserk and enable alpha
+			// Check if special body effect and enable the correct blend mode
 			if (type !== 'shadow' &&
 				entity.getOpt3(StatusConst.Status.BERSERK) ||
 				entity.getOpt3(StatusConst.Status.MARIONETTE)
 			) {
-				isEffectSprite = true;
+				isBlendModeOne = true;
 			}
-
 
 			// Render all frames
 			for (var i=0, count=layers.length; i<count; ++i) {
-				entity.renderLayer( layers[i], spr, pal, files.size, _position, type, isEffectSprite);
+				entity.renderLayer( layers[i], spr, pal, files.size, _position, type, isBlendModeOne);
 			}
 
 			// Save reference
@@ -568,9 +567,9 @@ define( function( require )
 	 * @param {float}  sprite size
 	 * @param {Array} pos [x,y] where to render the sprite
 	 * @param {string} type
-	 * @param {boolean} isEffectSprite
+	 * @param {boolean} isBlendModeOne
 	 */
-	function renderLayer( layer, spr, pal, size, pos, type, isEffectSprite )
+	function renderLayer( layer, spr, pal, size, pos, type, isBlendModeOne )
 	{
 		// If there is nothing to render
 		if (layer.index < 0) {
@@ -649,7 +648,7 @@ define( function( require )
 		SpriteRenderer.image.texture = frame.texture;
 
 		// Draw Sprite
-		SpriteRenderer.render(isEffectSprite);
+		SpriteRenderer.render(isBlendModeOne);
 	}
 
 

--- a/src/Renderer/Entity/EntityRender.js
+++ b/src/Renderer/Entity/EntityRender.js
@@ -421,14 +421,17 @@ define( function( require )
 			}
 
 			// Check if berserk and enable alpha
-			if (entity.getOpt3(StatusConst.Status.BERSERK)) {
+			if (type !== 'shadow' &&
+				entity.getOpt3(StatusConst.Status.BERSERK) ||
+				entity.getOpt3(StatusConst.Status.MARIONETTE)
+			) {
 				isEffectSprite = true;
 			}
 
 
 			// Render all frames
 			for (var i=0, count=layers.length; i<count; ++i) {
-				entity.renderLayer( layers[i], spr, pal, files.size, _position, type === 'body', isEffectSprite);
+				entity.renderLayer( layers[i], spr, pal, files.size, _position, type, isEffectSprite);
 			}
 
 			// Save reference
@@ -564,9 +567,10 @@ define( function( require )
 	 * @param {object} pal palette structure
 	 * @param {float}  sprite size
 	 * @param {Array} pos [x,y] where to render the sprite
-	 * @param {bool} is main body
+	 * @param {string} type
+	 * @param {boolean} isEffectSprite
 	 */
-	function renderLayer( layer, spr, pal, size, pos, isbody, isEffectSprite )
+	function renderLayer( layer, spr, pal, size, pos, type, isEffectSprite )
 	{
 		// If there is nothing to render
 		if (layer.index < 0) {
@@ -601,7 +605,7 @@ define( function( require )
 
 
 		// Get the entity bounding rect
-		if (isbody) {
+		if (type === 'body') {
 			var w = (frame.originalWidth  * layer.scale[0] * size) / 2;
 			var h = (frame.originalHeight * layer.scale[1] * size) / 2;
 
@@ -617,15 +621,21 @@ define( function( require )
 		}
 
 		// copy color
-		SpriteRenderer.color[0] = layer.color[0] * this.effectColor[0];
-		SpriteRenderer.color[1] = layer.color[1] * this.effectColor[1];
-		SpriteRenderer.color[2] = layer.color[2] * this.effectColor[2];
-		SpriteRenderer.color[3] = layer.color[3] * this.effectColor[3];
+		if (type !== 'shadow') {
+			SpriteRenderer.color[0] = layer.color[0] * this.effectColor[0];
+			SpriteRenderer.color[1] = layer.color[1] * this.effectColor[1];
+			SpriteRenderer.color[2] = layer.color[2] * this.effectColor[2];
+			SpriteRenderer.color[3] = layer.color[3] * this.effectColor[3];
+		} else {
+			SpriteRenderer.color[0] = layer.color[0];
+			SpriteRenderer.color[1] = layer.color[1];
+			SpriteRenderer.color[2] = layer.color[2];
+			SpriteRenderer.color[3] = layer.color[3];
+		}
 
 		// apply disapear
 		if (this.remove_tick) {
 			SpriteRenderer.color[3] *= 1 - ( Renderer.tick - this.remove_tick  ) / this.remove_delay;
-			console.log(SpriteRenderer.color[3] *= 1 - ( Renderer.tick - this.remove_tick  ) / this.remove_delay)
 		}
 
 		// Store shader info

--- a/src/Renderer/Entity/EntityRender.js
+++ b/src/Renderer/Entity/EntityRender.js
@@ -330,6 +330,8 @@ define( function( require )
 
 		return function renderElement( entity, files, type, position, is_main )
 		{
+			var isEffectSprite = false;
+			
 			// Nothing to render
 			if (!files.spr || !files.act)
 			{
@@ -418,10 +420,15 @@ define( function( require )
 			   }
 			}
 
+			// Check if berserk and enable alpha
+			if (entity.getOpt3(StatusConst.Status.BERSERK)) {
+				isEffectSprite = true;
+			}
+
 
 			// Render all frames
 			for (var i=0, count=layers.length; i<count; ++i) {
-				entity.renderLayer( layers[i], spr, pal, files.size, _position, type === 'body' );
+				entity.renderLayer( layers[i], spr, pal, files.size, _position, type === 'body', isEffectSprite);
 			}
 
 			// Save reference
@@ -559,7 +566,7 @@ define( function( require )
 	 * @param {Array} pos [x,y] where to render the sprite
 	 * @param {bool} is main body
 	 */
-	function renderLayer( layer, spr, pal, size, pos, isbody )
+	function renderLayer( layer, spr, pal, size, pos, isbody, isEffectSprite )
 	{
 		// If there is nothing to render
 		if (layer.index < 0) {
@@ -618,6 +625,7 @@ define( function( require )
 		// apply disapear
 		if (this.remove_tick) {
 			SpriteRenderer.color[3] *= 1 - ( Renderer.tick - this.remove_tick  ) / this.remove_delay;
+			console.log(SpriteRenderer.color[3] *= 1 - ( Renderer.tick - this.remove_tick  ) / this.remove_delay)
 		}
 
 		// Store shader info
@@ -631,7 +639,7 @@ define( function( require )
 		SpriteRenderer.image.texture = frame.texture;
 
 		// Draw Sprite
-		SpriteRenderer.render();
+		SpriteRenderer.render(isEffectSprite);
 	}
 
 

--- a/src/Renderer/Entity/EntityState.js
+++ b/src/Renderer/Entity/EntityState.js
@@ -78,6 +78,17 @@ define(function( require )
 		}
 	}
 
+	function getOpt3(state){
+		if (state === 0){
+			return false;
+		}
+		var value = _stateToVirtue[state];
+		if (value === undefined){
+			console.log('toggleState: unknown state', state);
+			return false;
+		}
+		return (this.virtue & value) !== 0;
+	}
 	function updateVirtue(value){
 		// Reset value
 		this._virtueColor[0] = 1.0;
@@ -130,10 +141,16 @@ define(function( require )
 			this._virtueColor[2] = 0.65;
 		}
 
-		if ((value & StatusConst.OPT3.MARIONETTE) ||
-			(value & StatusConst.OPT3.BERSERK) ){
-			this._virtueColor[0] = 1.0;
-			this._virtueColor[1] = 0.3;
+		if (value & StatusConst.OPT3.MARIONETTE){
+			this._virtueColor[0] = 2.0;
+			this._virtueColor[1] = 0.50;
+			this._virtueColor[2] = 0.85;
+			this._virtueColor[3] = 0.5;
+		}
+
+		if (value & StatusConst.OPT3.BERSERK) {
+			this._virtueColor[0] = 2.0;
+			this._virtueColor[1] = 0.7;
 			this._virtueColor[2] = 0.7;
 			this._virtueColor[3] = 0.5;
 		}
@@ -542,6 +559,7 @@ define(function( require )
 		});
 
 		this.toggleOpt3 = toggleOpt3;
+		this.getOpt3 = getOpt3;
         this.recalculateBlendingColor = recalculateBlendingColor;
 	};
 });

--- a/src/Renderer/Entity/EntityState.js
+++ b/src/Renderer/Entity/EntityState.js
@@ -136,23 +136,23 @@ define(function( require )
 			this._virtueColor[3] = 0.90;
 		}
 
-        if (value & StatusConst.OPT3.UNDEAD){
+    if (value & StatusConst.OPT3.UNDEAD){
 			this._virtueColor[0] = 0.70;
 			this._virtueColor[2] = 0.65;
 		}
 
 		if (value & StatusConst.OPT3.MARIONETTE){
-			this._virtueColor[0] = 2.0;
-			this._virtueColor[1] = 0.50;
-			this._virtueColor[2] = 0.85;
+			this._virtueColor[0] = 1.0;
+			this._virtueColor[1] = 0.34;
+			this._virtueColor[2] = 0.71;
 			this._virtueColor[3] = 0.5;
 		}
 
 		if (value & StatusConst.OPT3.BERSERK) {
-			this._virtueColor[0] = 2.0;
-			this._virtueColor[1] = 0.7;
-			this._virtueColor[2] = 0.7;
-			this._virtueColor[3] = 0.5;
+			this._virtueColor[0] = 1.0;
+			this._virtueColor[1] = 0.4;
+			this._virtueColor[2] = 0.4;
+			this._virtueColor[3] = 1.0;
 		}
 
 		recalculateBlendingColor.call(this);

--- a/src/Renderer/SpriteRenderer.js
+++ b/src/Renderer/SpriteRenderer.js
@@ -487,9 +487,9 @@ function(      WebGL,         glMatrix,      Camera )
 		if (isEffectSprite) {
 			gl.blendFunc(gl.SRC_ALPHA, gl.ONE);
 		} else {
+			gl.enable(gl.BLEND);
 			gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
 		}
-		gl.enable(gl.BLEND);
 
 		if (this.shadow !== _shadow) {
 			gl.uniform1f( uniform.uShadow, _shadow = this.shadow);

--- a/src/Renderer/SpriteRenderer.js
+++ b/src/Renderer/SpriteRenderer.js
@@ -169,8 +169,6 @@ function(      WebGL,         glMatrix,      Camera )
 				float fogFactor = smoothstep( uFogNear, uFogFar, depth );
 				gl_FragColor    = mix( gl_FragColor, vec4( uFogColor, gl_FragColor.w ), fogFactor );
 			}
-			
-		
 		}
 	`;
 
@@ -239,7 +237,6 @@ function(      WebGL,         glMatrix,      Camera )
 		size:    new Float32Array(2)
 	};
 
-	SpriteRenderer.removing = false;
 
 	/**
 	 * @var {object} sprite imageData (for 2D context)
@@ -398,9 +395,6 @@ function(      WebGL,         glMatrix,      Camera )
 		var attribute = _program.attribute;
 		var uniform   = _program.uniform;
 
-		// is going to be removed
-		//console.log("SpriteRenderer.bind3DContext =>", this)
-
 		gl.useProgram( _program );
 		gl.uniformMatrix4fv( uniform.uProjectionMat, false,  projection );
 		gl.uniformMatrix4fv( uniform.uModelViewMat,  false,  modelView );
@@ -475,7 +469,7 @@ function(      WebGL,         glMatrix,      Camera )
 	/**
 	 * Render in 3D mode
 	 */
-	function RenderCanvas3D()
+	function RenderCanvas3D(isEffectSprite)
 	{
 		// Nothing to render ?
 		if (!this.image.texture || !this.color[3]) {
@@ -488,6 +482,14 @@ function(      WebGL,         glMatrix,      Camera )
 		var uniform = _program.uniform;
 		var gl      = _gl;
 		var use_pal = this.image.palette !== null;
+
+				
+		if (isEffectSprite) {
+			gl.blendFunc(gl.SRC_ALPHA, gl.ONE);
+		} else {
+			gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
+		}
+		gl.enable(gl.BLEND);
 
 		if (this.shadow !== _shadow) {
 			gl.uniform1f( uniform.uShadow, _shadow = this.shadow);
@@ -528,7 +530,6 @@ function(      WebGL,         glMatrix,      Camera )
 		_size[0]   = this.size[0]   / 175.0 * this.xSize;
 		_size[1]   = this.size[1]   / 175.0 * this.ySize;
 
-		console.log(this.color)
 		gl.uniform4fv( uniform.uSpriteRendererColor,  this.color );
 		gl.uniform2fv( uniform.uSpriteRendererSize,   _size );
 		gl.uniform2fv( uniform.uSpriteRendererOffset, _offset );

--- a/src/Renderer/SpriteRenderer.js
+++ b/src/Renderer/SpriteRenderer.js
@@ -469,7 +469,7 @@ function(      WebGL,         glMatrix,      Camera )
 	/**
 	 * Render in 3D mode
 	 */
-	function RenderCanvas3D(isEffectSprite)
+	function RenderCanvas3D(isBlendModeOne)
 	{
 		// Nothing to render ?
 		if (!this.image.texture || !this.color[3]) {
@@ -483,11 +483,9 @@ function(      WebGL,         glMatrix,      Camera )
 		var gl      = _gl;
 		var use_pal = this.image.palette !== null;
 
-				
-		if (isEffectSprite) {
+		if (isBlendModeOne) {
 			gl.blendFunc(gl.SRC_ALPHA, gl.ONE);
-		} else {
-			gl.enable(gl.BLEND);
+		} else if (isBlendModeOne === false) {
 			gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
 		}
 


### PR DESCRIPTION
Fixes how frenzy and marionette looks, applying the correct blend mode for them.
This disables too the virtue colors applied to shadows (the shadow under the sprite).
And adds a new method to check the current state of an entity status `entity.getOpt3(status)`.
