### PR TITLE
Fixed an skilltree exception caused by High First-Classes not being defined

### DIFF
--- a/src/DB/Skills/SkillTreeView.js
+++ b/src/DB/Skills/SkillTreeView.js
@@ -499,6 +499,34 @@ define(["./SkillConst", "DB/Jobs/JobConst"], function (SK, JobId) {
 			[SK.NJ_BUNSINJYUTSU]: 30,
 			[SK.NJ_ISSEN]: 31
 		},
+		SkillTreeView[JobId.NOVICE_H] = {
+			list: 1,
+			beforeJob: JobId.NOVICE,
+		},
+		SkillTreeView[JobId.SWORDMAN_H] = {
+			list: 1,
+			beforeJob: JobId.SWORDMAN,
+		},
+		SkillTreeView[JobId.MAGICIAN_H] = {
+			list: 1,
+			beforeJob: JobId.MAGICIAN,
+		},
+		SkillTreeView[JobId.ARCHER_H] = {
+			list: 1,
+			beforeJob: JobId.ARCHER,
+		},
+		SkillTreeView[JobId.ACOLYTE_H] = {
+			list: 1,
+			beforeJob: JobId.ACOLYTE,
+		},
+		SkillTreeView[JobId.MERCHANT_H] = {
+			list: 1,
+			beforeJob: JobId.MERCHANT,
+		},
+		SkillTreeView[JobId.THIEF_H] = {
+			list: 1,
+			beforeJob: JobId.THIEF,
+		},
 		SkillTreeView[JobId.PRIEST_H] = {
 			list: 2,
 			beforeJob: JobId.PRIEST,

--- a/src/UI/Components/SkillList/SkillList.js
+++ b/src/UI/Components/SkillList/SkillList.js
@@ -383,6 +383,13 @@ define(function(require)
 	 */
 	function getSkillPosition(JobId) {
 		var positions = [];
+
+		//TODO: DB.isBaby( JobId ) translation check?
+		if( !( JobId in SkillTreeView ) ) {
+			console.error( 'Unimplemented JobId ' + JobId + ' in SkillTree!' );
+			return positions;
+		}
+
 		positions[SkillTreeView[JobId]['list']] = SkillTreeView[JobId];
 
 		if (SkillTreeView[JobId]['beforeJob'] !== null) {


### PR DESCRIPTION
This breaks the Valkyrie NPC script in the middle of rebirthing, which could potentially lead to other issues down the road.
It also fixes not being able to get back into First-Classes due to not having `Base Skill` available, even after a relog.

There are more classes missing like the `_B` suffixed baby classes, which is why the exception itself is now caught, and an error logged to the console instead.

There probably needs to be a more sophisticated solution like ID redirection/aliasing in the long-term.