### PR TITLE
Added frame limit

### DIFF
--- a/src/Preferences/Graphics.js
+++ b/src/Preferences/Graphics.js
@@ -32,8 +32,13 @@ define( ['Core/Preferences'], function( Preferences )
 		/**
 		 * Do we show official game cursor ?
 		 */
-		cursor:      true
+		cursor:      true,
 
+
+		/**
+		 * Game FPS Limit
+		 */
+		fpslimit:    60
 	}, 1.1 );
 
 });

--- a/src/Renderer/Renderer.js
+++ b/src/Renderer/Renderer.js
@@ -19,6 +19,7 @@ define(function( require )
 	var jQuery        = require('Utils/jquery');
 	var glMatrix      = require('Utils/gl-matrix');
 	var Configs       = require('Core/Configs');
+	var GraphicsSettings = require('Preferences/Graphics');
 	var Events        = require('Core/Events');
 	var Background    = require('UI/Background');
 	var Cursor        = require('UI/CursorManager');
@@ -65,7 +66,19 @@ define(function( require )
 
 
 	/**
-	 * @var {integer} game tick
+	 * @var {long} unique identifier of the current render callback (can be used for cancelAnimationFrame/clearInterval)
+	 */
+	Renderer.updateId = 0;
+
+
+	/**
+	 * @var {integer} frame rate limit
+	 */
+	Renderer.frameLimit = GraphicsSettings.fpslimit;
+
+
+	/**
+	 * @var {double} game tick
 	 */
 	Renderer.tick = 0;
 	
@@ -90,7 +103,22 @@ define(function( require )
 		window.oRequestAnimationFrame       ||
 		window.msRequestAnimationFrame      ||
 		function(callback){
-			window.setTimeout( callback, 1000/60 );
+			return window.setTimeout( callback, 1000/60 );
+		}
+	;
+
+
+	/**
+	 * Shime for cancelAnimationFrame
+	 */
+	var _cancelAnimationFrame =
+		window.cancelAnimationFrame        ||
+		window.webkitCancelAnimationFrame  ||
+		window.mozCancelAnimationFrame     ||
+		window.oCancelAnimationFrame       ||
+		window.msCancelAnimationFrame      ||
+		function(updateId){
+			window.clearTimeout( updateId );
 		}
 	;
 
@@ -220,14 +248,29 @@ define(function( require )
 	/**
 	 * Rendering scene
 	 */
-	Renderer._render = function render()
+	Renderer._render = function render( timeDelta )
 	{
-		_requestAnimationFrame( this._render.bind(this), this.canvas );
+		if( this.frameLimit > 0 ) {
+			if( typeof( timeDelta ) !== 'undefined' ) {
+				_cancelAnimationFrame( this.updateId );
+			}
+
+			if( ( timeDelta - this.tick ) > ( 1000 / this.frameLimit ) ) return;
+		}
+		else {
+			if( typeof( timeDelta ) === 'undefined' ) {
+				clearInterval( this.updateId );
+			}
+
+			this.updateId = _requestAnimationFrame( this._render.bind(this), this.canvas );
+		}
+
+		// TODO: clamp this so we don't accumulate a huge delta if we're set inactive for a while
+		this.tick = timeDelta || performance.now();
 
 		// Execute events
 		Events.process( this.tick );
 
-		this.tick = Date.now();
 		var i, count;
 
 		for (i = 0, count = this.renderCallbacks.length; i < count; ++i) {
@@ -249,7 +292,12 @@ define(function( require )
 
 		if (!this.rendering) {
 			this.rendering = true;
-			this._render();
+			if( this.frameLimit > 0 ) {
+				this.updateId = setInterval( this._render.bind(this), 1000 / this.frameLimit );
+			}
+			else {
+				this._render();
+			}
 		}
 	};
 

--- a/src/UI/Components/GraphicsOption/GraphicsOption.html
+++ b/src/UI/Components/GraphicsOption/GraphicsOption.html
@@ -41,7 +41,19 @@
 				</td>
 			</tr>
 			<tr>
-				<td>FPS: </td>
+				<td>FPS Limit</td>
+				<td>
+					<select class="fpslimit"">
+						<option value="-1">Unlimited</option>
+						<option value="30">30</option>
+						<option value="60">60</option>
+						<option value="90">90</option>
+						<option value="120">120</option>
+					</select>
+				</td>
+			</tr>
+			<tr>
+				<td>FPS Display</td>
 				<td>
 					<label>
 						<input class="fps" type="checkbox" />

--- a/src/UI/Components/GraphicsOption/GraphicsOption.js
+++ b/src/UI/Components/GraphicsOption/GraphicsOption.js
@@ -55,8 +55,9 @@ define(function(require)
 		this.ui.find('.close').click(this.remove.bind(this));
 		this.ui.find('.details').change(onUpdateQualityDetails);
 		this.ui.find('.cursor').change(onToggleGameCursor);
-		this.ui.find('.fps').change(onToggleGameFps);
 		this.ui.find('.screensize').change(onUpdateScreenSize);
+		this.ui.find('.fpslimit').change(onUpdateFPSLimit);
+		this.ui.find('.fps').change(onToggleFPSDisplay);
 
 		this.draggable(this.ui.find('.titlebar'));
 	};
@@ -76,7 +77,8 @@ define(function(require)
 		this.ui.find('.details').val(GraphicsSettings.quality);
 		this.ui.find('.screensize').val(GraphicsSettings.screensize);
 		this.ui.find('.cursor').attr('checked', GraphicsSettings.cursor);
-		this.ui.find('.fps').attr('checked', GraphicsSettings.fps);
+		this.ui.find('.fpslimit').val(GraphicsSettings.fpslimit);
+		this.ui.find('.fps').attr('checked', FPS.ui.is(':visible'));
 	};
 
 
@@ -119,13 +121,28 @@ define(function(require)
 	}
 
 	/**
-	 * Toggle game fps
+	 * Update the fps limit
 	 */
-	function onToggleGameFps()
+	function onUpdateFPSLimit()
 	{
-		GraphicsSettings.fps = !!this.checked;
+		GraphicsSettings.fpslimit = parseInt( this.value, 10 );
 		GraphicsSettings.save();
-		FPS.toggle(GraphicsSettings.fps);
+
+		if( Renderer.frameLimit > 0 ) {
+			clearInterval( Renderer.updateId );
+		}
+
+		Renderer.frameLimit = GraphicsSettings.fpslimit;
+		Renderer.rendering = false;
+		Renderer.render( null );
+	}
+
+	/**
+	 * Toggle the fps display
+	 */
+	function onToggleFPSDisplay()
+	{
+		FPS.toggle(!!this.checked);
 	}
 
 	/**


### PR DESCRIPTION
Added a user configurable FPS limit, especially because most of RO1 doesn't need any more than 60 FPS, but for convenience 30, 60, 90, and 120 FPS are provided as limit, in addition to the previous unlimited.
This also fixes the FPS display counter, not storing its position on toggle or shutdown
As a bonus, the FPS display now is colored:
- green for target fps minus 10% tolerance
- orange for below tolerance
- red for below 15 FPS