### PR TITLE
chore: ignoring system folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /client/BGM/*
 /client/data/*
 /client/resources/*
+/client/System/*
 /dist/
 /node_modules/
 /src/Plugins/*/


### PR DESCRIPTION
## Description

Since the folder `client/System` belongs to files related to Ragnarok Installation (data.grf), we should ignore it. It's really annoying to have them on versioning file list.

![image](https://github.com/MrAntares/roBrowserLegacy/assets/6912596/549e2de3-73c4-4094-b403-8c0abe82906a)
