### PR TITLE
BasicInfo Update

### DIFF
--- a/src/UI/Components/BasicInfo/BasicInfoV0/BasicInfoV0.js
+++ b/src/UI/Components/BasicInfo/BasicInfoV0/BasicInfoV0.js
@@ -93,7 +93,7 @@ define(function(require)
 					break;
 
 				case 'info':
-					WinStats.toggle(); // split stats
+					WinStats.getUI().toggle(); // split stats
 					break;
 
 				case 'equip':

--- a/src/UI/Components/BasicInfo/BasicInfoV3/BasicInfoV3.js
+++ b/src/UI/Components/BasicInfo/BasicInfoV3/BasicInfoV3.js
@@ -31,6 +31,7 @@ define(function(require)
 	var Escape             = require('UI/Components/Escape/Escape');
 	var WorldMap           = require('UI/Components/WorldMap/WorldMap');
 	var Rodex              = require('UI/Components/Rodex/Rodex');
+	var WinStats           = require('UI/Components/WinStats/WinStats');
 
 	// Version Dependent UIs
 	var SkillList = require('UI/Components/SkillList/SkillList');
@@ -92,6 +93,10 @@ define(function(require)
 					break;
 
 				case 'info':
+					WinStats.getUI().toggle();
+					break;
+
+				case 'equip':
 					Equipment.getUI().toggle();
 					break;
 
@@ -170,7 +175,6 @@ define(function(require)
 			this.ui.find('.btn_close').hide();
 		}
 
-		this.ui.find('#equip').hide();
 		this.ui.find('#battle').hide();
 		this.ui.find('#navigation').hide();
 		this.ui.find('#battle').hide();

--- a/src/UI/Components/BasicInfo/BasicInfoV4/BasicInfoV4.js
+++ b/src/UI/Components/BasicInfo/BasicInfoV4/BasicInfoV4.js
@@ -34,6 +34,7 @@ define(function(require)
 	var WorldMap           = require('UI/Components/WorldMap/WorldMap');
 	var CheckAttendance    = require('UI/Components/CheckAttendance/CheckAttendance');
 	var Rodex              = require('UI/Components/Rodex/Rodex');
+	var WinStats           = require('UI/Components/WinStats/WinStats');
 
 	// Version Dependent UIs
 	var SkillList = require('UI/Components/SkillList/SkillList');
@@ -95,6 +96,10 @@ define(function(require)
 					break;
 
 				case 'info':
+					WinStats.getUI().toggle();
+					break;
+
+				case 'equip':
 					Equipment.getUI().toggle();
 					break;
 
@@ -178,7 +183,6 @@ define(function(require)
 			this.ui.find('.btn_close').hide();
 		}
 
-		this.ui.find('#equip').hide();
 		this.ui.find('#battle').hide();
 		this.ui.find('#navigation').hide();
 		this.ui.find('#battle').hide();

--- a/src/UI/Components/BasicInfo/BasicInfoV5/BasicInfoV5.js
+++ b/src/UI/Components/BasicInfo/BasicInfoV5/BasicInfoV5.js
@@ -34,6 +34,7 @@ define(function(require)
 	var WorldMap           = require('UI/Components/WorldMap/WorldMap');
 	var CheckAttendance    = require('UI/Components/CheckAttendance/CheckAttendance');
 	var Rodex              = require('UI/Components/Rodex/Rodex');
+	var WinStats           = require('UI/Components/WinStats/WinStats');
 
 	// Version Dependent UIs
 	var SkillList = require('UI/Components/SkillList/SkillList');
@@ -95,6 +96,10 @@ define(function(require)
 					break;
 
 				case 'info':
+					WinStats.getUI().toggle();
+					break;
+
+				case 'equip':
 					Equipment.getUI().toggle();
 					break;
 
@@ -178,7 +183,6 @@ define(function(require)
 			this.ui.find('.btn_close').hide();
 		}
 
-		this.ui.find('#equip').hide();
 		this.ui.find('#battle').hide();
 		this.ui.find('#navigation').hide();
 		this.ui.find('#battle').hide();


### PR DESCRIPTION
Unhide the equipment button for clients above 20140521
Added missing WinStats UI toggle function for BasicInfo shortcut button

![image](https://github.com/MrAntares/roBrowserLegacy/assets/4675631/cbde1659-0d63-4116-a00a-f27965e4bc31)

Tested with 20211103 client