### PR TITLE
Restore old behavior for equipmentV0

### DIFF
--- a/src/UI/Components/Equipment/EquipmentV0/EquipmentV0.js
+++ b/src/UI/Components/Equipment/EquipmentV0/EquipmentV0.js
@@ -664,6 +664,11 @@ define(function(require)
 		return num;
 	}
 
+	EquipmentV0.checkEquipLoc = function checkEquipLoc( location )
+	{
+		return 0;
+	};
+
 	/**
 	 * Method to define
 	 */


### PR DESCRIPTION
Function checkEquipLoc did not exists but value was always 0

Without this we got `Equipment.getUI().checkEquipLoc is not a function` from Item.js L166