### PR TITLE
feat: adding inputbox actions

### DIFF
--- a/src/Engine/MapEngine/NPC.js
+++ b/src/Engine/MapEngine/NPC.js
@@ -131,7 +131,9 @@ define(function( require )
 		InputBox.onAppend = function OnAppend()
 		{
 			InputBox.setType(type, true);
+			InputBox.ui.find('input').trigger('select');
 		};
+
 
 		InputBox.onSubmitRequest = function OnSubmitRequest( data )
 		{

--- a/src/UI/Components/InputBox/InputBox.js
+++ b/src/UI/Components/InputBox/InputBox.js
@@ -43,6 +43,13 @@ define(function(require)
 			event.stopImmediatePropagation();
 		});
 
+		this.ui.find('input').keyup(function(e){
+			if(e.keyCode == 13) { // Enter
+				let text = InputBox.ui.find('input').val(); 
+				InputBox.onSubmitRequest(text);
+			}
+		});
+
 		this.overlay = jQuery('<div/>')
 			.addClass('win_popup_overlay')
 			.css('zIndex', 30)
@@ -53,12 +60,10 @@ define(function(require)
 
 
 	/**
-	 * Once in HTML, focus the input
+	 * Input Post-Render callback
+	 * Should append data, focus, select text, etc...
 	 */
-	InputBox.onAppend = function OnAppend()
-	{
-		this.ui.find('input').select();
-	};
+	InputBox.onAppend = function OnAppend() {};
 
 
 	/**

--- a/src/UI/Components/InputBox/InputBox.js
+++ b/src/UI/Components/InputBox/InputBox.js
@@ -44,10 +44,11 @@ define(function(require)
 		});
 
 		this.ui.find('input').keyup(function(e){
-			if(e.keyCode == 13) { // Enter
-				let text = InputBox.ui.find('input').val(); 
-				InputBox.onSubmitRequest(text);
-			}
+			let enterKey = 13;
+			if (e.keyCode !== enterKey) return;
+
+			let text = InputBox.ui.find('input').val();
+			if (text.length > 0) InputBox.onSubmitRequest(text);
 		});
 
 		this.overlay = jQuery('<div/>')


### PR DESCRIPTION
## Description

![input_keydown](https://github.com/MrAntares/roBrowserLegacy/assets/6912596/a04a0f49-40db-40b4-956a-17b0ce53de33)

When I was doing the tutorial, I noticed that you can't just press "enter" to send a message but you should click in the button instead. Hopefully with the help of @alisonrag I did some tweaks and also fixed the InputBox autofocus (that wasn't working) that was being overwrite by the children function.

### Changes

* InputBox autofocus when the element shows on the screen;
* InputBox can send the package `PACKET_CZ_INPUT_EDITDLGSTR` when pressing enter inside the element;