### PR TITLE
Signboard

### DIFF
--- a/src/DB/DBManager.js
+++ b/src/DB/DBManager.js
@@ -157,6 +157,16 @@ define(function(require)
 	var ItemReformTable = {};
 
 	/**
+	 * @var SignBoardTranslated Table
+	 */
+	var SignBoardTranslatedTable = {};
+
+	/**
+	 * @var SignBoard Table
+	 */
+	var SignBoardTable = {};
+
+	/**
 	 * Initialize DB
 	 */
 	DB.init = function init()
@@ -188,7 +198,9 @@ define(function(require)
 
 		if (Configs.get('loadLua')) {
 			loadLuaFile( 'System/itemInfo.lub', function(json){ItemTable = json;}, onLoad());
+			loadSignBoardData( 'System/Sign_Data_EN.lub', function(json){SignBoardTranslatedTable = json;}, onLoad());
 			loadItemDBTable( DB.LUA_PATH + 'ItemDBNameTbl.lub', function(json){ ItemDBNameTbl = json; },  onLoad());
+			loadSignBoardList( DB.LUA_PATH + 'SignBoardList.lub', function(signBoardList){ SignBoardTable = signBoardList; },  onLoad());
 			loadLuaTable([DB.LUA_PATH + 'datainfo/accessoryid.lub', DB.LUA_PATH + 'datainfo/accname.lub'], 'AccNameTable', function(json){ HatTable = json; },  onLoad());
 			loadLuaTable([DB.LUA_PATH + 'datainfo/spriterobeid.lub', DB.LUA_PATH + 'datainfo/spriterobename.lub'], 'RobeNameTable', function(json){ RobeTable = json; },  onLoad());
 			loadLuaTable([DB.LUA_PATH + 'datainfo/npcidentity.lub', DB.LUA_PATH + 'datainfo/jobname.lub'], 'JobNameTable', function(json){ MonsterTable = json; },  onLoad());
@@ -848,6 +860,199 @@ define(function(require)
 				callback.call(null, json);
 				onEnd();
 			}, onEnd);
+	};
+
+	/**
+	 * Loads the System/Sign_Data_EN.lub to json object.
+	 *
+	 * @param {string} filename - The name of the Lua file to load.
+	 * @param {function} callback - The function to invoke with the loaded data.
+	 * @param {function} onEnd - The function to invoke when loading is complete.
+	 * @return {void}
+	 */
+	function loadSignBoardData(filename, callback, onEnd) {
+		Client.loadFile(filename, async function(lua) {
+			console.log('Loading file "' + filename + '"...');
+			let json = {};
+	
+			try {
+				if (lua instanceof ArrayBuffer) {
+					lua = new TextDecoder('iso-8859-1').decode(lua);
+				}
+	
+				// Load the Lua file
+				fengari.load(lua)();
+	
+				// Get the global table "SignBoardData"
+				fengari.lua.lua_getglobal(fengari.L, "SignBoardData");
+	
+				// Check if it's a table
+				if (!fengari.lua.lua_istable(fengari.L, -1)) {
+					console.log('[loadSignBoardData] SignBoardData is not a table');
+					return;
+				}
+	
+				// Push nil key to start iteration
+				fengari.lua.lua_pushnil(fengari.L);
+	
+				// Iterate over the "SignBoardData" table
+				while (fengari.lua.lua_next(fengari.L, -2)) {
+					let key = fengari.lua.lua_tojsstring(fengari.L, -2);
+					let value = fengari.lua.lua_tojsstring(fengari.L, -1);
+					json[key] = value;
+	
+					// Pop the value and move to the next key
+					fengari.lua.lua_pop(fengari.L, 1);
+				}
+	
+				// Clean Lua stack
+				fengari.lua.lua_settop(fengari.L, 0);
+			} catch (hException) {
+				console.error('error: ', hException);
+			}
+
+			callback.call(null, json);
+			onEnd();
+		}, onEnd);
+	};
+
+	/**
+	 * Load SignBoardList.lub to JSON object
+	 *
+	 * @param {string} filename - The name of the Lua file to load.
+	 * @param {function} callback - The function to invoke with the loaded data.
+	 * @param {function} onEnd - The function to invoke when loading is complete.
+	 * @return {void}
+	 */
+	function loadSignBoardList(filename, callback, onEnd) {
+	    Client.loadFile(filename,
+	        async function (lua) {
+	            console.log('Loading file "' + filename + '"...');
+	            let signBoardList = [];
+
+	            try {
+	                if (lua instanceof ArrayBuffer) {
+	                    lua = new TextDecoder('iso-8859-1').decode(lua);
+	                }
+
+	                // Load the Lua file
+	                fengari.load(lua)();
+
+	                // Get the global table "SignBoardList"
+	                fengari.lua.lua_getglobal(fengari.L, "SignBoardList");
+
+	                // Check if it's a table
+	                if (!fengari.lua.lua_istable(fengari.L, -1)) {
+	                    console.log('[loadSignBoardList] SignBoardList is not a table');
+	                    return;
+	                }
+
+	                // Push nil key to start iteration
+	                fengari.lua.lua_pushnil(fengari.L);
+
+	                // Iterate over the "SignBoardList" table
+	                while (fengari.lua.lua_next(fengari.L, -2)) {
+	                    let entry = {};
+
+	                    // get mapname (index 1)
+	                    fengari.lua.lua_pushinteger(fengari.L, 1);
+	                    fengari.lua.lua_gettable(fengari.L, -2);
+	                    entry.mapname = fengari.lua.lua_tojsstring(fengari.L, -1);
+	                    fengari.lua.lua_pop(fengari.L, 1);
+
+	                    // get x (index 2)
+	                    fengari.lua.lua_pushinteger(fengari.L, 2);
+	                    fengari.lua.lua_gettable(fengari.L, -2);
+	                    entry.x = fengari.lua.lua_tointeger(fengari.L, -1);
+	                    fengari.lua.lua_pop(fengari.L, 1);
+
+	                    // get y (index 3)
+	                    fengari.lua.lua_pushinteger(fengari.L, 3);
+	                    fengari.lua.lua_gettable(fengari.L, -2);
+	                    entry.y = fengari.lua.lua_tointeger(fengari.L, -1);
+	                    fengari.lua.lua_pop(fengari.L, 1);
+
+	                    // get height (index 4)
+	                    fengari.lua.lua_pushinteger(fengari.L, 4);
+	                    fengari.lua.lua_gettable(fengari.L, -2);
+	                    entry.height = fengari.lua.lua_tointeger(fengari.L, -1);
+	                    fengari.lua.lua_pop(fengari.L, 1);
+
+	                    // get type (index 5)
+	                    fengari.lua.lua_pushinteger(fengari.L, 5);
+	                    fengari.lua.lua_gettable(fengari.L, -2);
+	                    entry.type = fengari.lua.lua_tointeger(fengari.L, -1);
+	                    fengari.lua.lua_pop(fengari.L, 1);
+
+	                    // get icon_location (index 6)
+	                    fengari.lua.lua_pushinteger(fengari.L, 6);
+	                    fengari.lua.lua_gettable(fengari.L, -2);
+	                    entry.icon_location = fengari.lua.lua_tojsstring(fengari.L, -1);
+	                    fengari.lua.lua_pop(fengari.L, 1);
+
+	                    // get description (index 7, optional)
+	                    fengari.lua.lua_pushinteger(fengari.L, 7);
+	                    fengari.lua.lua_gettable(fengari.L, -2);
+	                    if (fengari.lua.lua_isstring(fengari.L, -1)) {
+	                        let rawDescription = fengari.lua.lua_tojsstring(fengari.L, -1);
+    						entry.description = DB.getTranslatedSignBoard(rawDescription);
+	                    } else {
+	                        entry.description = null;
+	                    }
+	                    fengari.lua.lua_pop(fengari.L, 1);
+
+	                    // get color (index 8, optional)
+	                    fengari.lua.lua_pushinteger(fengari.L, 8);
+	                    fengari.lua.lua_gettable(fengari.L, -2);
+	                    if (fengari.lua.lua_isstring(fengari.L, -1)) {
+	                        entry.color = fengari.lua.lua_tojsstring(fengari.L, -1);
+	                    } else {
+	                        entry.color = null;
+	                    }
+	                    fengari.lua.lua_pop(fengari.L, 1);
+
+	                    // Add entry to signBoardList
+	                    signBoardList.push(entry);
+
+	                    // Pop the value and move to the next key
+	                    fengari.lua.lua_pop(fengari.L, 1);
+	                }
+
+	                // Clean Lua stack
+	                fengari.lua.lua_settop(fengari.L, 0);
+	            } catch (hException) {
+	                console.error('error: ', hException);
+	            }
+				// Preprocess the signboard list into a nested dictionary
+				const signboardDict = preprocessSignboardData(signBoardList);
+	            callback.call(null, signboardDict);
+	            onEnd();
+	        },
+	        onEnd
+	    );
+	};
+
+	/**
+	 * Preprocesses an array of signboard objects and organizes them into a nested dictionary.
+	 *
+	 * @param {Array} signboardArray - The array of signboard objects.
+	 * @return {Object} The nested dictionary containing the preprocessed signboard data.
+	 */
+	function preprocessSignboardData(signboardArray) {
+	    const signboardDict = {};
+
+	    for (let signboard of signboardArray) {
+	        const { mapname, x, y } = signboard;
+	        if (!signboardDict[mapname]) {
+	            signboardDict[mapname] = {};
+	        }
+	        if (!signboardDict[mapname][x]) {
+	            signboardDict[mapname][x] = {};
+	        }
+	        signboardDict[mapname][x][y] = signboard;
+	    }
+
+	    return signboardDict;
 	};
 
 	/**
@@ -2667,6 +2872,42 @@ define(function(require)
 		}
 		
 		return reformInfos;
+	};
+
+	/**
+	 * Finds a signboard in the given map based on the provided coordinates.
+	 *
+	 * @param {string} mapname - The name of the map to search in.
+	 * @param {number} x - The x-coordinate of the signboard.
+	 * @param {number} y - The y-coordinate of the signboard.
+	 * @param {number} [tolerance=1] - The tolerance value for matching coordinates.
+	 * @return {Object|null} The signboard object if found, or null if not found.
+	 */
+	DB.findSignboard = function findSignboard(mapname, x, y, tolerance = 1) {
+		const mapData = SignBoardTable[mapname];
+    	if (mapData) {
+    	    for (let xKey in mapData) {
+    	        if (Math.abs(x - xKey) <= tolerance) {
+    	            const yData = mapData[xKey];
+    	            for (let yKey in yData) {
+    	                if (Math.abs(y - yKey) <= tolerance) {
+    	                    return yData[yKey];
+    	                }
+    	            }
+    	        }
+    	    }
+    	}
+    	return null;
+	};
+
+	/**
+	 * Retrieves the translated signboard description based on the provided description.
+	 *
+	 * @param {string} description - The description of the signboard.
+	 * @return {string} The translated signboard description if found, otherwise the original description.
+	 */
+	DB.getTranslatedSignBoard = function getTranslatedSignBoard(description) {
+		return SignBoardTranslatedTable[description] || description;
 	};
 
 	/**

--- a/src/Engine/MapEngine/Entity.js
+++ b/src/Engine/MapEngine/Entity.js
@@ -51,6 +51,7 @@ define(function( require )
 	var Inventory         = require('UI/Components/Inventory/Inventory');
 	var ShortCut          = require('UI/Components/ShortCut/ShortCut');
 	var StatusIcons       = require('UI/Components/StatusIcons/StatusIcons');
+	var getModule	      = require;
 
 	// Version Dependent UIs
 	var BasicInfo = require('UI/Components/BasicInfo/BasicInfo');
@@ -129,6 +130,13 @@ define(function( require )
 				} else {
 					EF_Init_Par.effectId = EffectConst.EF_WARPZONE2;
 					EffectManager.spam( EF_Init_Par );
+				}
+			}
+			if (entity.objecttype === Entity.TYPE_NPC || Entity.TYPE_WARP) {
+				const mapName = getModule("Renderer/MapRenderer").currentMap.replace('.gat', '').toLowerCase();
+				let signboardData = DB.findSignboard(mapName, entity.position[0], entity.position[1], 1 );
+				if(signboardData) {
+					entity.signboard.load(signboardData);
 				}
 			}
 			EntityManager.add(entity);

--- a/src/Renderer/Entity/Entity.js
+++ b/src/Renderer/Entity/Entity.js
@@ -48,6 +48,7 @@ define( function( require )
 		require('./EntityAura').call(this);
 		require('./EntityDropEffect').call(this);
 		require('./EntityEmblem').call(this);
+		require('./EntitySignboard').call(this);
 
 		this.boundingRect = { x1:0, y1:0, x2:0, y2:0 };
 		this.matrix       = mat4.create();
@@ -363,6 +364,7 @@ define( function( require )
 		this.animations.free();
 		this.aura.free();
 		this.dropEffect.free();
+		this.signboard.clean();
 
 		// Remove
 		this.remove_tick  = 0;

--- a/src/Renderer/Entity/EntityRender.js
+++ b/src/Renderer/Entity/EntityRender.js
@@ -110,6 +110,7 @@ define( function( require )
 			if (entity.dialog.display)  entity.dialog.render( _matrix );
 			if (entity.cast.display)	entity.cast.render( _matrix );
 			if (entity.room.display)	entity.room.render( _matrix );
+			if (entity.signboard.display)	entity.signboard.render( _matrix );
 		};
 	}();
 

--- a/src/Renderer/Entity/EntitySignboard.js
+++ b/src/Renderer/Entity/EntitySignboard.js
@@ -1,0 +1,158 @@
+/**
+ * Renderer/EntitySignboard/EntitySignboard.js
+ *
+ * Signboard above entity's head
+ *
+ * This file is part of ROBrowser, (http://www.robrowser.com/).
+ */
+define(function( require )
+{
+	'use strict';
+
+
+	// Load dependencies
+	var glMatrix   = require('Utils/gl-matrix');
+	var Renderer   = require('Renderer/Renderer');
+	var Client     = require('Core/Client');
+	var DB         = require('DB/DBManager');
+	var EntitySignboard = require('UI/Components/EntitySignboard/EntitySignboard');
+
+    var vec4 = glMatrix.vec4;
+    var _pos = new Float32Array(4);
+    var _size = new Float32Array(2);
+
+    var posY = 0;
+    var posZ = 0;
+
+    /**
+     * Signboard class
+     */
+    function Signboard(owner) {
+        this.owner = owner;
+        this.type = Signboard.Type.ICON_ONLY;
+        this.background = null;
+        this.icon = null;
+        this.description = '';
+        this.display = false;
+        this.posY = 0;
+        this.posX = 0;
+    }
+
+    /**
+     * Constants
+     */
+    Signboard.Type = {
+        ICON_ONLY: 1,
+        FULL_SIGNBOARD: 3
+    };
+
+    /**
+     * Load Signboard with background, icon, and description
+     *
+     * @param {Object} signboardData - Data for the signboard
+     */
+    Signboard.prototype.load = function(signboardData) {
+        var self = this;
+
+		function init() {
+
+            self.type = signboardData.type;
+            signboardData.icon_location = signboardData.icon_location.replace('\xc0\xaf\xc0\xfa\xc0\xce\xc5\xcd\xc6\xe4\xc0\xcc\xbd\xba' + '\\', '');
+
+            if (self.type === Signboard.Type.ICON_ONLY) {
+                self.posY = 15;
+                self.posX = 120;
+                console.log("Signboard icon!");
+                Client.loadFile( DB.INTERFACE_PATH + signboardData.icon_location, function(url){
+                    self.display = true;
+
+                    if (self.node) {
+                        self.node.setIconOnly( url );
+                    }
+                });
+            } else if (self.type === Signboard.Type.FULL_SIGNBOARD) {
+                self.posY = 70;
+                self.posX = 140;
+                console.log("Signboard Fullboard!");
+                Client.loadFile( DB.INTERFACE_PATH + signboardData.icon_location, function(url){
+                    self.display = true;
+    
+                    if (self.node) {
+                        self.node.setTitle( signboardData.description, url );
+                    }
+                });
+            }
+        }
+
+        // Already exist
+		if (this.node) {
+			init();
+			this.node.append();
+			return;
+		}
+
+		this.node      = EntitySignboard.clone('EntitySignboard', true);
+		this.node.init = init;
+		this.node.append();
+    };
+
+
+    /**
+     * Render Signboard
+     *
+     * @param {mat4} matrix
+     */
+    Signboard.prototype.render = function(matrix) {
+        var ui = this.node.ui[0];
+        var z;
+
+        // Cast position
+		_pos[0] =  0.0;
+		_pos[1] =  this.posX / 35;
+		_pos[2] =  0.0;
+		_pos[3] =  1.0;
+
+        // Set the viewport
+        _size[0] = Renderer.width / 2;
+        _size[1] = Renderer.height / 2;
+
+        // Project point to scene
+        vec4.transformMat4(_pos, _pos, matrix);
+
+        // Calculate position
+        z = _pos[3] === 0.0 ? 1.0 : (1.0 / _pos[3]);
+        _pos[0] = _size[0] + Math.round(_size[0] * (_pos[0] * z));
+        _pos[1] = _size[1] - Math.round(_size[1] * (_pos[1] * z));
+
+        ui.style.top  = (_pos[1] | 0 ) + 'px';
+		ui.style.left = ((_pos[0] - this.posY) | 0) + 'px';
+    };
+
+    /**
+     * Remove Signboard
+     */
+    Signboard.prototype.remove = function() {
+        this.display = false;
+		if (this.node) {
+			this.node.remove();
+		}
+    };
+
+    /**
+     * Clean Signboard
+     */
+    Signboard.prototype.clean = function() {
+        this.remove();
+        this.background = null;
+        this.icon = null;
+        this.description = '';
+    };
+
+    /**
+     * Export
+     */
+    return function Init() {
+        this.signboard = new Signboard(this);
+    };
+});
+

--- a/src/UI/Components/EntitySignboard/EntitySignboard.css
+++ b/src/UI/Components/EntitySignboard/EntitySignboard.css
@@ -1,0 +1,66 @@
+.EntitySignboard {
+    position: absolute;
+    z-index: 45;
+    width: 161px;
+    background-repeat: no-repeat;
+    padding: 3px;
+    letter-spacing: 0px;
+    height: 30px;
+    cursor: inherit;
+}
+
+.EntitySignboard button {
+    position: relative;
+    height: 24px;
+    width: 100%;
+    text-align: left;
+    padding: 0px;
+    background-color: transparent;
+    background-repeat: no-repeat;
+    white-space: nowrap;
+    border: none;
+    left: 2px;
+    top: 2px;
+}
+
+.EntitySignboard button:hover {
+    cursor: inherit;
+}
+
+.EntitySignboard button.icon-only {
+    pointer-events: none;
+}
+
+.EntitySignboard button .title {
+    position: relative;
+    left: 30px;
+    width: 122px;
+    color: white;
+    overflow: hidden;
+    color: white;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+    display: inline-block;
+    max-width: 100%;
+    vertical-align: middle;
+    font-size: 0.9em;
+}
+
+.EntitySignboard .overlay {
+	position: absolute;
+	top: 0px;
+	left: 26px;
+	display: none;
+	white-space: nowrap;
+	z-index:900;
+	height:13px;
+	padding:5px;
+	background-color:rgba(0,0,0,0.6);
+	color:white;
+	text-shadow:1px 1px black;
+}
+
+.EntitySignboard button:hover .overlay {
+	display:block;
+}

--- a/src/UI/Components/EntitySignboard/EntitySignboard.html
+++ b/src/UI/Components/EntitySignboard/EntitySignboard.html
@@ -1,0 +1,6 @@
+<div class="EntitySignboard" data-background="signboard/bg_signboard.bmp">
+	<button>
+		<div class="overlay"></div>
+		<span class="title"></span>
+	</button>
+</div>

--- a/src/UI/Components/EntitySignboard/EntitySignboard.js
+++ b/src/UI/Components/EntitySignboard/EntitySignboard.js
@@ -1,0 +1,116 @@
+/**
+ * UI/Components/EntitySignboard/EntitySignboard.js
+ *
+ * Entity room (chat room, shop room, ...)
+ *
+ * This file is part of ROBrowser, (http://www.robrowser.com/).
+ *
+ * @author Vincent Thibault
+ */
+define(function(require)
+{
+	'use strict';
+
+
+	/**
+	 * Dependencies
+	 */
+	var UIManager          = require('UI/UIManager');
+	var UIComponent        = require('UI/UIComponent');
+	var htmlText           = require('text!./EntitySignboard.html');
+	var cssText            = require('text!./EntitySignboard.css');
+
+
+	/**
+	 * Createcomponent
+	 */
+	var EntitySignboard = new UIComponent( 'EntitySignboard', htmlText, cssText );
+
+
+	/**
+	 * @var {boolean} do not focus this UI
+	 */
+	EntitySignboard.needFocus = false;
+
+
+	/**
+	 * Once in HTML, focus the input
+	 */
+	EntitySignboard.onAppend = function onAppend()
+	{
+		this.ui.find('button').dblclick(function(){
+			if (this.onEnter) {
+				this.onEnter();
+			}
+		}.bind(this));
+
+		// Avoid player to move to the cell
+		this.ui.mousedown(function(){
+			return false;
+		});
+
+		this.ui.css('zIndex', 45);
+	};
+
+
+	/**
+	 * Remove data from UI
+	 */
+	EntitySignboard.onRemove = function onRemove()
+	{
+		this.ui.find('button').unbind();
+		//this.ui.find('button').removeClass('icon-only');
+	};
+
+
+	/**
+	 * Define title and icons
+	 *
+	 * @param {string} title
+	 * @param {string} url - icon url
+	 */
+	EntitySignboard.setTitle = function setTitle( title, url )
+	{
+		this.ui.find('button').css('backgroundImage', 'url('+ url +')');
+		this.ui.find('.title, .overlay').text(title);
+
+		const titleElement = this.ui.find('.title');
+		const overlayElement = this.ui.find('.overlay');
+
+		// Check if the title is overflowing
+		if (!isOverflowing(titleElement[0])) {
+			overlayElement.hide(); // Hide the overlay if no overflow
+		}
+	};
+
+
+	/**
+	 * Define title and icons
+	 *
+	 * @param {string} title
+	 * @param {string} url - icon url
+	 */
+	EntitySignboard.setIconOnly = function setIconOnly(url)
+	{
+		this.ui.css('backgroundImage', 'none'); // Hide the background image of the entire signboard
+		this.ui.find('button').addClass('icon-only').css('backgroundImage', 'url('+ url +')');
+		this.ui.find('.title').hide();
+		this.ui.find('.overlay').hide();
+	};
+
+	// Function to check if an element's content is overflowing
+	function isOverflowing(element) {
+	    return element.scrollWidth > element.clientWidth || element.scrollHeight > element.clientHeight;
+	}
+
+	/**
+	 * function to define
+	 */
+	EntitySignboard.onEnter = function onEnter(){};
+
+
+	/**
+	 * Stored component and return it
+	 */
+	return UIManager.addComponent(EntitySignboard);
+});


### PR DESCRIPTION
Initial implementation of Signboard

Some Notes:
Sign_Data_EN.lub - is a lub from Translated files (used to translate the text to show in some of the signboards, can be changed into other language depending on the owner but haven't tested with other language that uses other encoding. The key in this table should be read in ISO-8859-1 while value should be versatile. As of now only tested with English characters)

Implementation was attached to NPC entities which gave us the limitation of seeing the board only if we already received the packet that NPC is near or visible which is unlike in the client, it is directly loaded into map I think (but I don't think it's much of a problem, you will only notice this if you are zoom out so far)

![Screenshot 2024-08-06 154034](https://github.com/user-attachments/assets/292d525e-77ff-431a-b8fc-8f2e4a4b318e)