### PR TITLE
Fixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,7 +4,6 @@ root = true
 # All Files
 [*]
 charset = utf-8
-end_of_line = lf
 indent_style = tab
 indent_size = 4
 insert_final_newline = true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,7 @@
+# Macros for LFS
+[attr]lfs filter=lfs diff=lfs merge=lfs -text
+[attr]lfslock lockable
+
 # Auto detect text files and perform LF normalization
 *					text=auto
 
@@ -24,14 +28,33 @@ package-lock.json	text eol=lf -diff
 *.bmp				binary
 *.gif				binary
 *.png				binary
+*.tga				binary
+
+# Video
+*.bik				binary
 
 # Audio
 *.mp3				binary
 *.wav				binary
 
-# Prevents massive diffs from built files
+# RO files
+*.act				binary
+*.ebm				binary
+*.ezv				binary
+*.gat				binary
+*.gnd				binary
+*.gr2				binary
+*.grf				binary
+*.gpf				binary
+*.pal				binary
+*.rgz				binary
+*.rsm				binary
+*.rsw				binary
+*.spr				binary
+*.str				binary
+
+*.lub				binary
+
+# intermediate and build files
 node_modules/*		binary
 dist/*				binary
-
-# RO files
-*.grf				binary

--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,21 @@
-AI/*
-applications/settings.js
-client/BGM/*
-client/data/*
-client/resources/*
-dist/
-node_modules/
-src/Plugins/*/
-api.html
-index.html
-package-lock.json
+/AI/*
+/applications/settings.js
+/client/BGM/*
+/client/data/*
+/client/resources/*
+/dist/
+/node_modules/
+/src/Plugins/*/
+/api.html
+/index.html
+/package-lock.json
+/GrannyModelViewer.js
+/GrfViewer.js
+/MapViewer.js
+/ModelViewer.js
+/Online.js
+/StrViewer.js
+/ThreadEventHandler.js
 
 # IDE files
 .idea/

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -15,9 +15,9 @@
 			"type": "npm",
 			"group": "build",
 			"label": "npm: build (minified)",
-			"detail": "node ./tools/builder-web.js -- -m",
+			"detail": "node ./tools/builder-web.js -- --all -m",
 
-			"script": "build -- -m",
+			"script": "build -- --all -m",
 			"problemMatcher": []
 		}
 	]

--- a/src/Controls/ProcessCommand.js
+++ b/src/Controls/ProcessCommand.js
@@ -19,6 +19,7 @@ define(function( require )
 	var Sound              = require('Audio/SoundManager');
 	var Session            = require('Engine/SessionStorage');
 	var PACKET             = require('Network/PacketStructure');
+	var PACKETVER          = require('Network/PacketVerManager');
 	var Network            = require('Network/NetworkManager');
 	var ControlPreferences = require('Preferences/Controls');
 	var AudioPreferences   = require('Preferences/Audio');
@@ -165,19 +166,19 @@ define(function( require )
 				pkt.headDir = Session.Entity.headDir;
 				pkt.dir     = Session.Entity.direction;
 				Network.sendPacket(pkt);
-				
+
 				// Doridori recovery bonus
 				if(Session.Entity.action === Session.Entity.ACTION.SIT){
 					if(!Session.Entity.doriTime){
 						Session.Entity.doriTime = [0,0,0,0,0];
 					}
-					
+
 					Session.Entity.doriTime.shift();
 					Session.Entity.doriTime.push(Renderer.tick);
-					
+
 					var doriStart = Session.Entity.doriTime[0];
 					var doriEnd = Session.Entity.doriTime[4];
-					
+
 					if(doriEnd-doriStart > 1500 && doriEnd-doriStart < 3000){
 						var doripkt = new PACKET.CZ.DORIDORI();
 						Network.sendPacket(doripkt);
@@ -289,7 +290,7 @@ define(function( require )
                 pkt = new PACKET.CZ.TAEKWON_RANK();
 				Network.sendPacket(pkt);
                 return;
-				
+
 			case 'hoai':
 				Session.homCustomAI = !Session.homCustomAI;
 				if(Session.homCustomAI){
@@ -300,7 +301,7 @@ define(function( require )
 					this.addText( DB.getMessage(1024), this.TYPE.INFO );
 				}
 				return;
-			
+
 			case 'merai':
 				Session.merCustomAI = !Session.merCustomAI;
 				if(Session.merCustomAI){

--- a/src/Network/PacketStructure.js
+++ b/src/Network/PacketStructure.js
@@ -534,7 +534,7 @@ define(['Utils/BinaryWriter', './PacketVerManager', 'Utils/Struct'], function (B
 			pkt_len = 2 + 2 + this.itemList.length * 6;
 		} else {
 			pkt_len = 2 + 2 + this.itemList.length * 4;
-		} 
+		}
 		var pkt_buf = new BinaryWriter(pkt_len);
 
 		pkt_buf.writeShort(0xc8);
@@ -3790,7 +3790,7 @@ define(['Utils/BinaryWriter', './PacketVerManager', 'Utils/Struct'], function (B
 		pkt.view.setUint32(ver[3], this.GID, true);
 		return pkt;
 	};
-	
+
 	// 0x436
 	PACKET.CZ.ENTER2 = function PACKET_CZ_ENTER2() {
 		this.AID = 0;
@@ -4479,7 +4479,7 @@ define(['Utils/BinaryWriter', './PacketVerManager', 'Utils/Struct'], function (B
 		return pkt_buf;
 	};
 
-	//0848 <packet len>.W <count>.W <packet len>.W <kafra points>.L <count>.W { <amount>.W <name id>.W <tab>.W }.6B*count 
+	//0848 <packet len>.W <count>.W <packet len>.W <kafra points>.L <count>.W { <amount>.W <name id>.W <tab>.W }.6B*count
 	PACKET.CZ.SE_PC_BUY_CASHITEM_LIST = function PACKET_CZ_SE_PC_BUY_CASHITEM_LIST() {
 		this.kafraPoints = 0;
 		this.item_list = [];
@@ -4509,7 +4509,7 @@ define(['Utils/BinaryWriter', './PacketVerManager', 'Utils/Struct'], function (B
 		this.itemId = fp.readShort();
 		this.result = fp.readShort();
 		this.cashPoints = fp.readUShort();
-		
+
     };
     PACKET.ZC.SE_PC_BUY_CASHITEM_RESULT.size = 16;
 
@@ -6311,7 +6311,7 @@ define(['Utils/BinaryWriter', './PacketVerManager', 'Utils/Struct'], function (B
 		this.itemList = (function() {
 			var len = 22;
 			if (PACKETVER.value >= 20150226) len = 47;
-			
+
 			var i, count=(end-fp.tell())/len|0, out=new Array(count);
 			for (i = 0; i < count; ++i) {
 				out[i] = {};
@@ -6328,7 +6328,7 @@ define(['Utils/BinaryWriter', './PacketVerManager', 'Utils/Struct'], function (B
 				out[i].slot.card2 = fp.readUShort();
 				out[i].slot.card3 = fp.readUShort();
 				out[i].slot.card4 = fp.readUShort();
-				
+
 				if (PACKETVER.value >= 20150226) {
 					out[i].Options = [];
 					out[i].Options[1] = fp.readStruct(option);
@@ -6485,8 +6485,8 @@ define(['Utils/BinaryWriter', './PacketVerManager', 'Utils/Struct'], function (B
 			var i, count=(end-fp.tell())/32|0, out=new Array(count);
 			for (i = 0; i < count; ++i) {
 				out[i] = {};
-				out[i].GDID = fp.readLong();
 				out[i].relation = fp.readLong();
+				out[i].GDID = fp.readLong();
 				out[i].guildName = fp.readString(24);
 			}
 			return out;
@@ -11650,7 +11650,7 @@ define(['Utils/BinaryWriter', './PacketVerManager', 'Utils/Struct'], function (B
 	PACKET.ZC.ACK_WHISPER2.size = 7;
 
 	// 0x09e5 TODO: Implement the message and delete item from the shop window
-	PACKET.ZC.DELETEITEM_FROM_MCSTORE2 = function PACKET_ZC_DELETEITEM_FROM_MCSTORE2(fp, end) { 
+	PACKET.ZC.DELETEITEM_FROM_MCSTORE2 = function PACKET_ZC_DELETEITEM_FROM_MCSTORE2(fp, end) {
 		this.index = fp.readShort();
 		this.count = fp.readShort();
 		this.GID = fp.readULong();
@@ -12469,7 +12469,7 @@ define(['Utils/BinaryWriter', './PacketVerManager', 'Utils/Struct'], function (B
 	//0xb09
 	PACKET.ZC.SPLIT_SEND_ITEMLIST_NORMAL = function PACKET_ZC_SPLIT_SEND_ITEMLIST_NORMAL(fp, end) {
 		this.invType = fp.readUChar();
-		
+
 		let item_size = (PACKETVER.value >= 20181121 ? 34 : 24);
 		this.ItemInfo = (function() {
 			var i, count = (end - fp.tell()) / item_size | 0,
@@ -12559,7 +12559,7 @@ define(['Utils/BinaryWriter', './PacketVerManager', 'Utils/Struct'], function (B
 
 	// 0xb18
 	PACKET.ZC.EXTEND_BODYITEM_SIZE = function PACKET_ZC_EXTEND_BODYITEM_SIZE(fp, end) {
-        this.type = fp.readUShort();        
+        this.type = fp.readUShort();
     };
     PACKET.ZC.EXTEND_BODYITEM_SIZE.size = 4;
 
@@ -12811,7 +12811,7 @@ define(['Utils/BinaryWriter', './PacketVerManager', 'Utils/Struct'], function (B
 		})();
 	};
 	PACKET.ZC.PC_PURCHASE_ITEMLIST2.size = -1;
-	
+
 	//0xb8d
 	PACKET.ZC.REPUTE_INFO = function PACKET_ZC_REPUTE_INFO(fp, end) {
 		this.success = fp.readUChar();


### PR DESCRIPTION
Commands `/sit`, `/stand`, `/doridori`, `/bangbang` and `/bingbing` now work again.
And guild alliances should show as alliance instead of antagonist now, there's enough rivalry as it is, let's not increase it needlessly.