### PR TITLE
fix: allow show cutin

### DIFF
--- a/src/Engine/MapEngine/NPC.js
+++ b/src/Engine/MapEngine/NPC.js
@@ -250,12 +250,6 @@ define(function( require )
 		}
 
 		Client.loadFile( DB.INTERFACE_PATH + 'illust/' + pkt.imageName, function( url ){
-
-			// If the npc box is already closed, don't show the image
-			if (!NpcBox.ui || !NpcBox.ui.is(':visible')) {
-				return;
-			}
-
 			var img            = new Image();
 			img.src            = url;
 			img.style.position = 'absolute';


### PR DESCRIPTION
fixes: #301

old code is not reproducible at official servers, it only worked because at first time was necessary make a request to load npc image, then after that the image was already in cache and the code starts to load faster then the following npc messages 
