### PR TITLE
AIDriver: Accept remote client with or without end slash

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -281,8 +281,11 @@ TODO: improve this flow (important!)
 - check the `.htaccess` file if the ErrorDocument option points to the `index.php` via the correct url. If you don't run roBrowser from the www root and you use remote client then you need to adjust this url (see examples in the file)
 
 In all `AI/*.lua` files :
+- Replace all `dofile` with `require`
 - Replace all `require "AI\\Const"` with `require "AI/Const"`
 - Replace all `require "AI\\Util"` with `require "AI/Util"`
+- Replace all `require("./AI/Const.lua")` with `require("AI/Const")`
+- Replace all `require("./AI/Util.lua")` with `require("AI/Util")`
 
 # 6. Adding Custom Plugins
 - copy your custom plugins into `src\Plugins` 

--- a/src/Core/AIDriver.js
+++ b/src/Core/AIDriver.js
@@ -38,7 +38,7 @@ define(['Renderer/EntityManager', 'Renderer/Renderer', 'Vendors/fengari-web', 'R
         var clientPath = Configs.get('remoteClient');
 
         var code = `
-            package.path = '${clientPath}?.lua'
+            package.path = '${clientPath}/?.lua'
 
             local ai_main, ai_error = loadfile("${clientPath}${config.aiPath}.lua")
 


### PR DESCRIPTION
This will make it work with both remoteClient values, for example: `http://localhost:4000` and `http://localhost:4000/` since HTTP requests consider both `http://localhost:4000/AI/AI.lua` and `http://localhost:4000//AI/AI.lua` to be the same thing.

- This PR also updates the AI/*.lua replace documentation to include replaces to `dofile` and other formats that might be present.