### PR TITLE
Bugfix issue 473

### DIFF
--- a/src/Core/MemoryManager.js
+++ b/src/Core/MemoryManager.js
@@ -174,19 +174,19 @@ define( ['Core/MemoryItem'], function( MemoryItem )
 				case '.spr':
 					if (file.frames) {
 						for (i = 0, count = file.frames.length; i < count; ++i) {
-							if (file.frames[i].texture && gl.isTexture(file.frames[i].texture)) {
+							if (file.frames[i].texture && gl != null && gl.isTexture(file.frames[i].texture)) {
 								gl.deleteTexture( file.frames[i].texture );
 							}
 						}
 					}
-					if (file.texture && gl.isTexture(file.texture)) {
+					if (file.texture && gl != null && gl.isTexture(file.texture)) {
 						gl.deleteTexture( file.texture );
 					}
 					break;
 
 				// Delete palette
 				case '.pal':
-					if (file.texture && gl.isTexture(file.texture)) {
+					if (file.texture && gl != null && gl.isTexture(file.texture)) {
 						gl.deleteTexture( file.texture );
 					}
 					break;

--- a/src/Renderer/Effects/Damage.js
+++ b/src/Renderer/Effects/Damage.js
@@ -115,7 +115,7 @@ define(function( require )
 			var sprNumbers, sprMsg, sprBlue;
 
 			// Load it properly later using webgl
-			MemoryManager.remove(null, 'data/sprite/\xc0\xcc\xc6\xd1\xc6\xae/msg.spr');
+			MemoryManager.remove(gl, 'data/sprite/\xc0\xcc\xc6\xd1\xc6\xae/msg.spr');
 
 			try {
 				sprNumbers = new Sprite(numbers);


### PR DESCRIPTION
Fix issue: https://github.com/MrAntares/roBrowserLegacy/issues/473

Added null checks to MemoryManager.js where WebGL is null and it's method is being accessed.
Added WebGL reference to the MemoryManager.remove method in Effects/Damage.js, since memory manager it's accessing it's methods.

I have tried numerous times to reproduce the same loading issue with this change and this seems work. I have not noticed other issues.

PackerVer: 20131223