### PR TITLE
Add effectviewer to ease development of effects

### DIFF
--- a/api.js
+++ b/api.js
@@ -49,7 +49,8 @@
 		GRFVIEWER:    3,
 		MODELVIEWER:  4,
 		STRVIEWER:    5,
-		GRANNYMODELVIEWER: 6  //sound weird O_o
+		GRANNYMODELVIEWER: 6,  //sound weird O_o
+		EFFECTVIEWER: 7,
 	};
 
 
@@ -323,7 +324,7 @@
 				this.height = this.height || '100%';
 
 				var frame          = document.createElement('iframe');
-				frame.src          = this.baseUrl + '?' + Math.random(); // fix bug on firefox
+				frame.src          = this.baseUrl + '?' + Math.random() + location.hash; // fix bug on firefox
 				frame.width        = this.width;
 				frame.height       = this.height;
 				frame.style.border = 'none';
@@ -368,6 +369,10 @@
 
 			case ROBrowser.APP.GRANNYMODELVIEWER:
 				this.application = 'GrannyModelViewer';
+				break;
+
+			case ROBrowser.APP.EFFECTVIEWER:
+				this.application = 'EffectViewer';
 				break;
 		}
 

--- a/src/App/EffectViewer.js
+++ b/src/App/EffectViewer.js
@@ -1,0 +1,75 @@
+/**
+ * App/EffectViewer.js
+ *
+ * Show Str file effect
+ *
+ * This file is part of ROBrowser, (http://www.robrowser.com/).
+ *
+ * @author Vincent Thibault
+ */
+
+// Errors Handler (hack)
+require.onError = function (err) {
+  'use strict';
+
+  if (require.defined('UI/Components/Error/Error')) {
+    require('UI/Components/Error/Error').addTrace(err);
+    return;
+  }
+
+  require(['UI/Components/Error/Error'], function( Errors ){
+    Errors.addTrace(err);
+  });
+};
+
+require({
+    baseUrl: './src/',
+    paths: {
+      text:   'Vendors/text.require',
+      jquery: 'Vendors/jquery-1.9.1'
+    }
+  },
+  ['Core/Configs', 'Core/Thread', 'Core/Context', 'Core/Client', 'UI/Components/EffectViewer/EffectViewer'],
+  function( Configs,        Thread,        Context,        Client,                           EffectViewer ) {
+    'use strict';
+
+    function onAPIMessage( event ) {
+      if (typeof event.data !== 'object') {
+        return;
+      }
+
+      switch (event.data.type) {
+        case 'init':
+          Thread.delegate( event.source, event.origin );
+          Thread.init();
+          EffectViewer.append();
+          break;
+
+        case 'load':
+          EffectViewer.loadEffect(event.data.data);
+          event.stopPropagation();
+          break;
+
+        case 'stop':
+          EffectViewer.stop();
+          event.stopPropagation();
+          break;
+      }
+    }
+
+    // Resources sharing
+    if (Configs.get('API')) {
+      window.addEventListener('message', onAPIMessage, false);
+      return;
+    }
+
+    // Wait for thread to be ready and run the effectviewer
+    Thread.hook('THREAD_READY', function(){
+      Client.onFilesLoaded = function(){
+        EffectViewer.append();
+      };
+      Client.init([]);
+    });
+    Thread.init();
+
+  });

--- a/src/UI/Components/EffectViewer/EffectViewer.css
+++ b/src/UI/Components/EffectViewer/EffectViewer.css
@@ -1,0 +1,42 @@
+body {
+	background-color:#45484d;
+	font-family:Arial;
+	font-size:12px;
+	margin:0;
+	overflow:hidden;
+}
+#EffectViewer .warning {
+	display:none;
+}
+#EffectViewer .info {
+	text-align:center;
+	width:100%;
+	color:white;
+	margin-top:50px;
+	position:absolute;
+}
+#EffectViewer canvas {
+	position:absolute;
+	top:0px;
+	left:0px;
+}
+#EffectViewer #run_msg {
+	position:absolute;
+	right:10px;
+	top:12px;
+	text-align:right;
+	color:#fa5;
+}
+#EffectViewer .head {
+	position:absolute;
+	width:100%;
+	height:40px;
+	background: #222;
+	z-index:100;
+	display:none;
+}
+#EffectViewer .head div {
+	position:relative;
+	top: 8px;
+	left:5px;
+}

--- a/src/UI/Components/EffectViewer/EffectViewer.html
+++ b/src/UI/Components/EffectViewer/EffectViewer.html
@@ -1,0 +1,10 @@
+<div id="EffectViewer">
+	<div class="head">
+		<center><div><select></select>&nbsp;<button>Play effect</button></div></center>
+
+	</div>
+	<div class="info warning">
+		<strong>Error Occurred:</strong><br/>
+		Your browser doesn't seems to support WebGL or your graphic card isn't up to date.
+	</div>
+</div>

--- a/src/UI/Components/EffectViewer/EffectViewer.js
+++ b/src/UI/Components/EffectViewer/EffectViewer.js
@@ -1,0 +1,186 @@
+/**
+ * UI/Components/EffectViewer/EffectViewer.js
+ *
+ * Model Viewer (rsm file)
+ *
+ * This file is part of ROBrowser, (http://www.robrowser.com/).
+ *
+ * @author Vincent Thibault
+ */
+define(function(require)
+{
+	'use strict';
+
+
+	/**
+	 * Load dependencies
+	 */
+	var glMatrix           = require('Utils/gl-matrix');
+	var Client             = require('Core/Client');
+	var Renderer           = require('Renderer/Renderer');
+	var SpriteRenderer     = require('Renderer/SpriteRenderer');
+	var EffectManager      = require('Renderer/EffectManager');
+	var EffectTable        = require('DB/Effects/EffectTable');
+	var EntityManager      = require('Renderer/EntityManager');
+	var Entity             = require('Renderer/Entity/Entity');
+	var Session            = require('Engine/SessionStorage');
+	var Camera             = require('Renderer/Camera');
+
+	var UIManager          = require('UI/UIManager');
+	var UIComponent        = require('UI/UIComponent');
+	var htmlText           = require('text!./EffectViewer.html');
+	var cssText            = require('text!./EffectViewer.css');
+
+	var mat4               = glMatrix.mat4;
+
+	/**
+	 * @var {object} fog structure
+	 */
+	var _fog   = {
+		use:    false,
+		exist:  true,
+		far:    30,
+		near:   180,
+		factor: 1.0,
+		color:  new Float32Array([1,1,1])
+	};
+
+
+	/**
+	 * @var {object} model View mat
+	 */
+	var _modelView = mat4.create();
+
+	var _selectedEffect = null;
+
+	/**
+	 * Create GRFViewer component
+	 */
+	var Viewer = new UIComponent( 'EffectViewer', htmlText, cssText );
+
+
+	/**
+	 * Initialize Component
+	 */
+	Viewer.init = function Init()
+	{
+		// Initialize WebGL
+		Renderer.init({
+			alpha:              false,
+			depth:              true,
+			stencil:            false,
+			antialias:          true,
+			premultipliedAlpha: false,
+		});
+
+		Renderer.show();
+		EffectManager.init(Renderer.getContext());
+		SpriteRenderer.init(Renderer.getContext());
+		Client.init([]);
+
+		// We need an entity in order to apply effect
+		Session.Entity = new Entity({PosDir: [0, 0, 0], position: [0, 0, 0], GID: 0});
+		EntityManager.add(Session.Entity)
+
+		// Initialize the dropdown
+		initDropDown( this.ui.find('select').get(0), this.ui.find('button').get(0) );
+	};
+
+
+	/**
+	 * Initialise Drop Down list
+	 *
+	 * @param {HTMLElement} drop down
+	 */
+	function initDropDown( select, button )
+	{
+		var hash      = decodeURIComponent(location.hash);
+		if (hash) {
+			hash = hash.substring(1);
+			_selectedEffect = hash;
+		}
+		for(const effectId of Object.keys(EffectTable)) {
+			select.add( new Option(effectId, effectId, null, _selectedEffect === effectId), null );
+		}
+		select.onchange = function() {
+			_selectedEffect = this.value;
+			saveEffectId(_selectedEffect)
+			loadEffect(this.value);
+		};
+
+		button.onclick = function() {
+			loadEffect(_selectedEffect);
+		};
+
+		loadEffect( 0 );
+
+		Viewer.ui.find('.head').show();
+		select.focus();
+	}
+
+	function saveEffectId(effectId) {
+		location.hash = effectId;
+	}
+
+	/**
+	 * Start loading an effect
+	 *
+	 * @param {string} filename
+	 */
+	function loadEffect( effectId )
+	{
+		stop();
+		Session.Entity.renderEntity();
+		EffectManager.spam({effectId: effectId, ownerAID: Session.Entity.GID, otherAID: Session.Entity.GID, position: Session.Entity.position});
+		Renderer.render(render);
+	}
+
+
+	/**
+	 * Stop to render
+	 */
+	function stop()
+	{
+		var gl = Renderer.getContext();
+
+		Renderer.stop();
+		EffectManager.free(gl);
+		gl.clear( gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT );
+	}
+
+
+	/**
+	 * Rendering scene
+	 *
+	 * @param {number} tick
+	 * @param {object} webgl context
+	 */
+	function render( tick, gl )
+	{
+		// Updating camera position
+		mat4.identity( _modelView );
+		mat4.translate( _modelView, _modelView, [ 0, -3, -50] );
+		// Invert y axis
+		mat4.rotateX(_modelView, _modelView, Math.PI);
+		mat4.rotateX( _modelView, _modelView, (50/180) * Math.PI );
+
+
+		// Clear screen, update camera
+		gl.clear( gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT );
+
+		EffectManager.render( gl, _modelView, Camera.projection, _fog, tick, false);
+	}
+
+
+	/**
+	 * Exports methods
+	 */
+	Viewer.loadEffect = loadEffect;
+	Viewer.stop       = stop;
+
+
+	/**
+	 * Stored component and return it
+	 */
+	return UIManager.addComponent(Viewer);
+});


### PR DESCRIPTION
Add an effect viewer tool to make development of effect easier: effects can be rendered without running the game as it was done for modelviewer, strviewer, etc... reducing time of the feedback loop 

![image](https://github.com/MrAntares/roBrowserLegacy/assets/1909074/1bfe29e6-5f83-4f13-a797-f0f6067cdc79)
![image](https://github.com/MrAntares/roBrowserLegacy/assets/1909074/47917ea4-6562-4a1b-a172-3c62832e5182)


Effects are not repeated (unless they are repeatable) the button "Play" can be used to retrigger effect

Few effects are not working (e.g: effect 79, earth sprike) i am not a pro of rendering and do not understand what could be the issue