### PR TITLE
Demo: Disable unwanted zoom on mobile

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -3,6 +3,7 @@
 	<head>
 		<title>roBrowserLegacy Demo</title>
 		<meta name="mobile-web-app-capable" content="yes" />
+		<meta name="viewport" content="initial-scale=1.0, user-scalable=no">
 		<meta name="theme-color" content="#ff8cb5">
 		<meta charset="UTF-8">
 


### PR DESCRIPTION
In mobile, the user can accidentally zoom in the web page, instead of zooming in the map.

This PR updates the demo.html to prevent that by adding `<meta name="viewport" content="initial-scale=1.0, user-scalable=no">`.

I don't know if we want to also add it when generating the index.html in the tools/builder-web.js ?

This is already the case in niktoutro and in neic0.de robrowser clients.

Tested on Chrome Android 120.