### PR TITLE
Skilltabsupdate

### DIFF
--- a/src/UI/Components/SkillList/SkillList.css
+++ b/src/UI/Components/SkillList/SkillList.css
@@ -10,9 +10,19 @@
 #SkillList .titlebar .right { float:right; margin-right:3px;}
 #SkillList .titlebar .clear { clear:both; }
 
-#SkillList .content { overflow-y:auto; padding:5px; border-top:1px solid #c6c6c6; width:270px; height:200px; }
+#SkillList .content { position: relative; padding:5px; border-top:1px solid #c6c6c6; width:270px; height:200px; }
 #SkillList .content table { border:none; border-spacing:0px; padding-top:5px; }
 #SkillList .content td, #SkillList .content .name { padding:0px; }
+
+/* Mini Tab*/
+#SkillList .tabs-mini {position: relative;}
+#SkillList .tabs-mini::before, .tabs-mini::after { content: ""; display: table; }
+#SkillList .tabs-mini::after { clear: both; }
+#SkillList .tab-switch-mini { display: none; }
+#SkillList .tab-label-mini { writing-mode: vertical-lr; text-orientation: upright; left: -23px; width: 18px; position: relative; margin: -3px 0; border: 1px solid #c1c6c2; background: #fff; border-radius: 5px 0 0 5px; cursor: pointer; }
+#SkillList .tab-content-mini { overflow-y:auto; width:100%; height:100%; position: absolute; z-index: 1; left: 0; top: 0; right:0; bottom:0; opacity: 0; }
+#SkillList .tab-switch-mini:checked + .tab-label-mini { width: 20px; left: -25px; z-index: 1; }
+#SkillList .tab-switch-mini:checked + label + .tab-content-mini { z-index: 2; opacity: 1; }
 
 #SkillList .levelup { border:0; width:24px; height:24px; padding:0; background-repeat:no-repeat; background-color:transparent; }
 #SkillList td.type { vertical-align:bottom; }

--- a/src/UI/Components/SkillList/SkillList.html
+++ b/src/UI/Components/SkillList/SkillList.html
@@ -15,11 +15,57 @@
 		</div>
 
 		<div class="panel">
-			<div class="content" style="display: none; width: 256px; height: 320px;">
-				<table>
-					<!-- Just to get reference, will be removed -->
-					<button class="btn levelup" data-background="basic_interface/skill_up_a.bmp" data-hover="basic_interface/skill_up_b.bmp" data-down="basic_interface/skill_up_c.bmp"></button>
-				</table>
+			<div class="content" style="display: block; width: 256px; height: 320px;">
+				<!-- Just to get reference, will be removed -->
+				<button class="btn levelup" data-background="basic_interface/skill_up_a.bmp" data-hover="basic_interface/skill_up_b.bmp" data-down="basic_interface/skill_up_c.bmp"></button>
+				<div class="tabs-mini">
+					<div class="tab-mini">
+						<input type="radio" name="css-tabs" id="tab-1-mini" checked class="tab-switch-mini">
+						<label for="tab-1-mini" class="tab-label-mini">1st</label>
+						<div class="tab-content-mini">
+							<table id="minitab1">
+								
+							</table>
+						</div>
+					</div>
+					<div class="tab-mini">
+						<input type="radio" name="css-tabs" id="tab-2-mini" class="tab-switch-mini">
+						<label for="tab-2-mini" id="tabminil2" class="tab-label-mini">2nd</label>
+						<div class="tab-content-mini">
+							<table id="minitab2">
+								
+							</table>
+						</div>
+					</div>
+					<div class="tab-mini">
+						<input type="radio" name="css-tabs" id="tab-3-mini" class="tab-switch-mini">
+						<label for="tab-3-mini" id="tabminil3" class="tab-label-mini">3rd</label>
+						<div class="tab-content-mini">
+							<table id="minitab3">
+								
+							</table>
+						</div>
+					</div>
+					<div class="tab-mini">
+						<input type="radio" name="css-tabs" id="tab-4-mini" class="tab-switch-mini">
+						<label for="tab-4-mini" id="tabminil4" class="tab-label-mini">4th</label>
+						<div class="tab-content-mini">
+							<table id="minitab4">
+								
+							</table>
+						</div>
+					</div>
+					<div class="tab-mini">
+						<input type="radio" name="css-tabs" id="tab-5-mini" class="tab-switch-mini">
+						<label for="tab-5-mini" class="tab-label-mini">Etc</label>
+						<div class="tab-content-mini">
+							<table id="minitab5">
+								
+							</table>
+						</div>
+					</div>
+				</div>
+				
 			</div>
 			<div class="contentbig" style="width: 480px; height: 384px; display: block;">
 				<div class="tabs">
@@ -73,7 +119,7 @@
 					</div>
 					<div class="tab">
 						<input type="radio" name="css-tabs" id="tab-2" class="tab-switch">
-						<label for="tab-2" class="tab-label">2nd</label>
+						<label for="tab-2" id="tabl2" class="tab-label">2nd</label>
 						<div class="tab-content">
 							<div id="positionSkills2">
 								<div class="skillRow">
@@ -121,7 +167,7 @@
 					</div>
 					<div class="tab">
 						<input type="radio" name="css-tabs" id="tab-3" class="tab-switch">
-						<label for="tab-3" class="tab-label">3rd</label>
+						<label for="tab-3" id="tabl3" class="tab-label">3rd</label>
 						<div class="tab-content">
 							<div id="positionSkills3">
 								<div class="skillRow">
@@ -169,9 +215,57 @@
 					</div>
 					<div class="tab">
 						<input type="radio" name="css-tabs" id="tab-4" class="tab-switch">
-						<label for="tab-4" class="tab-label">4th</label>
+						<label for="tab-4" id="tabl4" class="tab-label">4th</label>
 						<div class="tab-content">
 							<div id="positionSkills4">
+								<div class="skillRow">
+									<div class="skillCol s0"></div><div class="skillCol s1"></div><div class="skillCol s2"></div>
+									<div class="skillCol s3"></div><div class="skillCol s4"></div><div class="skillCol s5"></div>
+									<div class="skillCol s6"></div>
+								</div>
+								<div class="skillRow">
+									<div class="skillCol s7"></div><div class="skillCol s8"></div><div class="skillCol s9"></div>
+									<div class="skillCol s10"></div><div class="skillCol s11"></div><div class="skillCol s12"></div>
+									<div class="skillCol s13"></div>
+								</div>
+								<div class="skillRow">
+									<div class="skillCol s14"></div><div class="skillCol s15"></div><div class="skillCol s16"></div>
+									<div class="skillCol s17"></div><div class="skillCol s18"></div><div class="skillCol s19"></div>
+									<div class="skillCol s20"></div>
+								</div>
+								<div class="skillRow">
+									<div class="skillCol s21"></div><div class="skillCol s22"></div><div class="skillCol s23"></div>
+									<div class="skillCol s24"></div><div class="skillCol s25"></div><div class="skillCol s26"></div>
+									<div class="skillCol s27"></div>
+								</div>
+								<div class="skillRow">
+									<div class="skillCol s28"></div><div class="skillCol s29"></div><div class="skillCol s30"></div>
+									<div class="skillCol s31"></div><div class="skillCol s32"></div><div class="skillCol s33"></div>
+									<div class="skillCol s34"></div>
+								</div>
+								<div class="skillRow">
+									<div class="skillCol s35"></div><div class="skillCol s36"></div><div class="skillCol s37"></div>
+									<div class="skillCol s38"></div><div class="skillCol s39"></div><div class="skillCol s40"></div>
+									<div class="skillCol s41"></div>
+								</div>
+								<div class="skillRow" style="display: none">
+									<div class="skillCol s42"></div><div class="skillCol s43"></div><div class="skillCol s44"></div>
+									<div class="skillCol s45"></div><div class="skillCol s46"></div><div class="skillCol s47"></div>
+									<div class="skillCol s48"></div>
+								</div>
+								<div class="skillRow" style="display: none">
+									<div class="skillCol s49"></div><div class="skillCol s50"></div><div class="skillCol s51"></div>
+									<div class="skillCol s52"></div><div class="skillCol s53"></div><div class="skillCol s54"></div>
+									<div class="skillCol s55"></div>
+								</div>
+							</div>
+						</div>
+					</div>
+					<div class="tab">
+						<input type="radio" name="css-tabs" id="tab-5" class="tab-switch">
+						<label for="tab-5" class="tab-label">Etc</label>
+						<div class="tab-content">
+							<div id="etcBIG5">
 								<div class="skillRow">
 									<div class="skillCol s0"></div><div class="skillCol s1"></div><div class="skillCol s2"></div>
 									<div class="skillCol s3"></div><div class="skillCol s4"></div><div class="skillCol s5"></div>

--- a/src/UI/Components/SkillList/SkillList.js
+++ b/src/UI/Components/SkillList/SkillList.js
@@ -232,6 +232,24 @@ define(function(require)
 			SkillList.prepareSkillTree(items, list)
 		});
 
+		// Hide tabs 2 - 4 if no skills in them
+		for (var i = 2; i <= 4; i++) {
+			var length = SkillList.ui.find('#minitab'+i+' tr').length;
+			var length2 = SkillList.ui.find('#positionSkills'+i+' .skill').length;
+
+			if (length > 0) {
+				SkillList.ui.find('#tabminil'+i).show();
+			} else {
+				SkillList.ui.find('#tabminil'+i).hide();
+			}
+
+			if (length2 > 0) {
+				SkillList.ui.find('#tabl'+i).show();
+			} else {
+				SkillList.ui.find('#tabl'+i).hide();
+			}
+		}
+
 		onResetChoice();
 	};
 
@@ -264,6 +282,7 @@ define(function(require)
 				} else {
 					console.log("Something wrong with this skill: %d", skid);
 				}
+				
 			});
 		});
 	}
@@ -279,7 +298,10 @@ define(function(require)
 			var element = '<div class="counterSkill">' + count + '</div>';
 			skillPosition.forEach(function (items, list) {
 				if (items[skillId] !== undefined) {
-					var skillbox = SkillList.ui.find('#positionSkills' + list + ' .s' + items[skillId]);
+					if (!_preferences.mini)
+						var skillbox = SkillList.ui.find('#positionSkills' + list + ' .s' + items[skillId]);
+					else
+						var skillbox = SkillList.ui.find('.content .skill.id' + items[skillId]);
 					if (skillbox.children().hasClass('disabled') || showAll) {
 						skillbox.addClass('needleSkill');
 						if (count !== null) skillbox.append(element);
@@ -386,13 +408,6 @@ define(function(require)
 	 */
 	function getSkillPosition(JobId) {
 		var positions = [];
-
-		//TODO: DB.isBaby( JobId ) translation check?
-		if( !( JobId in SkillTreeView ) ) {
-			console.error( 'Unimplemented JobId ' + JobId + ' in SkillTree!' );
-			return positions;
-		}
-
 		positions[SkillTreeView[JobId]['list']] = SkillTreeView[JobId];
 
 		if (SkillTreeView[JobId]['beforeJob'] !== null) {
@@ -426,7 +441,6 @@ define(function(require)
 		this.addSkillBig(skill);
 		this.addSkillMini(skill);
 	}
-
 
 	/**
 	 * Create disabled skills preview
@@ -524,6 +538,13 @@ define(function(require)
 			}
 		});
 
+		if (!SkillList.ui.find('.contentbig .skill.id' + skill.SKID).length) {
+			var pos = SkillList.ui.find('#etcBIG5 .skill').length;
+			var box = SkillList.ui.find('#etcBIG5 .s'+pos);
+			
+			box.append(element);
+		}
+
 		Client.loadFile( DB.INTERFACE_PATH + 'item/' + sk.Name + '.bmp', function(data){
 			element.find('.icon img').attr('src', data);
 		});
@@ -571,7 +592,22 @@ define(function(require)
 
 		element.find('.level .currentUp').click( function(){ skillLevelSelectUp(skill);  } );
 		element.find('.level .currentDown').click( function(){ skillLevelSelectDown(skill); } );
-		SkillList.ui.find('.content table').append(element);
+		
+		skillPosition.forEach(function (items, list) {
+			if (items[skill.SKID] !== undefined) {
+				var box = SkillList.ui.find('#minitab' + list);
+				
+				box.append(element);
+			}
+		});
+
+		if (!SkillList.ui.find('.content .skill.id' + skill.SKID).length) {
+
+			var box = SkillList.ui.find('#minitab5');
+			
+			box.append(element);
+		}
+
 		this.parseHTML.call(levelup);
 
 		Client.loadFile( DB.INTERFACE_PATH + 'item/' + sk.Name + '.bmp', function(data){
@@ -804,9 +840,11 @@ define(function(require)
 			height = Math.min( Math.max(height, 4), 10);
 			SkillList.ui.find('.extend').show();
 			SkillList.ui.find('.content').show();
+			var i = parseInt(SkillList.ui.find('.tab-switch:checked').attr('id').split('-')[1]);
+			SkillList.ui.find('#tab-'+i+'-mini').prop('checked', true);
 			SkillList.ui.find('.contentbig').hide();
 			SkillList.ui.find('.footer .btn').hide();
-			SkillList.ui.find('.content').css({
+			SkillList.ui.find('.content, .tab-content-mini').css({
 				width:  width  * 32,
 				height: height * 32
 			});
@@ -815,6 +853,8 @@ define(function(require)
 			height = 12;
 			SkillList.ui.find('.extend').hide();
 			SkillList.ui.find('.content').hide();
+			var i = parseInt(SkillList.ui.find('.tab-switch-mini:checked').attr('id').split('-')[1]);
+			SkillList.ui.find('#tab-'+i).prop('checked', true);
 			SkillList.ui.find('.contentbig').show();
 			SkillList.ui.find('.footer .btn').show();
 			SkillList.ui.find('.contentbig').css({
@@ -904,7 +944,10 @@ define(function(require)
 	function onResetChoice()
 	{
 		rememberChoice.forEach(function (count, skillId) {
-			var skillbox = SkillList.ui.find('.skillCol.s' + skillDependencyTree[skillId].position);
+			if (!_preferences.mini)
+				var skillbox = SkillList.ui.find('.skillCol.s' + skillDependencyTree[skillId].position);
+			else
+				var skillbox = SkillList.ui.find('.content' + skillDependencyTree[skillId]);
 			if (!hasSkills?.[skillId]?.level) {
 				skillbox.children().addClass('disabled');
 			}
@@ -967,7 +1010,7 @@ define(function(require)
 		}
 
 		// Add ui to window
-		if (_preferences.mini || _preferences.skillInfo) {
+		if (_preferences.skillInfo) {
 			SkillDescription.append();
 			SkillDescription.setSkill(skillID);
 		}

--- a/src/UI/Components/SkillList/SkillList.js
+++ b/src/UI/Components/SkillList/SkillList.js
@@ -408,6 +408,13 @@ define(function(require)
 	 */
 	function getSkillPosition(JobId) {
 		var positions = [];
+
+		//TODO: DB.isBaby( JobId ) translation check?
+		if( !( JobId in SkillTreeView ) ) {
+			console.error( 'Unimplemented JobId ' + JobId + ' in SkillTree!' );
+			return positions;
+		}
+		
 		positions[SkillTreeView[JobId]['list']] = SkillTreeView[JobId];
 
 		if (SkillTreeView[JobId]['beforeJob'] !== null) {

--- a/src/UI/Components/SkillList/SkillList.js
+++ b/src/UI/Components/SkillList/SkillList.js
@@ -298,13 +298,12 @@ define(function(require)
 			var element = '<div class="counterSkill">' + count + '</div>';
 			skillPosition.forEach(function (items, list) {
 				if (items[skillId] !== undefined) {
-					if (!_preferences.mini)
+					if (!_preferences.mini) {
 						var skillbox = SkillList.ui.find('#positionSkills' + list + ' .s' + items[skillId]);
-					else
-						var skillbox = SkillList.ui.find('.content .skill.id' + items[skillId]);
-					if (skillbox.children().hasClass('disabled') || showAll) {
-						skillbox.addClass('needleSkill');
-						if (count !== null) skillbox.append(element);
+						if (skillbox.children().hasClass('disabled') || showAll) {
+							skillbox.addClass('needleSkill');
+							if (count !== null) skillbox.append(element);
+						}
 					}
 				}
 			});
@@ -336,7 +335,7 @@ define(function(require)
 		rememberChoice.forEach(function (item, skId) {
 			if (!rememberChoice[skId]['isQuest'] && totalCounter < _points) {
 				var sk = skillDependencyTree[skId];
-				var skillbox = SkillList.ui.find('#positionSkills' + skId + ' .s' + sk.position);
+				var skillbox = SkillList.ui.find('#positionSkills' + sk.list + ' .s' + sk.position);
 				if (skillbox.find('.current').text() != sk.MaxLv ) {
 					totalCounter += rememberChoice[skId]['count'];
 					skillbox.children().removeClass('disabled');
@@ -847,8 +846,11 @@ define(function(require)
 			height = Math.min( Math.max(height, 4), 10);
 			SkillList.ui.find('.extend').show();
 			SkillList.ui.find('.content').show();
-			var i = parseInt(SkillList.ui.find('.tab-switch:checked').attr('id').split('-')[1]);
-			SkillList.ui.find('#tab-'+i+'-mini').prop('checked', true);
+			const id = SkillList.ui.find('.tab-switch:checked').attr('id');
+			if (id) {
+				var i = parseInt(id.split('-')[1]);
+				SkillList.ui.find('#tab-'+i+'-mini').prop('checked', true);
+			}
 			SkillList.ui.find('.contentbig').hide();
 			SkillList.ui.find('.footer .btn').hide();
 			SkillList.ui.find('.content, .tab-content-mini').css({
@@ -860,8 +862,11 @@ define(function(require)
 			height = 12;
 			SkillList.ui.find('.extend').hide();
 			SkillList.ui.find('.content').hide();
-			var i = parseInt(SkillList.ui.find('.tab-switch-mini:checked').attr('id').split('-')[1]);
-			SkillList.ui.find('#tab-'+i).prop('checked', true);
+			const id = SkillList.ui.find('.tab-switch-mini:checked').attr('id');
+			if (id) {
+				var i = parseInt(id.split('-')[1]);
+				SkillList.ui.find('#tab-'+i).prop('checked', true);
+			}
 			SkillList.ui.find('.contentbig').show();
 			SkillList.ui.find('.footer .btn').show();
 			SkillList.ui.find('.contentbig').css({
@@ -951,16 +956,15 @@ define(function(require)
 	function onResetChoice()
 	{
 		rememberChoice.forEach(function (count, skillId) {
-			if (!_preferences.mini)
+			if (!_preferences.mini) {
 				var skillbox = SkillList.ui.find('.skillCol.s' + skillDependencyTree[skillId].position);
-			else
-				var skillbox = SkillList.ui.find('.content' + skillDependencyTree[skillId]);
-			if (!hasSkills?.[skillId]?.level) {
-				skillbox.children().addClass('disabled');
+				if (!hasSkills?.[skillId]?.level) {
+					skillbox.children().addClass('disabled');
+				}
+				skillbox.find('.selectable').show();
+				skillbox.find('.current').empty().append(hasSkills?.[skillId]?.level ?? 0)
+				skillbox.find('.max').empty().append(hasSkills?.[skillId]?.level ?? 0)
 			}
-			skillbox.find('.selectable').show();
-			skillbox.find('.current').empty().append(hasSkills?.[skillId]?.level ?? 0)
-			skillbox.find('.max').empty().append(hasSkills?.[skillId]?.level ?? 0)
 
 		});
 		totalCounter = 0;


### PR DESCRIPTION
Added tabs to mini skill view
Added support to etc tab (both mini and big view)
Added support to tab persistence even if changed from mini and big view
Added auto hide tab that doesn't have any skills (tab 2-4 as tab 1 and etc are always present)
Fixed the view skill info always true in mini view

TODO:
In mini view, all skills in the list are added, level up buttons only appear to skills that can be level up
In mini view, resize can't be smaller with 2 tab open (tab 1 and etc)
Etc tab shows red N indicating skills are added in that tab (usually saw this upon login and opens skill)