### PR TITLE
feat: add forceuseaddress

### DIFF
--- a/api.js
+++ b/api.js
@@ -267,6 +267,10 @@
 	 */
 	ROBrowser.prototype.version = '';
 
+	/**
+	 * @var {boolean} Enable use address to connect in all servers (login, char, map)
+	*/
+	ROBrowser.prototype.forceUseAddress = false;
 
 	/**
 	 * @var {Array} list of extensions you want to use for your BGMs.
@@ -446,6 +450,7 @@
 			clientVersionMode: this.clientVersionMode,
 			CameraMaxZoomOut: this.CameraMaxZoomOut,
 			packetDump:       this.packetDump,
+			forceUseAddress:  this.forceUseAddress,
 		}, '*');
 	}
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -303,6 +303,7 @@ function initialize() {
               port:         6900,          // Must match your game server's
               langtype:     12,            // Must match your game server's
               packetver:    20191223,      // Must match your game server's
+              forceUseAddress: false,      // Some times when connect to server, the server return 127.0.0.1 as IP to connect. This key force robrowse to ignore and use IP set at 'address'
               //grfList:    "DATA.INI",    // By default uses DATA.INI to get grf list, but you can define an array (grfList: ['custom.grf', 'palette.grf', 'data.grf'],) or a regex (grfList: /\.grf$/i,)
               remoteClient: "http://127.0.0.1/client", // Your remote client address. Defaults to http://grf.robrowser.com/
               renewal:      true,          // Must match your game server's type (true/false). When using clientinfo.xml you can add the <renewal>true</renewal> custom tag.

--- a/examples/api-online-frame.html
+++ b/examples/api-online-frame.html
@@ -22,6 +22,7 @@
 						version:     25,
 						langtype:    12,
 						packetver:   20131223,
+						forceUseAddress: false,
 						packetKeys:  true,
 						socketProxy: "ws://5.135.190.4:443/",
 						adminList:   [2000000]

--- a/examples/api-online-popup.html
+++ b/examples/api-online-popup.html
@@ -22,6 +22,7 @@
 							version:     25,
 							langtype:    12,
 							packetver:   20131223,
+							forceUseAddress: false,
 							packetKeys:  true,
 							socketProxy: "ws://5.135.190.4:443/",
 							adminList:   [2000000]

--- a/src/Core/Configs.js
+++ b/src/Core/Configs.js
@@ -88,12 +88,25 @@ define(function()
 	}
 
 
+	
+	/**
+	 * Return the server informations
+	 *
+	 */
+	function getServer()
+	{
+		return _server;
+	}
+
+
+
 	/**
 	 * Export
 	 */
 	return {
 		get:       get,
 		set:       set,
-		setServer: setServer
+		setServer: setServer,
+		getServer: getServer
 	};
 });

--- a/src/Engine/CharEngine.js
+++ b/src/Engine/CharEngine.js
@@ -17,6 +17,7 @@ define(function( require )
 	// Load modules
 	var jQuery     = require('Utils/jquery');
 	var DB         = require('DB/DBManager');
+	var Configs    = require('Core/Configs');
 	var Events     = require('Core/Events');
 	var Sound      = require('Audio/SoundManager');
 	var BGM        = require('Audio/BGM');
@@ -59,7 +60,10 @@ define(function( require )
 		_server = server;
 
 		// Connect to char server
-		Network.connect( Network.utils.longToIP( server.ip ), server.port, function( success ){
+		var forceAddress = Configs.get('forceUseAddress');
+		var server_info = Configs.getServer();
+		var ip = forceAddress ? server_info.address : Network.utils.longToIP( server.ip );
+		Network.connect( ip, server.port, function( success ){
 
 			// Fail to connect...
 			if (!success) {

--- a/src/Engine/MapEngine.js
+++ b/src/Engine/MapEngine.js
@@ -119,7 +119,10 @@ define(function( require )
 		_mapName = mapName;
 
 		// Connect to char server
-		Network.connect( Network.utils.longToIP( ip ), port, function onconnect( success ) {
+		var forceAddress = Configs.get('forceUseAddress');
+		var server_info = Configs.getServer();
+		var current_ip = forceAddress ? server_info.address : Network.utils.longToIP( ip );
+		Network.connect( current_ip, port, function onconnect( success ) {
 
 			// Force reloading map
 			MapRenderer.currentMap = '';

--- a/tools/builder-web.js
+++ b/tools/builder-web.js
@@ -196,6 +196,7 @@ function createHTML(){
                                     version: 55,
                                     langtype: 5,
                                     packetver: 20180704,
+                                    forceUseAddress: false,
                                     socketProxy: "ws://127.0.0.1:5999/",
                                     packetKeys: false
                                 },


### PR DESCRIPTION
some times when u connect to a server it returns 127.0.0.1 as ip to char and map server and robrowser try to connect to your own device instead of remote server.

this pull allow user defines if use same ip to connect in all servers (login, char, map)

before:
![image](https://github.com/MrAntares/roBrowserLegacy/assets/10372732/cea3a00e-b90f-4134-8852-ccad40a5b574)
