### PR TITLE
Fix multiple issues

### DIFF
--- a/src/UI/Components/Equipment/EquipmentV0/EquipmentV0.js
+++ b/src/UI/Components/Equipment/EquipmentV0/EquipmentV0.js
@@ -51,7 +51,7 @@ define(function(require)
 		y:        200,
 		show:     false,
 		reduce:   false,
-		stats:    true
+		stats:    false
 	}, 1.0);
 
 
@@ -303,7 +303,7 @@ define(function(require)
 		}.bind(this));
 
 		var Inventory = getModule('UI/Components/Inventory/Inventory');
-		
+
 		if (!Inventory.getUI().equippedItems.includes(item.index)) {
 			Inventory.getUI().equippedItems.push(item.index);
 		}

--- a/src/UI/Components/Inventory/InventoryV0/InventoryV0.js
+++ b/src/UI/Components/Inventory/InventoryV0/InventoryV0.js
@@ -859,7 +859,7 @@ define(function(require)
 		}
 
 		let quantity = ' ea';
-		if ((item.type === ItemType.WEAPON || item.type === ItemType.EQUIP) && 
+		if (item.Options && (item.type === ItemType.WEAPON || item.type === ItemType.EQUIP) &&
 			item.Options.filter(Option => Option.index !== 0).length > 0)
 		{
 			quantity = ' Quantity';

--- a/src/UI/Components/Inventory/InventoryV1/InventoryV1.js
+++ b/src/UI/Components/Inventory/InventoryV1/InventoryV1.js
@@ -172,9 +172,9 @@ define(function(require)
 		InventoryV1.ui.find('.item_drop_lock').click(onItemLock);
 		InventoryV1.ui.find('.item_compare').click(onItemCompare);
 		InventoryV1.ui.find('.deal_lock').click(onNPCLock);
-		InventoryV1.ui.find('.lockoverlayclose').click(function(){ 
+		InventoryV1.ui.find('.lockoverlayclose').click(function(){
 			InventoryV1.ui.find('.lockoverlaymsg').hide();
-			clearTimeout(lockOverlayTimeout); 
+			clearTimeout(lockOverlayTimeout);
 		});
 		InventoryV1.ui.find('.sort').click( function(){ requestFilter();} );
 	};
@@ -928,7 +928,7 @@ define(function(require)
 		}
 
 		let quantity = ' ea';
-		if ((item.type === ItemType.WEAPON || item.type === ItemType.EQUIP) && 
+		if (item.Options && item.Opt(item.type === ItemType.WEAPON || item.type === ItemType.EQUIP) &&
 			item.Options.filter(Option => Option.index !== 0).length > 0)
 		{
 			quantity = ' Quantity';
@@ -1148,7 +1148,7 @@ define(function(require)
 	    // Retrieve the data-tab attribute using native JavaScript
     	var targetTab = event.target.getAttribute('data-tab');
 		var itemfav = (targetTab === 'fav' ? 0 : 1);
-	    
+
 		// Send Request to client
 		var pkt = new PACKET.CZ.INVENTORY_TAB();
 		pkt.item_index = item.index;
@@ -1165,11 +1165,11 @@ define(function(require)
 	InventoryV1.updatePlaceETCTab = function(itemIndex, newValue)
 	{
 		var item = InventoryV1.getItemByIndex(itemIndex);
-		
+
 		if (!item) {
 			return;
 		}
-    	
+
 		if (newValue) {
 			var favoriteval;
 			switch (item.type) {
@@ -1214,10 +1214,10 @@ define(function(require)
 
 		// Save it
 		InventoryV1.itemlock = _preferences.itemlock;
-	
+
 		// Determine the image path based on the toggled state
 		var lockImg = _preferences.itemlock ? 'inventory/item_drop_lock_on.bmp' : 'inventory/item_drop_lock_off.bmp';
-	
+
 		// Load the image and update the button background
 		Client.loadFile(DB.INTERFACE_PATH + lockImg, function (data) {
 			InventoryV1.ui.find('.item_drop_lock').css('backgroundImage', 'url(' + data + ')');

--- a/src/UI/Components/Inventory/InventoryV2/InventoryV2.js
+++ b/src/UI/Components/Inventory/InventoryV2/InventoryV2.js
@@ -180,9 +180,9 @@ define(function(require)
 		InventoryV2.ui.find('.item_drop_lock').click(onItemLock);
 		InventoryV2.ui.find('.item_compare').click(onItemCompare);
 		InventoryV2.ui.find('.deal_lock').click(onNPCLock);
-		InventoryV2.ui.find('.lockoverlayclose').click(function(){ 
+		InventoryV2.ui.find('.lockoverlayclose').click(function(){
 			InventoryV2.ui.find('.lockoverlaymsg').hide();
-			clearTimeout(lockOverlayTimeout); 
+			clearTimeout(lockOverlayTimeout);
 		});
 		InventoryV2.ui.find('.sort').click( function(){ requestFilter();} );
 	};
@@ -600,7 +600,7 @@ define(function(require)
 		return this.equipswitchlist.some(function(existingItem) {
 			return (existingItem.location & location) !== 0;
 		});
-	};	
+	};
 
 
 	/**
@@ -977,7 +977,7 @@ define(function(require)
 		}
 
 		let quantity = ' ea';
-		if ((item.type === ItemType.WEAPON || item.type === ItemType.EQUIP) && 
+		if (item.Options && (item.type === ItemType.WEAPON || item.type === ItemType.EQUIP) &&
 			item.Options.filter(Option => Option.index !== 0).length > 0)
 		{
 			quantity = ' Quantity';
@@ -1197,7 +1197,7 @@ define(function(require)
 	    // Retrieve the data-tab attribute using native JavaScript
     	var targetTab = event.target.getAttribute('data-tab');
 		var itemfav = (targetTab === 'fav' ? 0 : 1);
-	    
+
 		// Send Request to client
 		var pkt = new PACKET.CZ.INVENTORY_TAB();
 		pkt.item_index = item.index;
@@ -1214,11 +1214,11 @@ define(function(require)
 	InventoryV2.updatePlaceETCTab = function(itemIndex, newValue)
 	{
 		var item = InventoryV2.getItemByIndex(itemIndex);
-		
+
 		if (!item) {
 			return;
 		}
-    	
+
 		if (newValue) {
 			var favoriteval;
 			switch (item.type) {
@@ -1263,10 +1263,10 @@ define(function(require)
 
 		// Save it
 		InventoryV2.itemlock = _preferences.itemlock;
-	
+
 		// Determine the image path based on the toggled state
 		var lockImg = _preferences.itemlock ? 'inventory/item_drop_lock_on.bmp' : 'inventory/item_drop_lock_off.bmp';
-	
+
 		// Load the image and update the button background
 		Client.loadFile(DB.INTERFACE_PATH + lockImg, function (data) {
 			InventoryV2.ui.find('.item_drop_lock').css('backgroundImage', 'url(' + data + ')');
@@ -1344,14 +1344,14 @@ define(function(require)
 		var existingItemIndex = this.equipswitchlist.findIndex(function(existingItem) {
 			return existingItem.location === item.location;
 		});
-	
+
 		// If an item with the same location exists, unequip it and remove it from the list
 		if (existingItemIndex > -1) {
 			var existingItem = this.equipswitchlist[existingItemIndex];
 			SwitchEquip.unEquip(existingItem.index, existingItem.location);
 			this.equipswitchlist.splice(existingItemIndex, 1);
 		}
-	
+
 		// Add the new item to the list
 		this.equipswitchlist.push(item);
 
@@ -1390,14 +1390,14 @@ define(function(require)
     	});
 
     	if (existingItemIndex > -1) {
-    	
+
 			var content = this.ui.find('.container .content');
     	    content.find('.item[data-index="'+ item.index +'"] .switch1').css('backgroundImage', 'none');
 		    content.find('.item[data-index="'+ item.index +'"] .switch2').css('backgroundImage', 'none');
 
     	    SwitchEquip.unEquip(item.index, item.location);
 			var removedItem = this.equipswitchlist.splice(existingItemIndex, 1)[0];
-    	
+
 			ChatBox.addText(
 				DB.getItemName(item) + ' ' + DB.getMessage(3144),
 				ChatBox.TYPE.BLUE,

--- a/src/UI/Components/Inventory/InventoryV3/InventoryV3.js
+++ b/src/UI/Components/Inventory/InventoryV3/InventoryV3.js
@@ -182,9 +182,9 @@ define(function(require)
 		InventoryV3.ui.find('.item_drop_lock').click(onItemLock);
 		InventoryV3.ui.find('.item_compare').click(onItemCompare);
 		InventoryV3.ui.find('.deal_lock').click(onNPCLock);
-		InventoryV3.ui.find('.lockoverlayclose').click(function(){ 
+		InventoryV3.ui.find('.lockoverlayclose').click(function(){
 			InventoryV3.ui.find('.lockoverlaymsg').hide();
-			clearTimeout(lockOverlayTimeout); 
+			clearTimeout(lockOverlayTimeout);
 		});
 		InventoryV3.ui.find('.sort').click( function(){ requestFilter();} );
 	};
@@ -623,7 +623,7 @@ define(function(require)
 		return this.equipswitchlist.some(function(existingItem) {
 			return (existingItem.location & location) !== 0;
 		});
-	};	
+	};
 
 
 	/**
@@ -1009,7 +1009,7 @@ define(function(require)
 		}
 
 		let quantity = ' ea';
-		if ((item.type === ItemType.WEAPON || item.type === ItemType.EQUIP) && 
+		if (item.Options && (item.type === ItemType.WEAPON || item.type === ItemType.EQUIP) &&
 			item.Options.filter(Option => Option.index !== 0).length > 0)
 		{
 			quantity = ' Quantity';
@@ -1229,7 +1229,7 @@ define(function(require)
 	    // Retrieve the data-tab attribute using native JavaScript
     	var targetTab = event.target.getAttribute('data-tab');
 		var itemfav = (targetTab === 'fav' ? 0 : 1);
-	    
+
 		// Send Request to client
 		var pkt = new PACKET.CZ.INVENTORY_TAB();
 		pkt.item_index = item.index;
@@ -1246,11 +1246,11 @@ define(function(require)
 	InventoryV3.updatePlaceETCTab = function(itemIndex, newValue)
 	{
 		var item = InventoryV3.getItemByIndex(itemIndex);
-		
+
 		if (!item) {
 			return;
 		}
-    	
+
 		if (newValue) {
 			var favoriteval;
 			switch (item.type) {
@@ -1426,10 +1426,10 @@ define(function(require)
 
 		// Save it
 		InventoryV3.itemlock = _preferences.itemlock;
-	
+
 		// Determine the image path based on the toggled state
 		var lockImg = _preferences.itemlock ? 'inventory/item_drop_lock_on.bmp' : 'inventory/item_drop_lock_off.bmp';
-	
+
 		// Load the image and update the button background
 		Client.loadFile(DB.INTERFACE_PATH + lockImg, function (data) {
 			InventoryV3.ui.find('.item_drop_lock').css('backgroundImage', 'url(' + data + ')');
@@ -1507,7 +1507,7 @@ define(function(require)
 		var existingItemIndex = this.equipswitchlist.findIndex(function(existingItem) {
 			return existingItem.location === item.location;
 		});
-	
+
 		// If an item with the same location exists, unequip it and remove it from the list
 		if (existingItemIndex > -1) {
 			var existingItem = this.equipswitchlist[existingItemIndex];
@@ -1601,7 +1601,7 @@ define(function(require)
 	InventoryV3.onUpdateItem = function OnUpdateItem(/* index, amount */){};
 	InventoryV3.reqMoveItemToCart = function reqMoveItemToCart(/* index, amount */){};
 
-	
+
 	Network.hookPacket( PACKET.ZC.ACK_OPEN_MSGBOX_EXTEND_BODYITEM_SIZE,		onRequestInventoryExpandResult );
 	Network.hookPacket( PACKET.ZC.ACK_EXTEND_BODYITEM_SIZE,					onFinalReqInventoryExpandResult );
 

--- a/src/UI/Components/WinStats/WinStats/WinStats.js
+++ b/src/UI/Components/WinStats/WinStats/WinStats.js
@@ -69,6 +69,11 @@ define(function(require)
 	 */
 	WinStats.stack = [];
 
+	WinStats.append = function append(target) {
+		// ignoring target, to for WinStats not to be attached to equipment window
+		UIComponent.prototype.append.call(this);
+	}
+
 
 	/**
 	 * Execute elements in memory


### PR DESCRIPTION
# [Fix onItemOver when there is no item options](https://github.com/MrAntares/roBrowserLegacy/commit/de21c9a73a0c9cf6e44ceae90f26bb1d71589801)

![Screenshot_20240818_134603](https://github.com/user-attachments/assets/cd5a5adb-2e92-4f91-81d7-39d95180c2f4)

# [Force WinStats to not be attached to equipment](https://github.com/MrAntares/roBrowserLegacy/commit/eb241ad27e26bd356f52a3db10050978dc5a2ea6)
Since commit [0148a510340e3e26085880644eec4a7bde40d934 ](https://github.com/MrAntares/roBrowserLegacy/commit/0148a510340e3e26085880644eec4a7bde40d934) 

WinStats window is attached to equipment panel based on an hardcoded PACKETVER https://github.com/MrAntares/roBrowserLegacy/commit/0148a510340e3e26085880644eec4a7bde40d934#diff-d423d78a36829ef48b8b23658d51dce8b4aaba73c0b692541c36ae52f22d7436R591 instead of leveraging the **UIVersionManager** so there can be a miss matched between packet version and UI selected.
In some cases WinStats can be attached to equipment while it should not

To fix, WinStats now override the `append` method to ignore equipment panel target