### PR TITLE
By setting default to 0 for CameraMaxZoomOut zoom out is disabled

### DIFF
--- a/api.html
+++ b/api.html
@@ -41,7 +41,7 @@
 					ROConfig.plugins            = event.data.plugins            || {};
 					ROConfig.ThirdPersonCamera  = event.data.ThirdPersonCamera  || false;
 					ROConfig.FirstPersonCamera  = event.data.FirstPersonCamera  || false;
-					ROConfig.CameraMaxZoomOut   = event.data.CameraMaxZoomOut   || 0;
+					ROConfig.CameraMaxZoomOut   = event.data.CameraMaxZoomOut   || 5;
 
 					if (ROConfig.development) {
 						var script  = document.createElement('script');

--- a/api.js
+++ b/api.js
@@ -393,7 +393,7 @@
 	// Custom camera support
 	ROBrowser.prototype.ThirdPersonCamera = false;
 	ROBrowser.prototype.FirstPersonCamera = false;
-	ROBrowser.prototype.CameraMaxZoomOut = 0;
+	ROBrowser.prototype.CameraMaxZoomOut = 5;
 
 	/**
 	 * Spam the window until there is an answer


### PR DESCRIPTION
[Although this code is called](https://github.com/MrAntares/roBrowserLegacy/blob/master/src/Renderer/Camera.js#L276)  `Configs.get('CameraMaxZoomOut', C_MAX_ZOOM)`
It takes value 0 because [Configs.get take defaultValue argument only if key can't be found](https://github.com/MrAntares/roBrowserLegacy/blob/master/src/Core/Configs.js#L66)