### PR TITLE
Fix MAKINGITEM_LIST packet handling for PACKETVER 20211103

### DIFF
--- a/src/Engine/MapEngine/Item.js
+++ b/src/Engine/MapEngine/Item.js
@@ -557,15 +557,29 @@ define(function( require )
 	 */
 	function onMakeitem_List( pkt )
 	{
-		if (!pkt.idList.length) {
-			return;
+		let itemList;
+		let makeType;
+		if (PACKETVER.value >= 20211103) {
+			if (!pkt.items.length) {
+				return;
+			}
+			itemList = pkt.items.map(item => item.itemId);
+			makeType = pkt.makeItem;
+		} else {
+			if (!pkt.idList.length) {
+				return;
+			}
+			itemList = pkt.idList;
+			makeType = itemList[0]; // First item is mktype for older versions
+			itemList = itemList.slice(1); // Remove mktype from item list
 		}
+
 		MakeItemSelection.append();
-		MakeItemSelection.setCookingList(pkt.idList);
+		MakeItemSelection.setCookingList(itemList, makeType);
 		MakeItemSelection.setTitle(DB.getMessage(425));
 		MakeItemSelection.onIndexSelected = function(index, material, mkType) {
 			if (index >= -1) {
-				var pkt   = new PACKET.CZ.REQ_MAKINGITEM();
+				var pkt = new PACKET.CZ.REQ_MAKINGITEM();
 				pkt.mkType = mkType;
 				pkt.id = index;
 				Network.sendPacket(pkt);

--- a/src/Network/PacketStructure.js
+++ b/src/Network/PacketStructure.js
@@ -8421,14 +8421,27 @@ define(['Utils/BinaryWriter', './PacketVerManager', 'Utils/Struct', 'Core/Config
 
 	// 0x25a
 	PACKET.ZC.MAKINGITEM_LIST = function PACKET_ZC_MAKINGITEM_LIST(fp, end) {
-		let size = (PACKETVER.value >= 20181121) ? 4 : 2;
-		this.idList = (function(size) {
-			var count = (end-fp.tell())/size|0, out = new Array(count);
-			for (var i = 0; i < count; ++i) {
-				out[i] = (size == 4) ? fp.readULong() : fp.readUShort();
-			}
-			return out;
-		})(size);
+		if (PACKETVER.value >= 20211103) {
+			this.makeItem = fp.readShort();
+			let size = (PACKETVER.value >= 20181121) ? 4 : 2;
+			this.items = (function(size) {
+				var count = (end-fp.tell())/size|0, out = new Array(count);
+				for (var i = 0; i < count; ++i) {
+					out[i] = {};
+					out[i].itemId = (size == 4) ? fp.readULong() : fp.readUShort();
+				}
+				return out;
+			})(size);
+		} else {
+			let size = (PACKETVER.value >= 20181121) ? 4 : 2;
+			this.idList = (function(size) {
+				var count = (end-fp.tell())/size|0, out = new Array(count);
+				for (var i = 0; i < count; ++i) {
+					out[i] = (size == 4) ? fp.readULong() : fp.readUShort();
+				}
+				return out;
+			})(size);
+		}
 	};
 	PACKET.ZC.MAKINGITEM_LIST.size = -1;
 

--- a/src/UI/Components/MakeItemSelection/MakeItemSelection.js
+++ b/src/UI/Components/MakeItemSelection/MakeItemSelection.js
@@ -128,7 +128,7 @@
       *
       * @param {Array} list object to display
       */
-      MakeItemSelection.setCookingList = function setCookingList( list )
+      MakeItemSelection.setCookingList = function setCookingList( list, mkType )
       {
          var i, count;
          var item, it, file, name;
@@ -138,9 +138,9 @@
          this.ui.find('.materials').hide();
 		 this.ui.find('.item').remove();
 
-		 this.mkType = list[0]; // add mk type
+		 this.mkType = mkType; // add mk type
 
-         for (i = 1, count = list.length; i < count; ++i) {
+         for (i = 0, count = list.length; i < count; ++i) {
 
              item = list[i];
              it   = DB.getItemInfo( item );


### PR DESCRIPTION
While testing my private server I noticed a weird behavior when using the [Combination Kit](https://www.divine-pride.net/database/item/12849/combination-kit) to craft [Little Unripe Apples](https://www.divine-pride.net/database/item/12846/little-unripe-apple) in order to complete the Novice Poring taming quest.

I noticed on the console the packet was parsing a very large number for the first item on the list, which suggested something was wrong on how the packet was being parsed.

I'm using PACKETVER 20211103 so I'm not sure if this impacts older versions, I tried to implement the fix in a way that things are very well separated in order to keep functionality the same for other packet versions.