### PR TITLE
fix: Lua parser handle missing space after '=' in an array assignment.

### DIFF
--- a/src/DB/DBManager.js
+++ b/src/DB/DBManager.js
@@ -378,6 +378,9 @@ define(function(require)
 	 * @param {string} content
 	 */
 	function lua_parse_glob(content) {
+		// Fix possible missing spaces after an array assignment.
+		content = content.replace(/^(\s+)(\w+)\s+?={/mg, '$1$2 = {');
+
 		// Remove comments
 		content = lua_remove_comments(content);
 


### PR DESCRIPTION
In some itemInfo.lua files*, an array assignment might not have a space between the '=' and '{' characters.

This is valid Lua, but will mess up the parser and result in the "={" being kept in the JSON output. In addition to the variable name not being quoted, and the colon not being added.

*E.x. Item #100333 in https://github.com/llchrisll/ROenglishRE/raw/a41785ca936878a0bc921085f01ede566a1022e4/Renewal/System/itemInfo_EN.lua