### PR TITLE
fix: show aura for dead entities

### DIFF
--- a/src/Engine/MapEngine/Entity.js
+++ b/src/Engine/MapEngine/Entity.js
@@ -203,10 +203,6 @@ define(function( require )
 						EffectManager.spam( EF_Init_Par );
 					}
 
-				case Entity.VT.DEAD:
-					// free aura on death
-					entity.aura.free();
-
 				case Entity.VT.OUTOFSIGHT:
 					EffectManager.remove( null, pkt.GID, null);
 			}
@@ -350,9 +346,6 @@ define(function( require )
 			repeat: true,
 			play:   true
 		});
-
-		// restore aura on resurrection
-		entity.aura.load( EffectManager );
 
 		// If it's our main character update Escape ui
 		if (entity === Session.Entity) {
@@ -1696,9 +1689,6 @@ define(function( require )
 		if (entity === Session.Entity) {
 			StatusIcons.update( pkt.index, pkt.state, pkt.RemainMS );
 		}
-
-		// for changes in entity state (tickdead) or effectState (STEALTHFIELD)
-		entity.aura.load( EffectManager );
 	}
 
 

--- a/src/Engine/MapEngine/Entity.js
+++ b/src/Engine/MapEngine/Entity.js
@@ -205,6 +205,12 @@ define(function( require )
 
 				case Entity.VT.OUTOFSIGHT:
 					EffectManager.remove( null, pkt.GID, null);
+
+				case Entity.VT.DEAD:
+					// remove aura on non-PC death
+					if (entity.objecttype !== Entity.TYPE_PC) {
+						entity.aura.remove( EffectManager );
+					}
 			}
 
 			entity.remove( pkt.type );

--- a/src/Engine/MapEngine/Entity.js
+++ b/src/Engine/MapEngine/Entity.js
@@ -880,6 +880,9 @@ define(function( require )
 				else {
 					entity.weapon = pkt.value;
 				}
+
+				// load self aura
+				entity.aura.load( EffectManager );
 				break;
 
 			case 3: entity.accessory   = pkt.value; break;
@@ -892,9 +895,6 @@ define(function( require )
 			case 10: break; // UNKNOWN²
 			case 11: break; // robe, not supported yet
 		}
-
-		// load self aura
-		entity.aura.load( EffectManager );
 	}
 
 	/**

--- a/src/Renderer/Entity/EntityAura.js
+++ b/src/Renderer/Entity/EntityAura.js
@@ -41,8 +41,8 @@ function(EffectConst, MapPreferences)
 	{
 		// check if qualifies for aura and /aura2 preference
 		if( MapPreferences.aura > 0 && this.entity.clevel >= 99) {
-			// check if entity is visible and not dead
-			if(this.entity.isVisible() && !this.entity.isDead()) {
+			// check if entity is visible
+			if(this.entity.isVisible()) {
 				// aura is already loaded
 				if(!this.isLoaded) {
 					// select effects based on /aura preference

--- a/src/Renderer/Entity/EntityState.js
+++ b/src/Renderer/Entity/EntityState.js
@@ -536,6 +536,11 @@ define(function( require )
 		);
 	}
 
+	function isDead()
+	{
+		return this.action === this.ACTION.DIE;
+	}
+
 
 	/**
 	 * Hooking, export
@@ -549,6 +554,7 @@ define(function( require )
 		this._flashColor       = new Float32Array([1, 1, 1, 1]);
 		this.effectColor       = new Float32Array([1, 1, 1, 1]);
 		this.isVisible         = isVisible.bind(this);
+		this.isDead            = isDead.bind(this);
 
 
 		Object.defineProperty(this, 'bodyState', {

--- a/src/Renderer/Entity/EntityState.js
+++ b/src/Renderer/Entity/EntityState.js
@@ -536,11 +536,6 @@ define(function( require )
 		);
 	}
 
-	function isDead()
-	{
-		return this.action === this.ACTION.DIE;
-	}
-
 
 	/**
 	 * Hooking, export
@@ -554,7 +549,6 @@ define(function( require )
 		this._flashColor       = new Float32Array([1, 1, 1, 1]);
 		this.effectColor       = new Float32Array([1, 1, 1, 1]);
 		this.isVisible         = isVisible.bind(this);
-		this.isDead            = isDead.bind(this);
 
 
 		Object.defineProperty(this, 'bodyState', {


### PR DESCRIPTION
- supposedly in the official clients aura doesn't get remove when a character dies (at least tested in a 2018 client)