### PR TITLE
fix: moseover ui set overentity to null

### DIFF
--- a/src/UI/UIComponent.js
+++ b/src/UI/UIComponent.js
@@ -139,6 +139,7 @@ define(function( require )
 					if (_intersect) {
 						Mouse.intersect = false;
 						Cursor.setType( Cursor.ACTION.DEFAULT );
+						getModule('Renderer/EntityManager').setOverEntity(null);
 					}
 				}
 			});


### PR DESCRIPTION
fixes: #384

https://github.com/MrAntares/roBrowserLegacy/assets/10372732/0f0483a7-5c70-4b2e-8936-e68d8d931efb

