### PR TITLE
Laphine Synthesis Bug Fix

### DIFF
--- a/src/UI/Components/LaphineSys/LaphineSys.js
+++ b/src/UI/Components/LaphineSys/LaphineSys.js
@@ -558,7 +558,7 @@ define(function(require)
 
 		// If item doesn't exist and should be increased, add it back
 		if (increase && !itemExists) {
-			let item = Inventory.getUI().getItemById(itemId);
+			let item = Inventory.getUI().getItemByIndex(itemIndex);
 			if (item) {
 				let inventory_count = (item.type === ItemType.WEAPON || item.type === ItemType.EQUIP) ? 1 : item.count;
             	let sourceItem = LaphineUIState.sourceItems.find(sourceItem => sourceItem.id === itemId);


### PR DESCRIPTION
Fixed where items that were returned into the available mat list only returns the first item of the id in the inventory, should use item.index