### PR TITLE
feat: implement packet hex dump

### DIFF
--- a/api.js
+++ b/api.js
@@ -180,6 +180,11 @@
 
 
 	/**
+	 * @var {boolean}dump packet as hex in console ?
+	 */
+	ROBrowser.prototype.packetDump = false;
+
+	/**
 	 * @var {integer|boolean|array} packetKeys
 	 * see: http://hercules.ws/board/topic/1105-hercules-wpe-free-june-14th-patch/
 	 *
@@ -440,6 +445,7 @@
 			FirstPersonCamera: this.FirstPersonCamera,
 			clientVersionMode: this.clientVersionMode,
 			CameraMaxZoomOut: this.CameraMaxZoomOut,
+			packetDump:       this.packetDump,
 		}, '*');
 	}
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -310,7 +310,8 @@ function initialize() {
               socketProxy:  "ws://127.0.0.1:5999/",  // The websocket proxy's address you set up previously for robrowser (wsproxy)
               adminList:    [2000000]      // List admins' account IDs here like: [2000000, 2000001, 2000002 .... etc]
           }],
-          
+
+          packetDump:      false,  // Dump packet as hex in console?
           skipServerList:  true,   // Skip server selection?
           skipIntro:       false,  // Skip intro page?
           

--- a/examples/api-online-frame.html
+++ b/examples/api-online-frame.html
@@ -26,6 +26,7 @@
 						socketProxy: "ws://5.135.190.4:443/",
 						adminList:   [2000000]
 					}],
+					packetDump:  false,
 					skipServerList:  true,
 					skipIntro:       false,
 				};

--- a/examples/api-online-popup.html
+++ b/examples/api-online-popup.html
@@ -26,6 +26,7 @@
 							socketProxy: "ws://5.135.190.4:443/",
 							adminList:   [2000000]
 						}],
+						packetDump:  false,
 						skipServerList:  true,
 						skipIntro:       false,
 					};

--- a/tools/builder-web.js
+++ b/tools/builder-web.js
@@ -189,6 +189,7 @@ function createHTML(){
                                     packetKeys: false
                                 },
                             ],
+                            packetDump:  false,
                             skipServerList:  true,
                             skipIntro:       true,
                             clientVersionMode: 'PacketVer',


### PR DESCRIPTION
Disabled by default!

just set  `packetDump:  true` at RoConfig

can be usefull to get id and content and is more easy to compare with wireshark or other packets dumpers

example:
![image](https://github.com/MrAntares/roBrowserLegacy/assets/10372732/36d1edf7-02f8-4b0d-bc3d-31ed37ce3591)
