### PR TITLE
Bugfix: Load aura after free on map load

### DIFF
--- a/src/Engine/MapEngine.js
+++ b/src/Engine/MapEngine.js
@@ -37,6 +37,7 @@ define(function( require )
 	var Mouse            = require('Controls/MouseEventHandler');
 	var KEYS             = require('Controls/KeyEventHandler');
 	var UIManager        = require('UI/UIManager');
+	var EffectManager     = require('Renderer/EffectManager');
 	var Background       = require('UI/Background');
 	var Escape           = require('UI/Components/Escape/Escape');
 	var ChatBox          = require('UI/Components/ChatBox/ChatBox');
@@ -386,7 +387,9 @@ define(function( require )
 				GID: Session.Character.GID
 			});
 			EntityManager.add( Session.Entity );
-			Session.Entity.aura.free(); // free aura so it loads in new map
+			// free and load aura so it loads in new map
+			Session.Entity.aura.free();
+			Session.Entity.aura.load(EffectManager);
 
 			// Initialize camera
 			Camera.setTarget( Session.Entity );


### PR DESCRIPTION
When changing map or when joining game aura was not always visible, it was because aura was only free on map loading

# Before

https://github.com/MrAntares/roBrowserLegacy/assets/1909074/489fabb0-66d6-45e9-8ea5-b413d5b00041

# After

https://github.com/MrAntares/roBrowserLegacy/assets/1909074/1ec0071a-91e5-4beb-a53c-e5a1682f7e4f

