### PR TITLE
Refactor/commands

### DIFF
--- a/src/Controls/ProcessCommand.js
+++ b/src/Controls/ProcessCommand.js
@@ -539,6 +539,52 @@ define(function (require) {
 				return;
 			},
 		},
+		commands: {
+			//description: "Show available commands.",
+			callback: function () {
+				function addTextCommand(cmd, commands) {
+					let textAliases = '';
+
+					if (commands[cmd].aliases && commands[cmd].aliases.length > 0) {
+						textAliases = ` (${commands[cmd].aliases.join(", ")})`;
+					}
+
+					return `/${cmd}` + textAliases + ` : ${commands[cmd].description || 'Unknown description.'}\n`;
+				}
+				// we list custom in a separate section
+				let customsEnabled = false;
+
+				const separator = "=======================\n";
+
+				let messages = `${separator}Available Commands:\n${separator}`;
+				let customMessages = `${separator}Custom Commands:\n${separator}`;
+
+				const sortedCommands = {};
+
+				// sort a-z commands by their name
+				Object.keys(CommandStore).sort().forEach(function (key) {
+					sortedCommands[key] = CommandStore[key];
+				});
+
+
+				for (const cmd in sortedCommands) {
+					if (sortedCommands[cmd].custom) {
+						customMessages += addTextCommand(cmd, sortedCommands);
+						customsEnabled = true;
+					} else {
+						messages += addTextCommand(cmd, sortedCommands);
+					}
+				}
+
+				this.addText(messages, this.TYPE.BLUE, this.FILTER.PUBLIC_LOG);
+
+				if (customsEnabled)
+					this.addText(customMessages, this.TYPE.INFO, this.FILTER.PUBLIC_LOG);
+
+				return;
+			},
+			aliases: ["cmd", "h", "help"],
+		},
 	};
 
 	/**
@@ -610,7 +656,8 @@ define(function (require) {
 		name,
 		description = "",
 		callback = () => {},
-		aliases = []
+		aliases = [],
+		custom = true
 	) {
 		var ChatBox = getModule("UI/Components/ChatBox/ChatBox");
 		callback = callback.bind(ChatBox);
@@ -619,6 +666,7 @@ define(function (require) {
 			description: description,
 			callback: callback,
 			aliases: aliases,
+			custom
 		};
 		reloadAliases();
 	}

--- a/src/Controls/ProcessCommand.js
+++ b/src/Controls/ProcessCommand.js
@@ -11,24 +11,24 @@ define(function (require) {
 	"use strict";
 
 	// Load dependencies
-	var DB = require("DB/DBManager");
-	var Emotions = require("DB/Emotions");
-	var BGM = require("Audio/BGM");
-	var Sound = require("Audio/SoundManager");
-	var Session = require("Engine/SessionStorage");
-	var PACKET = require("Network/PacketStructure");
-	var PACKETVER = require("Network/PacketVerManager");
-	var Network = require("Network/NetworkManager");
-	var ControlPreferences = require("Preferences/Controls");
-	var AudioPreferences = require("Preferences/Audio");
-	var MapPreferences = require("Preferences/Map");
-	var CameraPreferences = require("Preferences/Camera");
-	var Renderer = require("Renderer/Renderer");
-	var getModule = require;
+	const DB = require("DB/DBManager");
+	const Emotions = require("DB/Emotions");
+	const BGM = require("Audio/BGM");
+	const Sound = require("Audio/SoundManager");
+	const Session = require("Engine/SessionStorage");
+	const PACKET = require("Network/PacketStructure");
+	const PACKETVER = require("Network/PacketVerManager");
+	const Network = require("Network/NetworkManager");
+	const ControlPreferences = require("Preferences/Controls");
+	const AudioPreferences = require("Preferences/Audio");
+	const MapPreferences = require("Preferences/Map");
+	const CameraPreferences = require("Preferences/Camera");
+	const Renderer = require("Renderer/Renderer");
+	const getModule = require;
 
-	var aliases = {};
+	let aliases = {};
 
-	var CommandStore = {
+	let CommandStore = {
 		sound: {
 			description: "Toggles playing of sound effects",
 			callback: function () {
@@ -105,7 +105,7 @@ define(function (require) {
 		aura: {
 			description: "Minimizes the aura effect for level 99 and 175 characters",
 			callback: function () {
-				var isSimplified = MapPreferences.aura > 1;
+				const isSimplified = MapPreferences.aura > 1;
 				this.addText(
 					DB.getMessage(711 + isSimplified),
 					this.TYPE.INFO,
@@ -291,14 +291,14 @@ define(function (require) {
 					Session.Entity.doriTime.shift();
 					Session.Entity.doriTime.push(Renderer.tick);
 
-					var doriStart = Session.Entity.doriTime[0];
-					var doriEnd = Session.Entity.doriTime[4];
+					const doriStart = Session.Entity.doriTime[0];
+					const doriEnd = Session.Entity.doriTime[4];
 
 					if (
 						doriEnd - doriStart > 1500 &&
 						doriEnd - doriStart < 3000
 					) {
-						var doripkt = new PACKET.CZ.DORIDORI();
+						const doripkt = new PACKET.CZ.DORIDORI();
 						Network.sendPacket(doripkt);
 						Session.Entity.doriTime = [0, 0, 0, 0, 0];
 					}
@@ -325,7 +325,7 @@ define(function (require) {
 		},
 
 		bingbing: {
-			description: "Bingbing",
+			description: "Rotates your character counterclockwise",
 			callback: function () {
 				var pkt;
 				Session.Entity.direction = (Session.Entity.direction + 7) % 8;
@@ -342,9 +342,9 @@ define(function (require) {
 		},
 
 		where: {
-			description: "Rotates your character counterclockwise",
+			description: "Shows your character's location as a map name and set of coordinates",
 			callback: function () {
-				var currentMap = getModule("Renderer/MapRenderer").currentMap;
+				const currentMap = getModule("Renderer/MapRenderer").currentMap;
 				this.addText(
 					DB.getMapName(currentMap) +
 						"(" +
@@ -659,7 +659,7 @@ define(function (require) {
 		aliases = [],
 		custom = true
 	) {
-		var ChatBox = getModule("UI/Components/ChatBox/ChatBox");
+		const ChatBox = getModule("UI/Components/ChatBox/ChatBox");
 		callback = callback.bind(ChatBox);
 
 		CommandStore[name] = {

--- a/src/Controls/ProcessCommand.js
+++ b/src/Controls/ProcessCommand.js
@@ -30,7 +30,7 @@ define(function (require) {
 
 	var CommandStore = {
 		sound: {
-			description: "Toggle sound.",
+			description: "Toggles playing of sound effects",
 			callback: function () {
 				this.addText(
 					DB.getMessage(27 + AudioPreferences.Sound.play),
@@ -45,7 +45,7 @@ define(function (require) {
 			},
 		},
 		bgm: {
-			description: "Toggle BGM.",
+			description: "Toggles playing of background music",
 			callback: function () {
 				this.addText(
 					DB.getMessage(31 + AudioPreferences.BGM.play),
@@ -64,7 +64,7 @@ define(function (require) {
 			},
 		},
 		effect: {
-			description: "Toggle effects.",
+			description: "Toggles the display of anything but basic graphical effects",
 			callback: function () {
 				this.addText(
 					DB.getMessage(23 + MapPreferences.effect),
@@ -77,7 +77,7 @@ define(function (require) {
 			},
 		},
 		mineffect: {
-			description: "Toggle mine effects.",
+			description: "Enables less graphically intense effects. This command does not work for Wizard's AoE skills.",
 			callback: function () {
 				this.addText(
 					DB.getMessage(687 + MapPreferences.mineffect),
@@ -90,7 +90,7 @@ define(function (require) {
 			},
 		},
 		miss: {
-			description: "Toggle miss effects.",
+			description: "Toggles display of the ‘miss’ animation",
 			callback: function () {
 				this.addText(
 					DB.getMessage(317 + MapPreferences.miss),
@@ -103,7 +103,7 @@ define(function (require) {
 			},
 		},
 		aura: {
-			description: "Toggle aura effect.",
+			description: "Minimizes the aura effect for level 99 and 175 characters",
 			callback: function () {
 				var isSimplified = MapPreferences.aura > 1;
 				this.addText(
@@ -117,7 +117,7 @@ define(function (require) {
 			},
 		},
 		aura2: {
-			description: "Toggle aura2 effect.",
+			description: "Disables the aura effect for level 99 and 175 characters",
 			callback: function () {
 				this.addText(
 					DB.getMessage(
@@ -135,7 +135,7 @@ define(function (require) {
 			},
 		},
 		showname: {
-			description: "Toggle display names.",
+			description: "Returns to the original font",
 			callback: function () {
 				this.addText(
 					DB.getMessage(722 + MapPreferences.showname),
@@ -154,7 +154,7 @@ define(function (require) {
 			},
 		},
 		camera: {
-			description: "Toggle camera smoothing.",
+			description: "Turns camera 'smoothing' off and on.",
 			callback: function () {
 				this.addText(
 					DB.getMessage(319 + CameraPreferences.smooth),
@@ -168,7 +168,7 @@ define(function (require) {
 		},
 
 		fog: {
-			description: "Toggle fog.",
+			description: "Turns fog on and off",
 			callback: function () {
 				MapPreferences.fog = !MapPreferences.fog;
 				this.addText(
@@ -182,7 +182,7 @@ define(function (require) {
 		},
 
 		lightmap: {
-			description: "Toggle lightmap",
+			description: "Removes shade effects and a majority of lighting effects",
 			callback: function () {
 				MapPreferences.lightmap = !MapPreferences.lightmap;
 				MapPreferences.save();
@@ -191,7 +191,7 @@ define(function (require) {
 		},
 
 		noctrl: {
-			description: "Toggle noctrl.",
+			description: "Allows attacking monsters continuously with only one left-click",
 			callback: function () {
 				this.addText(
 					DB.getMessage(717 + ControlPreferences.noctrl),
@@ -206,7 +206,7 @@ define(function (require) {
 		},
 
 		noshift: {
-			description: "Toggle noshift.",
+			description: " Allows targeting monsters or other players in PvP arenas with support skills without having to press the Shift key",
 			callback: function () {
 				this.addText(
 					DB.getMessage(701 + ControlPreferences.noshift),
@@ -221,7 +221,7 @@ define(function (require) {
 		},
 
 		snap: {
-			description: "Toggle snap.",
+			description: "The mouse cursor semi-automatically moves to the target",
 			callback: function () {
 				this.addText(
 					DB.getMessage(271 + ControlPreferences.snap),
@@ -235,7 +235,7 @@ define(function (require) {
 		},
 
 		itemsnap: {
-			description: "Toggle itemsnap.",
+			description: "The mouse cursor semi-automatically moves to the loot",
 			callback: function () {
 				this.addText(
 					DB.getMessage(276 + ControlPreferences.itemsnap),
@@ -249,7 +249,7 @@ define(function (require) {
 		},
 
 		stand: {
-			description: "Sit/Stand",
+			description: "Makes your character sit or stand",
 			callback: function () {
 				var pkt;
 				if (PACKETVER.value >= 20180307) {
@@ -269,7 +269,7 @@ define(function (require) {
 		},
 
 		doridori: {
-			description: "Doridori",
+			description: "Moves your character's head from side to side",
 			callback: function () {
 				var pkt;
 				Session.Entity.headDir = Session.Entity.headDir === 1 ? 2 : 1;
@@ -308,7 +308,7 @@ define(function (require) {
 		},
 
 		bangbang: {
-			description: "Bangbang",
+			description: "Rotates your character clockwise",
 			callback: function () {
 				var pkt;
 				Session.Entity.direction = (Session.Entity.direction + 1) % 8;
@@ -342,7 +342,7 @@ define(function (require) {
 		},
 
 		where: {
-			description: "Show current position.",
+			description: "Rotates your character counterclockwise",
 			callback: function () {
 				var currentMap = getModule("Renderer/MapRenderer").currentMap;
 				this.addText(
@@ -361,7 +361,7 @@ define(function (require) {
 		},
 
 		who: {
-			description: "Show online players.",
+			description: "Shows the current number of players on the server",
 			callback: function () {
 				var pkt = new PACKET.CZ.REQ_USER_COUNT();
 				Network.sendPacket(pkt);
@@ -371,7 +371,7 @@ define(function (require) {
 		},
 
 		memo: {
-			description: "Save current position.",
+			description: "Memorizes a location for use with the Warp Portal skill",
 			callback: function () {
 				var pkt = new PACKET.CZ.REMEMBER_WARPPOINT();
 				Network.sendPacket(pkt);
@@ -380,7 +380,7 @@ define(function (require) {
 		},
 
 		chat: {
-			description: "Create chat room.",
+			description: "Creates a chat room",
 			callback: function () {
 				getModule("UI/Components/ChatRoomCreate/ChatRoomCreate").show();
 				return;
@@ -388,7 +388,7 @@ define(function (require) {
 		},
 
 		q: {
-			description: "Close chat room.",
+			description: "Leaves a chat room",
 			callback: function () {
 				getModule("UI/Components/ChatRoom/ChatRoom").remove();
 				return;
@@ -396,7 +396,7 @@ define(function (require) {
 		},
 
 		leave: {
-			description: "Leave group.",
+			description: "Allows one to leave a party",
 			callback: function () {
 				getModule("Engine/MapEngine/Group").onRequestLeave();
 				return;
@@ -404,7 +404,7 @@ define(function (require) {
 		},
 
 		invite: {
-			description: "Invite player to group.",
+			description: "\"<name>\" Invite a person to your party. Works across different maps",
 			callback: function (text) {
 				var matches = text.match(/^invite\s+(")?([^"]+)(")?/);
 				if (matches && matches[2]) {
@@ -418,7 +418,7 @@ define(function (require) {
 		},
 
 		organize: {
-			description: "Create group.",
+			description: "Creates a party named <Party Name>",
 			callback: function (text) {
 				var matches = text.match(/^organize\s+(")?([^"]+)(")?/);
 				if (matches && matches[2]) {
@@ -431,7 +431,7 @@ define(function (require) {
 		},
 
 		hi: {
-			description: "Say hi to friends.",
+			description: "Sends the specified message to everyone on your friend list",
 			callback: function () {
 				getModule("Engine/MapEngine/Friends").sayHi();
 				return;
@@ -439,7 +439,7 @@ define(function (require) {
 		},
 
 		guild: {
-			description: "Create guild.",
+			description: "Creates a guild named <Guild Name>. This requires an Emperium to be in the creator's inventory",
 			callback: function (text) {
 				var matches = text.match(/^guild\s+(")?([^"]+)(")?/);
 				if (matches && matches[2]) {
@@ -450,7 +450,7 @@ define(function (require) {
 		},
 
 		breakguild: {
-			description: "Break guild.",
+			description: "Disbands a guild. Can only be used by the guild leader. All members must be expelled first",
 			callback: function (text) {
 				var matches = text.match(/^breakguild\s+(")?([^"]+)(")?/);
 				if (matches && matches[2]) {
@@ -461,7 +461,7 @@ define(function (require) {
 		},
 
 		alchemist: {
-			description: "Show alchemist ranking.",
+			description: "Shows the top 10 brewing Alchemists in the server.",
 			callback: function () {
 				var pkt = new PACKET.CZ.ALCHEMIST_RANK();
 				Network.sendPacket(pkt);
@@ -470,7 +470,7 @@ define(function (require) {
 		},
 
 		blacksmith: {
-			description: "Show blacksmith ranking.",
+			description: "Shows the top 10 forging/upgrading Blacksmiths in the server",
 			callback: function () {
 				var pkt = new PACKET.CZ.BLACKSMITH_RANK();
 				Network.sendPacket(pkt);
@@ -479,7 +479,7 @@ define(function (require) {
 		},
 
 		taekwon: {
-			description: "Show taekwon ranking.",
+			description: "Shows the top 10 TaeKwon Kids based on completion of TaeKwon Missions in the server",
 			callback: function () {
 				var pkt = new PACKET.CZ.TAEKWON_RANK();
 				Network.sendPacket(pkt);
@@ -488,7 +488,7 @@ define(function (require) {
 		},
 
 		hoai: {
-			description: "Toggle custom homunculus AI.",
+			description: "Switches Homunculus AI between default and custom mode",
 			callback: function () {
 				Session.homCustomAI = !Session.homCustomAI;
 				if (Session.homCustomAI) {
@@ -515,7 +515,7 @@ define(function (require) {
 		},
 
 		merai: {
-			description: "Toggle custom mercenary AI.",
+			description: "Switches Mercenary AI between default and custom mode",
 			callback: function () {
 				Session.merCustomAI = !Session.merCustomAI;
 				if (Session.merCustomAI) {
@@ -540,7 +540,7 @@ define(function (require) {
 			},
 		},
 		commands: {
-			//description: "Show available commands.",
+			description: "Show available commands.",
 			callback: function () {
 				function addTextCommand(cmd, commands) {
 					let textAliases = '';

--- a/src/Controls/ProcessCommand.js
+++ b/src/Controls/ProcessCommand.js
@@ -28,27 +28,23 @@ define(function( require )
 	var Renderer           = require('Renderer/Renderer');
 	var getModule          = require;
 
+	var aliases = {};
 
-	/**
-	 * Process command
-	 */
-	return function processCommand( text ){
-		var pkt, matches;
-		var cmd = text.split(' ')[0];
-
-		switch (cmd) {
-
-			case 'sound':
+	var CommandStore = {
+		'sound': {
+			description: 'Toggle sound.',
+			callback: function() {
 				this.addText( DB.getMessage(27 + AudioPreferences.Sound.play), this.TYPE.INFO, this.FILTER.PUBLIC_LOG );
 				AudioPreferences.Sound.play = !AudioPreferences.Sound.play;
 				AudioPreferences.save();
-
 				if (AudioPreferences.Sound.play) {
 					Sound.stop();
 				}
-				return;
-
-			case 'bgm':
+			}
+		},
+		'bgm': {
+			description: 'Toggle BGM.',
+			callback: function() {
 				this.addText( DB.getMessage(31 + AudioPreferences.BGM.play), this.TYPE.INFO, this.FILTER.PUBLIC_LOG );
 				AudioPreferences.BGM.play = !AudioPreferences.BGM.play;
 				AudioPreferences.save();
@@ -60,33 +56,48 @@ define(function( require )
 					BGM.stop();
 				}
 				return;
-
-			case 'effect':
+			}
+		},
+		'effect': {
+			description: 'Toggle effects.',
+			callback: function() {
 				this.addText( DB.getMessage(23 + MapPreferences.effect), this.TYPE.INFO, this.FILTER.PUBLIC_LOG );
 				MapPreferences.effect = !MapPreferences.effect;
 				MapPreferences.save();
 				return;
-
-			case 'mineffect':
+			}
+		},
+		'mineffect': {
+			description: 'Toggle mine effects.',
+			callback: function() {
 				this.addText( DB.getMessage(687 + MapPreferences.mineffect), this.TYPE.INFO, this.FILTER.PUBLIC_LOG );
 				MapPreferences.mineffect = !MapPreferences.mineffect;
 				MapPreferences.save();
 				return;
-
-			case 'miss':
+			}
+		},
+		'miss': {
+			description: 'Toggle miss effects.',
+			callback: function() {
 				this.addText( DB.getMessage(317 + MapPreferences.miss), this.TYPE.INFO, this.FILTER.PUBLIC_LOG );
 				MapPreferences.miss = !MapPreferences.miss;
 				MapPreferences.save();
 				return;
-
-			case 'aura':
+			}
+		},
+		'aura': {
+			description: 'Toggle aura effect.',
+			callback: function() {
 				var isSimplified = MapPreferences.aura > 1;
 				this.addText( DB.getMessage(711 + isSimplified), this.TYPE.INFO, this.FILTER.PUBLIC_LOG );
 				MapPreferences.aura = isSimplified ? 1 : 2;
 				MapPreferences.save();
 				return;
-
-			case 'aura2':
+			}
+		},
+		'aura2': {
+			description: 'Toggle aura2 effect.',
+			callback: function() {
 				this.addText(
 					DB.getMessage(
 						2994 + MapPreferences.aura,
@@ -100,8 +111,11 @@ define(function( require )
 				MapPreferences.aura = MapPreferences.aura ? 0 : 1;
 				MapPreferences.save();
 				return;
-
-			case 'showname':
+			}
+		},
+		'showname': {
+			description: 'Toggle display names.',
+			callback: function() {
 				this.addText( DB.getMessage(722 + MapPreferences.showname), this.TYPE.INFO );
 				MapPreferences.showname = !MapPreferences.showname;
 				MapPreferences.save();
@@ -113,51 +127,84 @@ define(function( require )
 					entity.display.refresh(entity);
 				});
 				return;
-
-			case 'camera':
+			}
+		},
+		'camera': {
+			description: 'Toggle camera smoothing.',
+			callback: function() {
 				this.addText( DB.getMessage(319 + CameraPreferences.smooth), this.TYPE.INFO, this.FILTER.PUBLIC_LOG );
 				CameraPreferences.smooth = !CameraPreferences.smooth;
 				CameraPreferences.save();
 				return;
+			}
+		},
 
-			case 'fog':
+		'fog': {
+			description: 'Toggle fog.',
+			callback: function() {
 				MapPreferences.fog = !MapPreferences.fog;
 				this.addText( 'fog ' + ( MapPreferences.fog ? 'on' : 'off'), this.TYPE.INFO, this.FILTER.PUBLIC_LOG );
 				MapPreferences.save();
 				return;
+			}
+		},
 
-			case 'lightmap':
+		'lightmap': {
+			description: 'Toggle lightmap',
+			callback: function() {
 				MapPreferences.lightmap = !MapPreferences.lightmap;
 				MapPreferences.save();
 				return;
+			}
+		},
 
-			case 'noctrl':
-			case 'nc':
+
+		'noctrl': {
+			description: 'Toggle noctrl.',
+			callback: function() {
 				this.addText( DB.getMessage(717 + ControlPreferences.noctrl), this.TYPE.INFO, this.FILTER.PUBLIC_LOG );
 				ControlPreferences.noctrl = !ControlPreferences.noctrl;
 				ControlPreferences.save();
 				return;
+			},
+			aliases: ['nc']
+		},
 
-			case 'noshift':
-			case 'ns':
+		'noshift': {
+			description: 'Toggle noshift.',
+			callback: function() {
 				this.addText( DB.getMessage(701 + ControlPreferences.noshift), this.TYPE.INFO, this.FILTER.PUBLIC_LOG );
 				ControlPreferences.noshift = !ControlPreferences.noshift;
 				ControlPreferences.save();
 				return;
-            		case 'snap':
+			},
+			aliases: ['ns']
+		},
+
+		'snap': {
+			description: 'Toggle snap.',
+			callback: function() {
 				this.addText( DB.getMessage(271 + ControlPreferences.snap), this.TYPE.INFO, this.FILTER.PUBLIC_LOG );
 				ControlPreferences.snap = !ControlPreferences.snap;
 				ControlPreferences.save();
 				return;
+			}
+		},
 
-            		case 'itemsnap':
+		'itemsnap': {
+			description: 'Toggle itemsnap.',
+			callback: function() {
 				this.addText( DB.getMessage(276 + ControlPreferences.itemsnap), this.TYPE.INFO, this.FILTER.PUBLIC_LOG );
 				ControlPreferences.itemsnap = !ControlPreferences.itemsnap;
 				ControlPreferences.save();
 				return;
+			}
+		},
 
-			case 'sit':
-			case 'stand':
+		'stand': {
+			description: 'Sit/Stand',
+			callback: function() {
+				var pkt;
 				if(PACKETVER.value >= 20180307) {
 					pkt        = new PACKET.CZ.REQUEST_ACT2();
 				} else {
@@ -171,8 +218,14 @@ define(function( require )
 				}
 				Network.sendPacket(pkt);
 				return;
+			},
+			aliases: ['sit']
+		},
 
-			case 'doridori':
+		'doridori': {
+			description: 'Doridori',
+			callback: function() {
+				var pkt;
 				Session.Entity.headDir = ( Session.Entity.headDir === 1 ? 2 : 1 );
 				if(PACKETVER.value >= 20180307) {
 					pkt = new PACKET.CZ.CHANGE_DIRECTION2();
@@ -202,8 +255,13 @@ define(function( require )
 					}
 				}
 				return;
+			},
+		},
 
-			case 'bangbang':
+		'bangbang': {
+			description: 'Bangbang',
+			callback: function() {
+				var pkt;
 				Session.Entity.direction = ( Session.Entity.direction + 1 ) % 8;
 				if(PACKETVER.value >= 20180307) {
 					pkt = new PACKET.CZ.CHANGE_DIRECTION2();
@@ -214,8 +272,13 @@ define(function( require )
 				pkt.dir     = Session.Entity.direction;
 				Network.sendPacket(pkt);
 				return;
+			}
+		},
 
-			case 'bingbing':
+		'bingbing': {
+			description: 'Bingbing',
+			callback: function() {
+				var pkt;
 				Session.Entity.direction = ( Session.Entity.direction + 7 ) % 8;
 				if(PACKETVER.value >= 20180307) {
 					pkt = new PACKET.CZ.CHANGE_DIRECTION2();
@@ -226,88 +289,148 @@ define(function( require )
 				pkt.dir     = Session.Entity.direction;
 				Network.sendPacket(pkt);
 				return;
+			}
+		},
 
-			case 'where':
+		'where': {
+			description: 'Show current position.',
+			callback: function() {
 				var currentMap = getModule('Renderer/MapRenderer').currentMap;
 				this.addText(
 					DB.getMapName(currentMap) + '(' + currentMap + ') : ' + Math.floor(Session.Entity.position[0]) + ', ' + Math.floor(Session.Entity.position[1]),
 					this.TYPE.INFO, this.FILTER.PUBLIC_LOG
 				);
 				return;
+			}
+		},
 
-			case 'who':
-			case 'w':
-				pkt = new PACKET.CZ.REQ_USER_COUNT();
+		'who': {
+			description: 'Show online players.',
+			callback: function() {
+				var pkt = new PACKET.CZ.REQ_USER_COUNT();
 				Network.sendPacket(pkt);
 				return;
+			},
+			aliases: ['w']
+		},
 
-			case 'memo':
-				pkt = new PACKET.CZ.REMEMBER_WARPPOINT();
+		'memo': {
+			description: 'Save current position.',
+			callback: function() {
+				var pkt = new PACKET.CZ.REMEMBER_WARPPOINT();
 				Network.sendPacket(pkt);
 				return;
+			}
+		},
 
-			case 'chat':
+		'chat': {
+			description: 'Create chat room.',
+			callback: function() {
 				getModule('UI/Components/ChatRoomCreate/ChatRoomCreate').show();
 				return;
+			}
+		},
 
-			case 'q':
+
+		'q': {
+			description: 'Close chat room.',
+			callback: function() {
 				getModule('UI/Components/ChatRoom/ChatRoom').remove();
 				return;
+			}
+		},
 
-			case 'leave':
+		'leave': {
+			description: 'Leave group.',
+			callback: function() {
 				getModule('Engine/MapEngine/Group').onRequestLeave();
 				return;
+			}
+		},
 
-			case 'invite':
-				matches = text.match(/^invite\s+(")?([^"]+)(")?/);
+		'invite': {
+			description: 'Invite player to group.',
+			callback: function(text) {
+				var matches = text.match(/^invite\s+(")?([^"]+)(")?/);
 				if (matches && matches[2]) {
 					getModule('Engine/MapEngine/Group').onRequestInvitation(0, matches[2]);
 					return;
 				}
-				break;
+			}
+		},
 
-			case 'organize':
-				matches = text.match(/^organize\s+(")?([^"]+)(")?/);
+		'organize': {
+			description: 'Create group.',
+			callback: function(text) {
+				var matches = text.match(/^organize\s+(")?([^"]+)(")?/);
 				if (matches && matches[2]) {
 					getModule('Engine/MapEngine/Group').onRequestCreationEasy(matches[2]);
 					return;
 				}
-				break;
+			}
+		},
 
-			case 'hi':
+		'hi': {
+			description: 'Say hi to friends.',
+			callback: function() {
 				getModule('Engine/MapEngine/Friends').sayHi();
 				return;
+			}
+		},
 
-			case 'guild':
-				matches = text.match(/^guild\s+(")?([^"]+)(")?/);
+		'guild': {
+			description: 'Create guild.',
+			callback: function(text) {
+				var matches = text.match(/^guild\s+(")?([^"]+)(")?/);
 				if (matches && matches[2]) {
 					getModule('Engine/MapEngine/Guild').createGuild(matches[2]);
 					return;
 				}
-				break;
+			}
+		},
 
-			case 'breakguild':
-				matches = text.match(/^breakguild\s+(")?([^"]+)(")?/);
+		'breakguild': {
+			description: 'Break guild.',
+			callback: function(text) {
+				var matches = text.match(/^breakguild\s+(")?([^"]+)(")?/);
 				if (matches && matches[2]) {
 					getModule('Engine/MapEngine/Guild').breakGuild(matches[2]);
 					return;
 				}
-				break;
+			}
+		},
 
-			case 'alchemist':
-                pkt = new PACKET.CZ.ALCHEMIST_RANK();
-				Network.sendPacket(pkt);
-                return;
-            case 'blacksmith':
-            	pkt = new PACKET.CZ.BLACKSMITH_RANK();
-				Network.sendPacket(pkt);
-                return;
-            case 'taekwon':
-                pkt = new PACKET.CZ.TAEKWON_RANK();
-				Network.sendPacket(pkt);
-                return;
 
-			case 'hoai':
+		'alchemist': {
+			description: 'Show alchemist ranking.',
+			callback: function() {
+				var pkt = new PACKET.CZ.ALCHEMIST_RANK();
+				Network.sendPacket(pkt);
+				return;
+			}
+		},
+
+		'blacksmith': {
+			description: 'Show blacksmith ranking.',
+			callback: function() {
+				var pkt = new PACKET.CZ.BLACKSMITH_RANK();
+				Network.sendPacket(pkt);
+				return;
+			}
+		},
+
+		'taekwon': {
+			description: 'Show taekwon ranking.',
+			callback: function() {
+				var pkt = new PACKET.CZ.TAEKWON_RANK();
+				Network.sendPacket(pkt);
+				return;
+			}
+		},
+
+		'hoai': {
+			description: 'Toggle custom homunculus AI.',
+			callback: function() {
 				Session.homCustomAI = !Session.homCustomAI;
 				if(Session.homCustomAI){
 					getModule('UI/Components/HomunInformations/HomunInformations').resetAI();
@@ -317,8 +440,12 @@ define(function( require )
 					this.addText( DB.getMessage(1024), this.TYPE.INFO, this.FILTER.PUBLIC_LOG );
 				}
 				return;
+			}
+		},
 
-			case 'merai':
+		'merai': {
+			description: 'Toggle custom mercenary AI.',
+			callback: function() {
 				Session.merCustomAI = !Session.merCustomAI;
 				if(Session.merCustomAI){
 					this.addText( DB.getMessage(1273), this.TYPE.INFO, this.FILTER.PUBLIC_LOG );
@@ -327,33 +454,105 @@ define(function( require )
 				}
 				this.addText( '(Mercenary not supported yet)', this.TYPE.INFO, this.FILTER.PUBLIC_LOG );
 				return;
-
-		}
-
-
-		// /str+
-		// TODO: do we have to spam the server with "1" unit or do we have to fix the servers code ?
-		matches = text.match(/^(\w{3})\+ (\d+)$/);
-		if (matches) {
-			var pos = ['str', 'agi', 'vit', 'int', 'dex', 'luk'].indexOf(matches[1]);
-			if (pos > -1 && matches[2] !== 0) {
-				pkt = new PACKET.CZ.STATUS_CHANGE();
-				pkt.statusID     = pos + 13;
-				pkt.changeAmount = parseInt( matches[2], 10 );
-				Network.sendPacket(pkt);
-				return;
 			}
 		}
 
-		// Show emotion
-		if (cmd in Emotions.commands) {
-			pkt      = new PACKET.CZ.REQ_EMOTION();
-			pkt.type = Emotions.commands[cmd];
-			Network.sendPacket(pkt);
-			return;
-		}
-
-		// Command not found
-		this.addText( DB.getMessage(95), this.TYPE.INFO, this.FILTER.PUBLIC_LOG );
 	};
+
+	/**
+	 * Load aliases
+	 */
+	function loadAliases() {
+		for (var cmd in CommandStore) {
+			if (CommandStore[cmd].aliases) {
+				for (var i = 0; i < CommandStore[cmd].aliases.length; i++) {
+					aliases[CommandStore[cmd].aliases[i]] = cmd;
+				}
+			}
+		}
+	}
+
+	loadAliases();
+
+	/**
+	 * Process command
+	 */
+	function processCommand( text ) {
+        var cmd = text.split(' ')[0];
+		var pkt, matches;
+
+        // Check if the command exists in the store
+        if (CommandStore[cmd]) {
+            CommandStore[cmd].callback.call(this, text);
+        } else if (aliases[cmd]) {
+			var parentCommand = aliases[cmd];
+			CommandStore[parentCommand].callback.call(this, text);
+		} else {
+			// /str+
+			// TODO: do we have to spam the server with "1" unit or do we have to fix the servers code ?
+			matches = text.match(/^(\w{3})\+ (\d+)$/);
+			if (matches) {
+				var pos = ['str', 'agi', 'vit', 'int', 'dex', 'luk'].indexOf(matches[1]);
+				if (pos > -1 && matches[2] !== 0) {
+					pkt = new PACKET.CZ.STATUS_CHANGE();
+					pkt.statusID     = pos + 13;
+					pkt.changeAmount = parseInt( matches[2], 10 );
+					Network.sendPacket(pkt);
+					return;
+				}
+			}
+
+			// Show emotion
+			if (cmd in Emotions.commands) {
+				pkt      = new PACKET.CZ.REQ_EMOTION();
+				pkt.type = Emotions.commands[cmd];
+				Network.sendPacket(pkt);
+				return;
+			}
+
+            // Command not found
+            this.addText( DB.getMessage(95), this.TYPE.INFO, this.FILTER.PUBLIC_LOG );
+        }
+    };
+
+	/**
+	 * Add a command to the store
+	 */
+	function addCommand( name, description = '', callback = () => {}, aliases = [] ) {
+		var ChatBox = getModule('UI/Components/ChatBox/ChatBox');
+		callback = callback.bind(ChatBox);
+
+		CommandStore[name] = {
+			description: description,
+			callback: callback,
+			aliases: aliases
+		};
+		reloadAliases();
+	};
+
+	/**
+	 * Remove a command from the store
+	 */
+	function removeCommand( name ) {
+		delete CommandStore[name];
+		reloadAliases();
+	};
+
+	/**
+ 	* Reload aliases (we dont reload aliases on each ProcessCommand because it's not a common operation)
+	 */
+	function reloadAliases() {
+		aliases = {};
+		loadAliases();
+	}
+
+	return {
+		processCommand: processCommand,
+		add: addCommand,
+		remove: removeCommand,
+		isEnabled: function( name ) {
+			return name in CommandStore;
+		},
+		reloadAliases: reloadAliases
+	}
 });

--- a/src/Controls/ProcessCommand.js
+++ b/src/Controls/ProcessCommand.js
@@ -7,239 +7,285 @@
  *
  * @author Vincent Thibault
  */
-define(function( require )
-{
-	'use strict';
-
+define(function (require) {
+	"use strict";
 
 	// Load dependencies
-	var DB                 = require('DB/DBManager');
-	var Emotions           = require('DB/Emotions');
-	var BGM                = require('Audio/BGM');
-	var Sound              = require('Audio/SoundManager');
-	var Session            = require('Engine/SessionStorage');
-	var PACKET             = require('Network/PacketStructure');
-	var PACKETVER          = require('Network/PacketVerManager');
-	var Network            = require('Network/NetworkManager');
-	var ControlPreferences = require('Preferences/Controls');
-	var AudioPreferences   = require('Preferences/Audio');
-	var MapPreferences     = require('Preferences/Map');
-	var CameraPreferences  = require('Preferences/Camera');
-	var Renderer           = require('Renderer/Renderer');
-	var getModule          = require;
+	var DB = require("DB/DBManager");
+	var Emotions = require("DB/Emotions");
+	var BGM = require("Audio/BGM");
+	var Sound = require("Audio/SoundManager");
+	var Session = require("Engine/SessionStorage");
+	var PACKET = require("Network/PacketStructure");
+	var PACKETVER = require("Network/PacketVerManager");
+	var Network = require("Network/NetworkManager");
+	var ControlPreferences = require("Preferences/Controls");
+	var AudioPreferences = require("Preferences/Audio");
+	var MapPreferences = require("Preferences/Map");
+	var CameraPreferences = require("Preferences/Camera");
+	var Renderer = require("Renderer/Renderer");
+	var getModule = require;
 
 	var aliases = {};
 
 	var CommandStore = {
-		'sound': {
-			description: 'Toggle sound.',
-			callback: function() {
-				this.addText( DB.getMessage(27 + AudioPreferences.Sound.play), this.TYPE.INFO, this.FILTER.PUBLIC_LOG );
+		sound: {
+			description: "Toggle sound.",
+			callback: function () {
+				this.addText(
+					DB.getMessage(27 + AudioPreferences.Sound.play),
+					this.TYPE.INFO,
+					this.FILTER.PUBLIC_LOG
+				);
 				AudioPreferences.Sound.play = !AudioPreferences.Sound.play;
 				AudioPreferences.save();
 				if (AudioPreferences.Sound.play) {
 					Sound.stop();
 				}
-			}
+			},
 		},
-		'bgm': {
-			description: 'Toggle BGM.',
-			callback: function() {
-				this.addText( DB.getMessage(31 + AudioPreferences.BGM.play), this.TYPE.INFO, this.FILTER.PUBLIC_LOG );
+		bgm: {
+			description: "Toggle BGM.",
+			callback: function () {
+				this.addText(
+					DB.getMessage(31 + AudioPreferences.BGM.play),
+					this.TYPE.INFO,
+					this.FILTER.PUBLIC_LOG
+				);
 				AudioPreferences.BGM.play = !AudioPreferences.BGM.play;
 				AudioPreferences.save();
 
 				if (AudioPreferences.BGM.play) {
-					BGM.play( BGM.filename );
-				}
-				else {
+					BGM.play(BGM.filename);
+				} else {
 					BGM.stop();
 				}
 				return;
-			}
+			},
 		},
-		'effect': {
-			description: 'Toggle effects.',
-			callback: function() {
-				this.addText( DB.getMessage(23 + MapPreferences.effect), this.TYPE.INFO, this.FILTER.PUBLIC_LOG );
+		effect: {
+			description: "Toggle effects.",
+			callback: function () {
+				this.addText(
+					DB.getMessage(23 + MapPreferences.effect),
+					this.TYPE.INFO,
+					this.FILTER.PUBLIC_LOG
+				);
 				MapPreferences.effect = !MapPreferences.effect;
 				MapPreferences.save();
 				return;
-			}
+			},
 		},
-		'mineffect': {
-			description: 'Toggle mine effects.',
-			callback: function() {
-				this.addText( DB.getMessage(687 + MapPreferences.mineffect), this.TYPE.INFO, this.FILTER.PUBLIC_LOG );
+		mineffect: {
+			description: "Toggle mine effects.",
+			callback: function () {
+				this.addText(
+					DB.getMessage(687 + MapPreferences.mineffect),
+					this.TYPE.INFO,
+					this.FILTER.PUBLIC_LOG
+				);
 				MapPreferences.mineffect = !MapPreferences.mineffect;
 				MapPreferences.save();
 				return;
-			}
+			},
 		},
-		'miss': {
-			description: 'Toggle miss effects.',
-			callback: function() {
-				this.addText( DB.getMessage(317 + MapPreferences.miss), this.TYPE.INFO, this.FILTER.PUBLIC_LOG );
+		miss: {
+			description: "Toggle miss effects.",
+			callback: function () {
+				this.addText(
+					DB.getMessage(317 + MapPreferences.miss),
+					this.TYPE.INFO,
+					this.FILTER.PUBLIC_LOG
+				);
 				MapPreferences.miss = !MapPreferences.miss;
 				MapPreferences.save();
 				return;
-			}
+			},
 		},
-		'aura': {
-			description: 'Toggle aura effect.',
-			callback: function() {
+		aura: {
+			description: "Toggle aura effect.",
+			callback: function () {
 				var isSimplified = MapPreferences.aura > 1;
-				this.addText( DB.getMessage(711 + isSimplified), this.TYPE.INFO, this.FILTER.PUBLIC_LOG );
+				this.addText(
+					DB.getMessage(711 + isSimplified),
+					this.TYPE.INFO,
+					this.FILTER.PUBLIC_LOG
+				);
 				MapPreferences.aura = isSimplified ? 1 : 2;
 				MapPreferences.save();
 				return;
-			}
+			},
 		},
-		'aura2': {
-			description: 'Toggle aura2 effect.',
-			callback: function() {
+		aura2: {
+			description: "Toggle aura2 effect.",
+			callback: function () {
 				this.addText(
 					DB.getMessage(
 						2994 + MapPreferences.aura,
-						(
-							MapPreferences.aura
-							? 'Aura effect is OFF' : 'Aura effect is ON'
-						) // default text if not in DB msgstringtable
+						MapPreferences.aura
+							? "Aura effect is OFF"
+							: "Aura effect is ON" // default text if not in DB msgstringtable
 					),
-					this.TYPE.INFO, this.FILTER.PUBLIC_LOG
+					this.TYPE.INFO,
+					this.FILTER.PUBLIC_LOG
 				);
 				MapPreferences.aura = MapPreferences.aura ? 0 : 1;
 				MapPreferences.save();
 				return;
-			}
+			},
 		},
-		'showname': {
-			description: 'Toggle display names.',
-			callback: function() {
-				this.addText( DB.getMessage(722 + MapPreferences.showname), this.TYPE.INFO );
+		showname: {
+			description: "Toggle display names.",
+			callback: function () {
+				this.addText(
+					DB.getMessage(722 + MapPreferences.showname),
+					this.TYPE.INFO
+				);
 				MapPreferences.showname = !MapPreferences.showname;
 				MapPreferences.save();
 
-				var EntityManager = getModule('Renderer/EntityManager');
+				var EntityManager = getModule("Renderer/EntityManager");
 
 				// update all display names
-				EntityManager.forEach(function(entity){
+				EntityManager.forEach(function (entity) {
 					entity.display.refresh(entity);
 				});
 				return;
-			}
+			},
 		},
-		'camera': {
-			description: 'Toggle camera smoothing.',
-			callback: function() {
-				this.addText( DB.getMessage(319 + CameraPreferences.smooth), this.TYPE.INFO, this.FILTER.PUBLIC_LOG );
+		camera: {
+			description: "Toggle camera smoothing.",
+			callback: function () {
+				this.addText(
+					DB.getMessage(319 + CameraPreferences.smooth),
+					this.TYPE.INFO,
+					this.FILTER.PUBLIC_LOG
+				);
 				CameraPreferences.smooth = !CameraPreferences.smooth;
 				CameraPreferences.save();
 				return;
-			}
+			},
 		},
 
-		'fog': {
-			description: 'Toggle fog.',
-			callback: function() {
+		fog: {
+			description: "Toggle fog.",
+			callback: function () {
 				MapPreferences.fog = !MapPreferences.fog;
-				this.addText( 'fog ' + ( MapPreferences.fog ? 'on' : 'off'), this.TYPE.INFO, this.FILTER.PUBLIC_LOG );
+				this.addText(
+					"fog " + (MapPreferences.fog ? "on" : "off"),
+					this.TYPE.INFO,
+					this.FILTER.PUBLIC_LOG
+				);
 				MapPreferences.save();
 				return;
-			}
+			},
 		},
 
-		'lightmap': {
-			description: 'Toggle lightmap',
-			callback: function() {
+		lightmap: {
+			description: "Toggle lightmap",
+			callback: function () {
 				MapPreferences.lightmap = !MapPreferences.lightmap;
 				MapPreferences.save();
 				return;
-			}
+			},
 		},
 
-
-		'noctrl': {
-			description: 'Toggle noctrl.',
-			callback: function() {
-				this.addText( DB.getMessage(717 + ControlPreferences.noctrl), this.TYPE.INFO, this.FILTER.PUBLIC_LOG );
+		noctrl: {
+			description: "Toggle noctrl.",
+			callback: function () {
+				this.addText(
+					DB.getMessage(717 + ControlPreferences.noctrl),
+					this.TYPE.INFO,
+					this.FILTER.PUBLIC_LOG
+				);
 				ControlPreferences.noctrl = !ControlPreferences.noctrl;
 				ControlPreferences.save();
 				return;
 			},
-			aliases: ['nc']
+			aliases: ["nc"],
 		},
 
-		'noshift': {
-			description: 'Toggle noshift.',
-			callback: function() {
-				this.addText( DB.getMessage(701 + ControlPreferences.noshift), this.TYPE.INFO, this.FILTER.PUBLIC_LOG );
+		noshift: {
+			description: "Toggle noshift.",
+			callback: function () {
+				this.addText(
+					DB.getMessage(701 + ControlPreferences.noshift),
+					this.TYPE.INFO,
+					this.FILTER.PUBLIC_LOG
+				);
 				ControlPreferences.noshift = !ControlPreferences.noshift;
 				ControlPreferences.save();
 				return;
 			},
-			aliases: ['ns']
+			aliases: ["ns"],
 		},
 
-		'snap': {
-			description: 'Toggle snap.',
-			callback: function() {
-				this.addText( DB.getMessage(271 + ControlPreferences.snap), this.TYPE.INFO, this.FILTER.PUBLIC_LOG );
+		snap: {
+			description: "Toggle snap.",
+			callback: function () {
+				this.addText(
+					DB.getMessage(271 + ControlPreferences.snap),
+					this.TYPE.INFO,
+					this.FILTER.PUBLIC_LOG
+				);
 				ControlPreferences.snap = !ControlPreferences.snap;
 				ControlPreferences.save();
 				return;
-			}
+			},
 		},
 
-		'itemsnap': {
-			description: 'Toggle itemsnap.',
-			callback: function() {
-				this.addText( DB.getMessage(276 + ControlPreferences.itemsnap), this.TYPE.INFO, this.FILTER.PUBLIC_LOG );
+		itemsnap: {
+			description: "Toggle itemsnap.",
+			callback: function () {
+				this.addText(
+					DB.getMessage(276 + ControlPreferences.itemsnap),
+					this.TYPE.INFO,
+					this.FILTER.PUBLIC_LOG
+				);
 				ControlPreferences.itemsnap = !ControlPreferences.itemsnap;
 				ControlPreferences.save();
 				return;
-			}
+			},
 		},
 
-		'stand': {
-			description: 'Sit/Stand',
-			callback: function() {
+		stand: {
+			description: "Sit/Stand",
+			callback: function () {
 				var pkt;
-				if(PACKETVER.value >= 20180307) {
-					pkt        = new PACKET.CZ.REQUEST_ACT2();
+				if (PACKETVER.value >= 20180307) {
+					pkt = new PACKET.CZ.REQUEST_ACT2();
 				} else {
-					pkt        = new PACKET.CZ.REQUEST_ACT();
+					pkt = new PACKET.CZ.REQUEST_ACT();
 				}
 				if (Session.Entity.action === Session.Entity.ACTION.SIT) {
 					pkt.action = 3; // stand up
-				}
-				else {
+				} else {
 					pkt.action = 2; // sit down
 				}
 				Network.sendPacket(pkt);
 				return;
 			},
-			aliases: ['sit']
+			aliases: ["sit"],
 		},
 
-		'doridori': {
-			description: 'Doridori',
-			callback: function() {
+		doridori: {
+			description: "Doridori",
+			callback: function () {
 				var pkt;
-				Session.Entity.headDir = ( Session.Entity.headDir === 1 ? 2 : 1 );
-				if(PACKETVER.value >= 20180307) {
+				Session.Entity.headDir = Session.Entity.headDir === 1 ? 2 : 1;
+				if (PACKETVER.value >= 20180307) {
 					pkt = new PACKET.CZ.CHANGE_DIRECTION2();
 				} else {
 					pkt = new PACKET.CZ.CHANGE_DIRECTION();
 				}
 				pkt.headDir = Session.Entity.headDir;
-				pkt.dir     = Session.Entity.direction;
+				pkt.dir = Session.Entity.direction;
 				Network.sendPacket(pkt);
 
 				// Doridori recovery bonus
-				if(Session.Entity.action === Session.Entity.ACTION.SIT){
-					if(!Session.Entity.doriTime){
-						Session.Entity.doriTime = [0,0,0,0,0];
+				if (Session.Entity.action === Session.Entity.ACTION.SIT) {
+					if (!Session.Entity.doriTime) {
+						Session.Entity.doriTime = [0, 0, 0, 0, 0];
 					}
 
 					Session.Entity.doriTime.shift();
@@ -248,215 +294,251 @@ define(function( require )
 					var doriStart = Session.Entity.doriTime[0];
 					var doriEnd = Session.Entity.doriTime[4];
 
-					if(doriEnd-doriStart > 1500 && doriEnd-doriStart < 3000){
+					if (
+						doriEnd - doriStart > 1500 &&
+						doriEnd - doriStart < 3000
+					) {
 						var doripkt = new PACKET.CZ.DORIDORI();
 						Network.sendPacket(doripkt);
-						Session.Entity.doriTime = [0,0,0,0,0];
+						Session.Entity.doriTime = [0, 0, 0, 0, 0];
 					}
 				}
 				return;
 			},
 		},
 
-		'bangbang': {
-			description: 'Bangbang',
-			callback: function() {
+		bangbang: {
+			description: "Bangbang",
+			callback: function () {
 				var pkt;
-				Session.Entity.direction = ( Session.Entity.direction + 1 ) % 8;
-				if(PACKETVER.value >= 20180307) {
+				Session.Entity.direction = (Session.Entity.direction + 1) % 8;
+				if (PACKETVER.value >= 20180307) {
 					pkt = new PACKET.CZ.CHANGE_DIRECTION2();
 				} else {
 					pkt = new PACKET.CZ.CHANGE_DIRECTION();
 				}
 				pkt.headDir = Session.Entity.headDir;
-				pkt.dir     = Session.Entity.direction;
+				pkt.dir = Session.Entity.direction;
 				Network.sendPacket(pkt);
 				return;
-			}
+			},
 		},
 
-		'bingbing': {
-			description: 'Bingbing',
-			callback: function() {
+		bingbing: {
+			description: "Bingbing",
+			callback: function () {
 				var pkt;
-				Session.Entity.direction = ( Session.Entity.direction + 7 ) % 8;
-				if(PACKETVER.value >= 20180307) {
+				Session.Entity.direction = (Session.Entity.direction + 7) % 8;
+				if (PACKETVER.value >= 20180307) {
 					pkt = new PACKET.CZ.CHANGE_DIRECTION2();
 				} else {
 					pkt = new PACKET.CZ.CHANGE_DIRECTION();
 				}
 				pkt.headDir = Session.Entity.headDir;
-				pkt.dir     = Session.Entity.direction;
+				pkt.dir = Session.Entity.direction;
 				Network.sendPacket(pkt);
 				return;
-			}
+			},
 		},
 
-		'where': {
-			description: 'Show current position.',
-			callback: function() {
-				var currentMap = getModule('Renderer/MapRenderer').currentMap;
+		where: {
+			description: "Show current position.",
+			callback: function () {
+				var currentMap = getModule("Renderer/MapRenderer").currentMap;
 				this.addText(
-					DB.getMapName(currentMap) + '(' + currentMap + ') : ' + Math.floor(Session.Entity.position[0]) + ', ' + Math.floor(Session.Entity.position[1]),
-					this.TYPE.INFO, this.FILTER.PUBLIC_LOG
+					DB.getMapName(currentMap) +
+						"(" +
+						currentMap +
+						") : " +
+						Math.floor(Session.Entity.position[0]) +
+						", " +
+						Math.floor(Session.Entity.position[1]),
+					this.TYPE.INFO,
+					this.FILTER.PUBLIC_LOG
 				);
 				return;
-			}
+			},
 		},
 
-		'who': {
-			description: 'Show online players.',
-			callback: function() {
+		who: {
+			description: "Show online players.",
+			callback: function () {
 				var pkt = new PACKET.CZ.REQ_USER_COUNT();
 				Network.sendPacket(pkt);
 				return;
 			},
-			aliases: ['w']
+			aliases: ["w"],
 		},
 
-		'memo': {
-			description: 'Save current position.',
-			callback: function() {
+		memo: {
+			description: "Save current position.",
+			callback: function () {
 				var pkt = new PACKET.CZ.REMEMBER_WARPPOINT();
 				Network.sendPacket(pkt);
 				return;
-			}
+			},
 		},
 
-		'chat': {
-			description: 'Create chat room.',
-			callback: function() {
-				getModule('UI/Components/ChatRoomCreate/ChatRoomCreate').show();
+		chat: {
+			description: "Create chat room.",
+			callback: function () {
+				getModule("UI/Components/ChatRoomCreate/ChatRoomCreate").show();
 				return;
-			}
+			},
 		},
 
-
-		'q': {
-			description: 'Close chat room.',
-			callback: function() {
-				getModule('UI/Components/ChatRoom/ChatRoom').remove();
+		q: {
+			description: "Close chat room.",
+			callback: function () {
+				getModule("UI/Components/ChatRoom/ChatRoom").remove();
 				return;
-			}
+			},
 		},
 
-		'leave': {
-			description: 'Leave group.',
-			callback: function() {
-				getModule('Engine/MapEngine/Group').onRequestLeave();
+		leave: {
+			description: "Leave group.",
+			callback: function () {
+				getModule("Engine/MapEngine/Group").onRequestLeave();
 				return;
-			}
+			},
 		},
 
-		'invite': {
-			description: 'Invite player to group.',
-			callback: function(text) {
+		invite: {
+			description: "Invite player to group.",
+			callback: function (text) {
 				var matches = text.match(/^invite\s+(")?([^"]+)(")?/);
 				if (matches && matches[2]) {
-					getModule('Engine/MapEngine/Group').onRequestInvitation(0, matches[2]);
+					getModule("Engine/MapEngine/Group").onRequestInvitation(
+						0,
+						matches[2]
+					);
 					return;
 				}
-			}
+			},
 		},
 
-		'organize': {
-			description: 'Create group.',
-			callback: function(text) {
+		organize: {
+			description: "Create group.",
+			callback: function (text) {
 				var matches = text.match(/^organize\s+(")?([^"]+)(")?/);
 				if (matches && matches[2]) {
-					getModule('Engine/MapEngine/Group').onRequestCreationEasy(matches[2]);
+					getModule("Engine/MapEngine/Group").onRequestCreationEasy(
+						matches[2]
+					);
 					return;
 				}
-			}
+			},
 		},
 
-		'hi': {
-			description: 'Say hi to friends.',
-			callback: function() {
-				getModule('Engine/MapEngine/Friends').sayHi();
+		hi: {
+			description: "Say hi to friends.",
+			callback: function () {
+				getModule("Engine/MapEngine/Friends").sayHi();
 				return;
-			}
+			},
 		},
 
-		'guild': {
-			description: 'Create guild.',
-			callback: function(text) {
+		guild: {
+			description: "Create guild.",
+			callback: function (text) {
 				var matches = text.match(/^guild\s+(")?([^"]+)(")?/);
 				if (matches && matches[2]) {
-					getModule('Engine/MapEngine/Guild').createGuild(matches[2]);
+					getModule("Engine/MapEngine/Guild").createGuild(matches[2]);
 					return;
 				}
-			}
+			},
 		},
 
-		'breakguild': {
-			description: 'Break guild.',
-			callback: function(text) {
+		breakguild: {
+			description: "Break guild.",
+			callback: function (text) {
 				var matches = text.match(/^breakguild\s+(")?([^"]+)(")?/);
 				if (matches && matches[2]) {
-					getModule('Engine/MapEngine/Guild').breakGuild(matches[2]);
+					getModule("Engine/MapEngine/Guild").breakGuild(matches[2]);
 					return;
 				}
-			}
+			},
 		},
 
-
-		'alchemist': {
-			description: 'Show alchemist ranking.',
-			callback: function() {
+		alchemist: {
+			description: "Show alchemist ranking.",
+			callback: function () {
 				var pkt = new PACKET.CZ.ALCHEMIST_RANK();
 				Network.sendPacket(pkt);
 				return;
-			}
+			},
 		},
 
-		'blacksmith': {
-			description: 'Show blacksmith ranking.',
-			callback: function() {
+		blacksmith: {
+			description: "Show blacksmith ranking.",
+			callback: function () {
 				var pkt = new PACKET.CZ.BLACKSMITH_RANK();
 				Network.sendPacket(pkt);
 				return;
-			}
+			},
 		},
 
-		'taekwon': {
-			description: 'Show taekwon ranking.',
-			callback: function() {
+		taekwon: {
+			description: "Show taekwon ranking.",
+			callback: function () {
 				var pkt = new PACKET.CZ.TAEKWON_RANK();
 				Network.sendPacket(pkt);
 				return;
-			}
+			},
 		},
 
-		'hoai': {
-			description: 'Toggle custom homunculus AI.',
-			callback: function() {
+		hoai: {
+			description: "Toggle custom homunculus AI.",
+			callback: function () {
 				Session.homCustomAI = !Session.homCustomAI;
-				if(Session.homCustomAI){
-					getModule('UI/Components/HomunInformations/HomunInformations').resetAI();
-					this.addText( DB.getMessage(1023), this.TYPE.INFO, this.FILTER.PUBLIC_LOG );
+				if (Session.homCustomAI) {
+					getModule(
+						"UI/Components/HomunInformations/HomunInformations"
+					).resetAI();
+					this.addText(
+						DB.getMessage(1023),
+						this.TYPE.INFO,
+						this.FILTER.PUBLIC_LOG
+					);
 				} else {
-					getModule('UI/Components/HomunInformations/HomunInformations').resetAI();
-					this.addText( DB.getMessage(1024), this.TYPE.INFO, this.FILTER.PUBLIC_LOG );
+					getModule(
+						"UI/Components/HomunInformations/HomunInformations"
+					).resetAI();
+					this.addText(
+						DB.getMessage(1024),
+						this.TYPE.INFO,
+						this.FILTER.PUBLIC_LOG
+					);
 				}
 				return;
-			}
+			},
 		},
 
-		'merai': {
-			description: 'Toggle custom mercenary AI.',
-			callback: function() {
+		merai: {
+			description: "Toggle custom mercenary AI.",
+			callback: function () {
 				Session.merCustomAI = !Session.merCustomAI;
-				if(Session.merCustomAI){
-					this.addText( DB.getMessage(1273), this.TYPE.INFO, this.FILTER.PUBLIC_LOG );
+				if (Session.merCustomAI) {
+					this.addText(
+						DB.getMessage(1273),
+						this.TYPE.INFO,
+						this.FILTER.PUBLIC_LOG
+					);
 				} else {
-					this.addText( DB.getMessage(1274), this.TYPE.INFO, this.FILTER.PUBLIC_LOG );
+					this.addText(
+						DB.getMessage(1274),
+						this.TYPE.INFO,
+						this.FILTER.PUBLIC_LOG
+					);
 				}
-				this.addText( '(Mercenary not supported yet)', this.TYPE.INFO, this.FILTER.PUBLIC_LOG );
+				this.addText(
+					"(Mercenary not supported yet)",
+					this.TYPE.INFO,
+					this.FILTER.PUBLIC_LOG
+				);
 				return;
-			}
-		}
-
+			},
+		},
 	};
 
 	/**
@@ -477,14 +559,14 @@ define(function( require )
 	/**
 	 * Process command
 	 */
-	function processCommand( text ) {
-        var cmd = text.split(' ')[0];
+	function processCommand(text) {
+		var cmd = text.split(" ")[0];
 		var pkt, matches;
 
-        // Check if the command exists in the store
-        if (CommandStore[cmd]) {
-            CommandStore[cmd].callback.call(this, text);
-        } else if (aliases[cmd]) {
+		// Check if the command exists in the store
+		if (CommandStore[cmd]) {
+			CommandStore[cmd].callback.call(this, text);
+		} else if (aliases[cmd]) {
 			var parentCommand = aliases[cmd];
 			CommandStore[parentCommand].callback.call(this, text);
 		} else {
@@ -492,11 +574,13 @@ define(function( require )
 			// TODO: do we have to spam the server with "1" unit or do we have to fix the servers code ?
 			matches = text.match(/^(\w{3})\+ (\d+)$/);
 			if (matches) {
-				var pos = ['str', 'agi', 'vit', 'int', 'dex', 'luk'].indexOf(matches[1]);
+				var pos = ["str", "agi", "vit", "int", "dex", "luk"].indexOf(
+					matches[1]
+				);
 				if (pos > -1 && matches[2] !== 0) {
 					pkt = new PACKET.CZ.STATUS_CHANGE();
-					pkt.statusID     = pos + 13;
-					pkt.changeAmount = parseInt( matches[2], 10 );
+					pkt.statusID = pos + 13;
+					pkt.changeAmount = parseInt(matches[2], 10);
 					Network.sendPacket(pkt);
 					return;
 				}
@@ -504,42 +588,51 @@ define(function( require )
 
 			// Show emotion
 			if (cmd in Emotions.commands) {
-				pkt      = new PACKET.CZ.REQ_EMOTION();
+				pkt = new PACKET.CZ.REQ_EMOTION();
 				pkt.type = Emotions.commands[cmd];
 				Network.sendPacket(pkt);
 				return;
 			}
 
-            // Command not found
-            this.addText( DB.getMessage(95), this.TYPE.INFO, this.FILTER.PUBLIC_LOG );
-        }
-    };
+			// Command not found
+			this.addText(
+				DB.getMessage(95),
+				this.TYPE.INFO,
+				this.FILTER.PUBLIC_LOG
+			);
+		}
+	}
 
 	/**
 	 * Add a command to the store
 	 */
-	function addCommand( name, description = '', callback = () => {}, aliases = [] ) {
-		var ChatBox = getModule('UI/Components/ChatBox/ChatBox');
+	function addCommand(
+		name,
+		description = "",
+		callback = () => {},
+		aliases = []
+	) {
+		var ChatBox = getModule("UI/Components/ChatBox/ChatBox");
 		callback = callback.bind(ChatBox);
 
 		CommandStore[name] = {
 			description: description,
 			callback: callback,
-			aliases: aliases
+			aliases: aliases,
 		};
 		reloadAliases();
-	};
+	}
 
 	/**
 	 * Remove a command from the store
 	 */
-	function removeCommand( name ) {
+	function removeCommand(name) {
 		delete CommandStore[name];
 		reloadAliases();
-	};
+	}
 
 	/**
- 	* Reload aliases (we dont reload aliases on each ProcessCommand because it's not a common operation)
+	 * Reload aliases (we dont reload aliases on each ProcessCommand because it's not a common operation)
 	 */
 	function reloadAliases() {
 		aliases = {};
@@ -550,9 +643,9 @@ define(function( require )
 		processCommand: processCommand,
 		add: addCommand,
 		remove: removeCommand,
-		isEnabled: function( name ) {
+		isEnabled: function (name) {
 			return name in CommandStore;
 		},
-		reloadAliases: reloadAliases
-	}
+		reloadAliases: reloadAliases,
+	};
 });

--- a/src/UI/Components/ChatBox/ChatBox.js
+++ b/src/UI/Components/ChatBox/ChatBox.js
@@ -30,7 +30,7 @@ define(function(require)
 	var ContextMenu        = require('UI/Components/ContextMenu/ContextMenu');
 	var htmlText           = require('text!./ChatBox.html');
 	var cssText            = require('text!./ChatBox.css');
-	var ProcessCommand     = require('Controls/ProcessCommand');
+	var Commands     = require('Controls/ProcessCommand');
 	var ChatBoxSettings  = require('UI/Components/ChatBoxSettings/ChatBoxSettings');
 
 
@@ -75,7 +75,7 @@ define(function(require)
 		tabs: [],
 		tabOption: [],
 		activeTab: 0
-		
+
 	}, 1.0);
 
 
@@ -101,7 +101,7 @@ define(function(require)
 		ADMIN:    1 << 9,
 		MAIL:     1 << 10,
 	};
-	
+
 	ChatBox.FILTER = {
 		PUBLIC_LOG:		0,
 		PUBLIC_CHAT:	1,
@@ -146,7 +146,7 @@ define(function(require)
 	ChatBox.lastTabID = -1;
 	ChatBox.tabCount = 0;
 	ChatBox.activeTab = 0;
-	
+
 	ChatBox.tabs = [];
 
 	/**
@@ -333,11 +333,11 @@ define(function(require)
 		this.ui.find('.chat-function .battleopt').click(function(){
 			ChatBox.toggleChatBattleOption();
 		});
-		
+
 		// Init settings window as well
 		ChatBoxSettings.append();
-		
-		
+
+
 		if(_preferences.tabs.length > 0 && _preferences.tabs.length == _preferences.tabOption.length){
 			// Load saved tabs
 			for(var i = 0; i < _preferences.tabs.length; i++){
@@ -345,7 +345,7 @@ define(function(require)
 					ChatBox.addNewTab(_preferences.tabs[i].name, _preferences.tabOption[i]);
 				}
 			}
-			
+
 			// Switch to last active tab
 			if(ChatBox.tabs[_preferences.activeTab]){
 				this.switchTab(_preferences.activeTab);
@@ -372,13 +372,13 @@ define(function(require)
 				ChatBox.FILTER.BATTLEFIELD,
 				ChatBox.FILTER.CLAN
 			]); // Public Log
-				
+
 			ChatBox.addNewTab(DB.getMessage(1292)); // Battle Log
-			
+
 			// switch to first
 			ChatBox.switchTab(firstTab);
 		}
-		
+
 		// dialog box size
 		makeResizableDiv()
 	};
@@ -416,16 +416,16 @@ define(function(require)
 	ChatBox.removeTab = function removeTab() {
 		this.ui.find('table.header tr td.tab[data-tab="'+ this.activeTab +'"]').remove();
 		this.ui.find('.body .content[data-content="'+ this.activeTab +'"]').remove();
-		
+
 		var tabName= '';
 		var _elem = this.ui.find('table.header tr td.tab');
  		_elem = this.ui.find('table.header tr td.tab')[_elem.length - 1];
-		
+
 		// Use delete instead of splice to avoid ID messup and make our life eastier.
 		delete ChatBoxSettings.tabOption[this.activeTab];
 		delete this.tabs[this.activeTab];
 		this.tabCount--;
-		
+
 		ChatBox.switchTab(_elem.dataset.tab);
 
 		tabName = this.ui.find('.header tr td div.on input').val();
@@ -433,7 +433,7 @@ define(function(require)
 	}
 
 	ChatBox.addNewTab = function addNewTab(name, settings){
-		
+
 		// Default settings
 		if(!name){
 			name = 'New Tab';
@@ -464,23 +464,23 @@ define(function(require)
 				ChatBox.FILTER.CLAN
 			];
 		}
-		
+
 		var tabName = name;
 		var tabID = ++this.lastTabID;
-		
+
 		var tab = {};
 		tab.id = tabID;
 		tab.name = tabName;
-		
+
 		// Store prev height
 		//var height = this.ui.find('.contentwrapper').height();
-		
+
 		// Remove current active state
 		this.ui.find('table.header tr td.tab div')
 			.removeClass('on');
 		this.ui.find('.body .content')
 			.removeClass('active');
-		
+
 		// Add new elements as active
 		this.ui.find('table.header tr .opttab').before(`
 			<td class="tab" data-tab="${tabID}">
@@ -489,42 +489,42 @@ define(function(require)
 				</div>
 			</td>
 		`);
-		
+
 		this.ui.find('table.header tr td.tab[data-tab="'+tabID+'"] div input').on('change', function(){
 			ChatBox.tabs[tabID].name = this.value;
 		});
-		
+
 		this.ui.find('.body .contentwrapper').append(
 			`<div class="content active" data-content="${tabID}"></div>`
 		);
 
 		ChatBoxSettings.tabOption[tabID] = settings;
-		
+
 		this.tabs[tabID] = tab;
 		this.activeTab = tabID;
-		
+
 		this.tabCount++;
-		
+
 		ChatBoxSettings.updateTab(this.activeTab, tabName);
-		
+
 		return tabID;
 	}
 
 	ChatBox.switchTab = function switchTab(tabID){
 		var tabName = '';
-		
+
 		this.ui.find('table.header tr td.tab div')
 			.removeClass('on');
 		this.ui.find('.body .content')
 			.removeClass('active');
-		
+
 		this.activeTab = tabID;
 
 		this.ui.find('table.header tr td.tab[data-tab="'+ this.activeTab +'"] div')
 			.addClass('on');
 		this.ui.find('.body .content[data-content="'+ this.activeTab +'"]')
 			.addClass('active');
-		
+
 		tabName = this.ui.find('.header tr td div.on input').val();
 		ChatBoxSettings.updateTab(this.activeTab, tabName);
 	}
@@ -556,13 +556,13 @@ define(function(require)
 		_preferences.magnet_bottom = this.magnet.BOTTOM;
 		_preferences.magnet_left = this.magnet.LEFT;
 		_preferences.magnet_right = this.magnet.RIGHT;
-		
+
 		_preferences.tabs = this.tabs;
 		_preferences.tabOption = ChatBoxSettings.tabOption;
 		_preferences.activeTab = this.activeTab;
-		
+
 		_preferences.save();
-		
+
 		this.lastTabID = -1;
 		this.activeTab = 0;
 	};
@@ -737,7 +737,7 @@ define(function(require)
 			Client.loadFile(DB.INTERFACE_PATH + 'basic_interface/chatmode_'+chatmode+'.bmp', function( data ){
 				ChatBox.ui.find('.chat-function .chatmode').css('backgroundImage', 'url('+ data +')');
 			});
-			
+
 			return;
 		}
 
@@ -756,7 +756,7 @@ define(function(require)
 
 		// Command
 		if (text[0] === '/') {
-			ProcessCommand.call(this, text.substr(1) );
+			Commands.processCommand.call(this, text.substr(1) );
 			return;
 		}
 
@@ -779,7 +779,7 @@ define(function(require)
 		if(isNaN(filterType)){
 			filterType = ChatBox.FILTER.PUBLIC_LOG;
 		}
-		
+
 		this.tabs.forEach((tab, TabNum) => {
 			var content = this.ui.find('.content[data-content="'+ TabNum +'"]');
 			var chatTabOption = ChatBoxSettings.tabOption[TabNum];
@@ -1007,7 +1007,7 @@ define(function(require)
 		let original_mouse_y = 0;
 		for (let i = 0;i < resizers.length; i++) {
 			const currentResizer = resizers[i];
-			
+
 			currentResizer.addEventListener('mousedown', function(e) {
 				e.preventDefault();
 				original_height = ChatBox.ui.find('.contentwrapper').height();
@@ -1026,7 +1026,7 @@ define(function(require)
 					}
 				}
 			}
-		  
+
 			function fixHeight(height){
 				return  Math.floor(height/MAGIC_NUMBER)*MAGIC_NUMBER;
 			}

--- a/src/UI/Components/ChatRoom/ChatRoom.js
+++ b/src/UI/Components/ChatRoom/ChatRoom.js
@@ -191,7 +191,7 @@ define(function(require)
 
 		// Process commands
 		if (message[0] === '/') {
-			getModule('Controls/ProcessCommand').call( ChatBox, message.substr(1) );
+			getModule('Controls/ProcessCommand').processCommand.call( ChatBox, message.substr(1) );
 			ui.find('.send input[name=message]').val('');
 			return true;
 		}

--- a/src/UI/Components/ShortCuts/ShortCuts.js
+++ b/src/UI/Components/ShortCuts/ShortCuts.js
@@ -9,8 +9,8 @@
  define(function(require)
  {
 	 'use strict';
- 
- 
+
+
 	 /**
 	  * Dependencies
 	  */
@@ -28,8 +28,8 @@
 	 var Network            = require('Network/NetworkManager');
 	 var PACKET             = require('Network/PacketStructure');
 	 var getModule    		= require;
- 
- 
+
+
 	 /**
 	  * Create Component
 	  */
@@ -50,7 +50,7 @@
 		Num_9:  '/$'	,
 		Num_0:  '/...'
 	}, 1.0);
-	
+
 	// Fixed, can't change them
 	var _FLAG_INIT = {
 		Num_1:  13, //ET_FLAG
@@ -63,19 +63,19 @@
 		Num_8:  66, //ET_FLAG8
 		Num_9:  67 //ET_FLAG9
 	};
- 
+
 	 /**
 	  * Store ShortCuts items
 	  */
 	 ShortCuts.list = [];
- 
- 
+
+
 	 /**
 	  * @var {number} used to remember the window height
 	  */
 	 var _realSize = 0;
- 
- 
+
+
 	 /**
 	  * @var {Preferences} structure
 	  */
@@ -91,14 +91,14 @@
 		 magnet_left: true,
 		 magnet_right: false
 	 }, 1.0);
- 
- 
+
+
 	 /**
 	  * Initialize UI
 	  */
 	 ShortCuts.init = function Init()
 	 {
-		
+
 		this.ui.find('.footer button').mousedown(function(){
 			if( this.className == 'emoticons')
 				Emoticons.onShortCut({cmd: 'TOGGLE'})
@@ -122,8 +122,8 @@
 
 		this.draggable(this.ui.find('.titlebar'));
 	 };
- 
- 
+
+
 	 /**
 	  * Apply preferences once append to body
 	  */
@@ -132,14 +132,14 @@
 		if (!_preferences.show) {
 			this.ui.hide();
 		}
-		
+
 		this.ui.css({
 			top:  Math.min( Math.max( 0, _preferences.y), Renderer.height - this.ui.height()),
 			left: Math.min( Math.max( 0, _preferences.x), Renderer.width  - this.ui.width())
 		});
 	 };
- 
- 
+
+
 	 /**
 	  * Remove ShortCuts from window (and so clean up items)
 	  */
@@ -148,7 +148,7 @@
 		 this.ui.find('.container .content').empty();
 		 this.list.length = 0;
 		 jQuery('.ItemInfo').remove();
- 
+
 		 // Save preferences
 		 _preferences.show   =  this.ui.is(':visible');
 		 _preferences.reduce = !!_realSize;
@@ -162,8 +162,8 @@
 		 _preferences.magnet_right = this.magnet.RIGHT;
 		 _preferences.save();
 	 };
- 
- 
+
+
 	 /**
 	  * Process shortcut
 	  *
@@ -211,7 +211,7 @@
 			case 'EXECUTE_MACRO_0':
 				executeCmd(0);
 				break;
-				
+
 			// Flags
 			case 'EXECUTE_FLAG_1':
 				executeFlag(1);
@@ -242,8 +242,8 @@
 				break;
 		}
 	 };
- 
- 
+
+
 	 /**
 	  * Extend ShortCuts window size
 	  *
@@ -254,19 +254,19 @@
 	 {
 		 width  = Math.min( Math.max(width,  6), 9);
 		 height = Math.min( Math.max(height, 2), 6);
- 
+
 		 this.ui.find('.container .content').css({
 			 width:  width  * 32 + 13, // 13 = scrollbar
 			 height: height * 32
 		 });
- 
+
 		 this.ui.css({
 			 width:  23 + 16 + 16 + width  * 32,
 			 height: 31 + 19      + height * 32
 		 });
 	 };
- 
- 
+
+
 	/**
 	 * Exit window
 	 */
@@ -274,8 +274,8 @@
 	{
 		ShortCuts.ui.hide();
 	}
- 
- 
+
+
 	 /**
 	  * Extend ShortCuts window size
 	  */
@@ -289,27 +289,27 @@
 		 var lastWidth  = 0;
 		 var lastHeight = 0;
 		 var _Interval;
- 
+
 		 function resizing()
 		 {
 			 var extraX = 23 + 16 + 16 - 30;
 			 var extraY = 31 + 19 - 30;
- 
+
 			 var w = Math.floor( (Mouse.screen.x - left - extraX) / 32 );
 			 var h = Math.floor( (Mouse.screen.y - top  - extraY) / 32 );
- 
+
 			 // Maximum and minimum window size
 			 w = Math.min( Math.max(w, 6), 9);
 			 h = Math.min( Math.max(h, 2), 6);
- 
+
 			 if (w === lastWidth && h === lastHeight) {
 				 return;
 			 }
- 
+
 			 ShortCuts.resize( w, h );
 			 lastWidth  = w;
 			 lastHeight = h;
- 
+
 			 //Show or hide scrollbar
 			 if (content.height() === content[0].scrollHeight) {
 				 hide.show();
@@ -318,10 +318,10 @@
 				 hide.hide();
 			 }
 		 }
- 
+
 		 // Start resizing
 		 _Interval = setInterval( resizing, 30);
- 
+
 		 // Stop resizing on left click
 		 jQuery(window).on('mouseup.resize', function(event){
 			 if (event.which === 1) {
@@ -331,9 +331,9 @@
 		 });
 	 }
 
-	 function executeCmd(value){		
+	 function executeCmd(value){
 		var command = _MACRO_INIT[`Num_${value}`];
-		
+
 		// Nothing to submit
 		if (command.length < 1 || command == '/hide') {
 			return;
@@ -341,22 +341,22 @@
 
 		// Process commands
 		if( command[0] == '/' ){
-			getModule('Controls/ProcessCommand').call( ChatBox, command.substr(1) );
+			getModule('Controls/ProcessCommand').processCommand.call( ChatBox, command.substr(1) );
 			return;
 		}
 
 		ChatBox.onRequestTalk('', command, ChatBox.sendTo);
 	 }
-	 
-	 function executeFlag(value){		
+
+	 function executeFlag(value){
 		var command = _FLAG_INIT[`Num_${value}`];
-		
+
 		// Nothing to submit
 		if (command.length < 1) {
 			return;
 		}
 
-		var pkt = 
+		var pkt =
 		pkt = new PACKET.CZ.REQ_EMOTION();
 		pkt.type = command;
 		Network.sendPacket(pkt);
@@ -375,7 +375,7 @@
 		element.ui.find('.macro input').blur(function(){
 			var index = jQuery(this).attr('id').split("macro_")[1]
 			_MACRO_INIT[`Num_${index}`] = this.value
-			_MACRO_INIT.save();			
+			_MACRO_INIT.save();
 		});
 	 }
 
@@ -384,7 +384,7 @@
 	 */
 	  function onDropText( event )
 	  {
-		  event.stopImmediatePropagation(); 
+		  event.stopImmediatePropagation();
 		  var data;
 		  try {
 			 data = JSON.parse(event.originalEvent.dataTransfer.getData('Text'));
@@ -392,12 +392,12 @@
 		  catch(e) {
 			  return false;
 		  }
-		  
+
 		  // Valid if the message type
 		  if (data.type == 'item') {
 			  return false;
 		  }
- 
+
 		  jQuery(event.currentTarget).val(data);
 		  return false;
 	  }
@@ -417,4 +417,4 @@
 	  */
 	 return UIManager.addComponent(ShortCuts);
  });
- 
+


### PR DESCRIPTION
Refactor commands, now commands are dynamic. (edited)
And now is possible to define new commands as plugins.

Example of how to define a new command via plugin:

```js
define(function(require) {
    var Commands  = require('Controls/ProcessCommand');

    return function Init() {
        Commands.add('hello', 'Says Hello', function() {
            this.addText('Hello!', this.TYPE.INFO);
        });
        return true;
    }
});
```

The `this` in Commands.add callback will point to ChatBox, so it access to right context when they are executed.

Other useful methods are `remove` and `isEnabled`, they are self explanatory.

Note: sorry about the tabs format but it's related i think to the .editorconfig