### PR TITLE
bugfix added missing method isInEquipList as fallback compatibility

### DIFF
--- a/src/UI/Components/Equipment/EquipmentV1/EquipmentV1.js
+++ b/src/UI/Components/Equipment/EquipmentV1/EquipmentV1.js
@@ -777,6 +777,13 @@ define(function(require)
 	}
 
 	/**
+	 * EquipmentV3 has the supported function. This is for compatibility with EquipmentV1
+	 */
+	EquipmentV1.isInEquipList = function() {
+		return 0;
+	}
+
+	/**
 	 * Method to define
 	 */
 	EquipmentV1.onUnEquip      = function onUnEquip(/* index */){};

--- a/src/UI/Components/Equipment/EquipmentV2/EquipmentV2.js
+++ b/src/UI/Components/Equipment/EquipmentV2/EquipmentV2.js
@@ -777,6 +777,13 @@ define(function(require)
 	}
 
 	/**
+	 * EquipmentV3 has the supported function. This is for compatibility with EquipmentV2
+	 */
+	EquipmentV2.isInEquipList = function() {
+		return 0;
+	}
+
+	/**
 	 * Method to define
 	 */
 	EquipmentV2.onUnEquip      = function onUnEquip(/* index */){};


### PR DESCRIPTION
bugfix added missing method isInEquipList, that was implemented only in EquipmentV3. This caused mouse right "contextmenu" to open when error occurred. Equipment.getUI().isInEquipList() can return undefined otherwise.
PacketVer 20131223