### PR TITLE
Packet dump: log packet name

### DIFF
--- a/api.html
+++ b/api.html
@@ -42,6 +42,7 @@
 					ROConfig.ThirdPersonCamera  = event.data.ThirdPersonCamera  || false;
 					ROConfig.FirstPersonCamera  = event.data.FirstPersonCamera  || false;
 					ROConfig.CameraMaxZoomOut   = event.data.CameraMaxZoomOut   || 5;
+					ROConfig.packetDump   		= event.data.packetDump   		|| false;
 
 					if (ROConfig.development) {
 						var script  = document.createElement('script');

--- a/src/Network/NetworkManager.js
+++ b/src/Network/NetworkManager.js
@@ -163,7 +163,7 @@ define(function( require )
 		if(packetDump) {
 			let fp = new BinaryReader( pkt.buffer );
 			let id = fp.readUShort()
-			console.log("[Network] [send] Packet ID: 0x%s - Length: %d\nContent:\n%s", id.toString(16), pkt.buffer.byteLength, utilsBufferToHexString(pkt.buffer).toUpperCase());
+			console.log("[Network] [send] Packet ID: 0x%s - %s - Length: %d\nContent:\n%s", id.toString(16), Packet.constructor.name, pkt.buffer.byteLength, utilsBufferToHexString(pkt.buffer).toUpperCase());
 		}
 
 		console.log( '%c[Network] Send: ', 'color:#007070', Packet );
@@ -333,7 +333,7 @@ define(function( require )
 
 			if(packetDump) {
 				let buffer_console = new Uint8Array( buffer, 0, length );
-				console.log("[Network] [recv] Packet ID: 0x%s - Length: %d\nContent:\n%s", id.toString(16), length, utilsBufferToHexString(buffer_console).toUpperCase());
+				console.log("[Network] [recv] Packet ID: 0x%s - %s - Length: %d\nContent:\n%s", id.toString(16), packet.name, length, utilsBufferToHexString(buffer_console).toUpperCase());
 			}
 
 			// Parse packet


### PR DESCRIPTION
- Log packet name in packet dump
- packetDump conf was always false because it was missing in api.html


![image](https://github.com/MrAntares/roBrowserLegacy/assets/1909074/84d4c0fe-b9bc-42a8-8378-ecbca651def1)
