### PR TITLE
add hook PACKET.ZC.HO_PAR_CHANGE to update homunculus

### DIFF
--- a/src/Engine/MapEngine/Homun.js
+++ b/src/Engine/MapEngine/Homun.js
@@ -224,6 +224,44 @@ define(function( require )
 		SkillListMH.homunculus.updateSkill( pkt );
 	}
 
+	/**
+	 * Update homunculus parameters e.g. hp/sp recovery
+	 * 
+	 * @param {object} pkt - PACKET.ZC.HO_PAR_CHANGE
+	 */
+	function onParamsUpdate( pkt )
+	{
+		if (!Session.homunId) {
+			return;
+		}
+
+		var entity = EntityManager.get(Session.homunId);
+
+		if (!entity) {
+			return;
+		}
+
+		switch (pkt.param) {
+			case 1: // EXP = value
+				// TODO update homunculus current EXP value.
+				// How go get expMax, whene is't only in onHomunInformation callback?
+				// HomunInformations.setExp(exp, expMax);
+				break;
+
+			case 5: // HP = value
+				entity.life.hp = pkt.value;
+				entity.life.update();
+				break;
+
+			case 7: // SP = value
+				// HomunInformations.setHP(pkt.value);
+				entity.life.sp = pkt.value;
+				entity.life.update();
+				break;
+
+			default: break;
+		}
+	}
 
 	// function testing( pkt )
 	// {
@@ -245,6 +283,7 @@ define(function( require )
 		Network.hookPacket( PACKET.ZC.FEED_MER,               onFeedResult);
 		Network.hookPacket( PACKET.ZC.MER_SKILLINFO_LIST,     onSkillList);
 		Network.hookPacket( PACKET.ZC.MER_SKILLINFO_UPDATE,   onSkillUpdate);
+		Network.hookPacket( PACKET.ZC.HO_PAR_CHANGE,          onParamsUpdate );
 
 		// Network.hookPacket( PACKET.ZC.MER_INIT,     testing);
 		// Network.hookPacket( PACKET.ZC.MER_PROPERTY,     testing);

--- a/src/Engine/MapEngine/Homun.js
+++ b/src/Engine/MapEngine/Homun.js
@@ -6,43 +6,85 @@
  * This file is part of ROBrowser, (http://www.robrowser.com/).
  *
  * @author IssID
+ *
+ * @typedef {Object} THomunPacket
+ * @prop {number} ATKRange
+ * @prop {number} ITID
+ * @prop {number} Matk
+ * @prop {number} Mdef
+ * @prop {number} SKPoint
+ * @prop {number} aspd
+ * @prop {number} atk
+ * @prop {number} bModified
+ * @prop {number} critical
+ * @prop {number} def
+ * @prop {number} exp
+ * @prop {number} flee
+ * @prop {number} hit
+ * @prop {number} hp
+ * @prop {TLife} life
+ * @prop {number} maxEXP
+ * @prop {number} maxHP
+ * @prop {number} maxSP
+ * @prop {number} nFullness
+ * @prop {number} nLevel
+ * @prop {number} nRelationship
+ * @prop {number} sp
+ * @prop {string} szName Homun name
+ * 
+ * @typedef {Object} TLife
+ * @prop {number} ap
+ * @prop {number} ap_max
+ * @prop {HTMLCanvasElement} canvas
+ * @prop {CanvasRenderingContext2D} ctx 
+ * @prop {boolean} display
+ * @prop {Entity} entity
+ * @prop {number} hp
+ * @prop {number} hp_max
+ * @prop {number} hunger
+ * @prop {number} hunger_max
+ * @prop {number} sp
+ * @prop {number} sp_max
  */
-
-define(function( require )
-{
+define(function (require) {
 	'use strict';
 
 	/**
 	 * Load dependencies
 	 */
-	var DB                   = require('DB/DBManager');
-	var Network              = require('Network/NetworkManager');
-	var PACKET               = require('Network/PacketStructure');
-	var Session              = require('Engine/SessionStorage');
-	var EntityManager        = require('Renderer/EntityManager');
-	var UIManager            = require('UI/UIManager');
-	var ChatBox              = require('UI/Components/ChatBox/ChatBox');
-	var HomunInformations    = require('UI/Components/HomunInformations/HomunInformations');
-	var SkillListMH          = require('UI/Components/SkillListMH/SkillListMH');
-	var Mouse                = require('Controls/MouseEventHandler');
+	var DB = require('DB/DBManager');
+	var Network = require('Network/NetworkManager');
+	var PACKET = require('Network/PacketStructure');
+	var Session = require('Engine/SessionStorage');
+	var EntityManager = require('Renderer/EntityManager');
+	var UIManager = require('UI/UIManager');
+	var ChatBox = require('UI/Components/ChatBox/ChatBox');
+	var HomunInformations = require('UI/Components/HomunInformations/HomunInformations');
+	var SkillListMH = require('UI/Components/SkillListMH/SkillListMH');
+	var Mouse = require('Controls/MouseEventHandler');
+
+	/**
+	 * @type {THomunPacket} cached homunculus information
+	 */
+	var _info = {};
 
 	/**
 	 * Get own homunculus information from server
 	 *
-	 * @param {object} pkt - PACKET.ZC.PROPERTY_HOMUN2
+	 * @param {THomunPacket} pkt - PACKET.ZC.PROPERTY_HOMUN2
 	 */
-	function onHomunInformation( pkt )
-	{
+	function onHomunInformation(pkt) {
+		_info = pkt;
 		var entity = EntityManager.get(Session.homunId);
 		if (Session.homunId) {
 			if (entity) {
-				entity.attack_range        = pkt.ATKRange;
-				entity.life.hp             = pkt.hp;
-				entity.life.hp_max         = pkt.maxHP;
-				entity.life.sp             = pkt.sp;
-				entity.life.sp_max         = pkt.maxSP;
-				entity.life.hunger         = pkt.nFullness;
-				entity.life.hunger_max     = 100;
+				entity.attack_range = pkt.ATKRange;
+				entity.life.hp = pkt.hp;
+				entity.life.hp_max = pkt.maxHP;
+				entity.life.sp = pkt.sp;
+				entity.life.sp_max = pkt.maxSP;
+				entity.life.hunger = pkt.nFullness;
+				entity.life.hunger_max = 100;
 				entity.life.update();
 			}
 		}
@@ -52,10 +94,10 @@ define(function( require )
 		}
 
 		HomunInformations.append();
-		HomunInformations.setInformations( pkt );
+		HomunInformations.setInformations(pkt);
 		HomunInformations.startAI();
 
-		SkillListMH.homunculus.setPoints( pkt.SKPoint );
+		SkillListMH.homunculus.setPoints(pkt.SKPoint);
 	}
 
 
@@ -64,11 +106,10 @@ define(function( require )
 	 *
 	 * @param {object} pkt - PACKET.ZC.FEED_HOMUN
 	 */
-	function onFeedResult( pkt )
-	{
+	function onFeedResult(pkt) {
 		// Fail to feed
 		if (!pkt.cRet) {
-			ChatBox.addText( DB.getMessage(591).replace('%s', DB.getItemInfo(pkt.ITID).identifiedDisplayName), ChatBox.TYPE.ERROR, ChatBox.FILTER.PUBLIC_LOG);
+			ChatBox.addText(DB.getMessage(591).replace('%s', DB.getItemInfo(pkt.ITID).identifiedDisplayName), ChatBox.TYPE.ERROR, ChatBox.FILTER.PUBLIC_LOG);
 			return;
 		}
 
@@ -81,8 +122,7 @@ define(function( require )
 	 *
 	 * @param {object} pkt - PACKET.ZC.CHANGESTATE_HOMUN
 	 */
-	function onHomunInformationUpdate( pkt )
-	{
+	function onHomunInformationUpdate(pkt) {
 		var entity = EntityManager.get(pkt.GID);
 
 		if (!entity) {
@@ -100,7 +140,7 @@ define(function( require )
 
 			case 2:
 				HomunInformations.setHunger(pkt.data);
-				entity.life.hunger    = pkt.data;
+				entity.life.hunger = pkt.data;
 				entity.life.hunger_max = 100;
 				entity.life.update();
 				break;
@@ -111,22 +151,20 @@ define(function( require )
 	/**
 	 * Client request to feed QHomun.
 	 */
-	HomunInformations.reqHomunFeed = function reqHomunFeed()
-	{
+	HomunInformations.reqHomunFeed = function reqHomunFeed() {
 		// Are you sure you want to feed your homunculus ?
-		UIManager.showPromptBox(DB.getMessage(601), 'ok', 'cancel', function(){
-			var pkt  = new PACKET.CZ.COMMAND_MER();
+		UIManager.showPromptBox(DB.getMessage(601), 'ok', 'cancel', function () {
+			var pkt = new PACKET.CZ.COMMAND_MER();
 			pkt.type = 0x22f;
 			pkt.command = 1;
 			Network.sendPacket(pkt);
 		});
 	};
 
-	HomunInformations.reqDeleteHomun = function reqDeleteHomun()
-	{
+	HomunInformations.reqDeleteHomun = function reqDeleteHomun() {
 		// Are you sure that you want to delete?
-		UIManager.showPromptBox(DB.getMessage(356), 'ok', 'cancel', function(){
-			var pkt  = new PACKET.CZ.COMMAND_MER();
+		UIManager.showPromptBox(DB.getMessage(356), 'ok', 'cancel', function () {
+			var pkt = new PACKET.CZ.COMMAND_MER();
 			pkt.type = 0x22f;
 			pkt.command = 2;
 			Network.sendPacket(pkt);
@@ -142,9 +180,8 @@ define(function( require )
 	 *     1 = feed
 	 *     2 = delete
 	 */
-	HomunInformations.reqHomunAction = function reqHomunAction()
-	{
-		var pkt  = new PACKET.CZ.COMMAND_MER(cmd);
+	HomunInformations.reqHomunAction = function reqHomunAction() {
+		var pkt = new PACKET.CZ.COMMAND_MER(cmd);
 		pkt.type = 0;
 		pkt.command = cmd;
 		Network.sendPacket(pkt);
@@ -154,9 +191,8 @@ define(function( require )
 	/**
 	 * @param gid
 	 */
-	HomunInformations.reqMoveToOwner = function reqMoveToOwner(gid)
-	{
-		var pkt  = new PACKET.CZ.REQUEST_MOVETOOWNER();
+	HomunInformations.reqMoveToOwner = function reqMoveToOwner(gid) {
+		var pkt = new PACKET.CZ.REQUEST_MOVETOOWNER();
 		pkt.GID = gid;
 		Network.sendPacket(pkt);
 	};
@@ -166,9 +202,8 @@ define(function( require )
 	 * @param GID
 	 * @param targetGID
 	 */
-	HomunInformations.reqAttack = function reqAttack(GID, targetGID)
-	{
-		var pkt  = new PACKET.CZ.REQUEST_ACTNPC();
+	HomunInformations.reqAttack = function reqAttack(GID, targetGID) {
+		var pkt = new PACKET.CZ.REQUEST_ACTNPC();
 		pkt.GID = GID;
 		pkt.targetGID = targetGID;
 		pkt.action = 0;
@@ -179,9 +214,8 @@ define(function( require )
 	/**
 	 * @param GID
 	 */
-	HomunInformations.reqMoveTo = function reqMoveTo(GID)
-	{
-		var pkt  = new PACKET.CZ.REQUEST_MOVENPC();
+	HomunInformations.reqMoveTo = function reqMoveTo(GID) {
+		var pkt = new PACKET.CZ.REQUEST_MOVENPC();
 		pkt.GID = GID;
 		pkt.dest[0] = Mouse.world.x;
 		pkt.dest[1] = Mouse.world.y;
@@ -194,10 +228,9 @@ define(function( require )
 	 *
 	 * @param {string} new homunculus name
 	 */
-	HomunInformations.reqNameEdit   = function reqNameEdit(name)
-	{
+	HomunInformations.reqNameEdit = function reqNameEdit(name) {
 		//msg 2904(2903)
-		var pkt    = new PACKET.CZ.RENAME_MER();
+		var pkt = new PACKET.CZ.RENAME_MER();
 		pkt.name = name;
 		Network.sendPacket(pkt);
 	};
@@ -208,9 +241,8 @@ define(function( require )
 	 *
 	 * @param {object} pkt - PACKET.ZC.MER_SKILLINFO_LIST
 	 */
-	function onSkillList( pkt )
-	{
-		SkillListMH.homunculus.setSkills( pkt.skillList );
+	function onSkillList(pkt) {
+		SkillListMH.homunculus.setSkills(pkt.skillList);
 	}
 
 
@@ -219,9 +251,8 @@ define(function( require )
 	 *
 	 * @param {object} pkt - PACKET.ZC.SKILLINFO_UPDATE
 	 */
-	function onSkillUpdate( pkt )
-	{
-		SkillListMH.homunculus.updateSkill( pkt );
+	function onSkillUpdate(pkt) {
+		SkillListMH.homunculus.updateSkill(pkt);
 	}
 
 	/**
@@ -229,8 +260,7 @@ define(function( require )
 	 * 
 	 * @param {object} pkt - PACKET.ZC.HO_PAR_CHANGE
 	 */
-	function onParamsUpdate( pkt )
-	{
+	function onParamsUpdate(pkt) {
 		if (!Session.homunId) {
 			return;
 		}
@@ -241,26 +271,27 @@ define(function( require )
 			return;
 		}
 
+		// sync all stats from server to client
 		switch (pkt.param) {
 			case 1: // EXP = value
-				// TODO update homunculus current EXP value.
-				// How go get expMax, whene is't only in onHomunInformation callback?
-				// HomunInformations.setExp(exp, expMax);
+				_info.exp = pkt.value;
 				break;
 
 			case 5: // HP = value
-				entity.life.hp = pkt.value;
+				_info.hp = _info.life.hp = entity.life.hp = pkt.value;
 				entity.life.update();
 				break;
 
 			case 7: // SP = value
-				// HomunInformations.setHP(pkt.value);
-				entity.life.sp = pkt.value;
+				_info.sp = _info.life.sp = entity.life.sp = pkt.value;
 				entity.life.update();
 				break;
 
 			default: break;
 		}
+
+		// UI update
+		HomunInformations.setInformations(_info);
 	}
 
 	// function testing( pkt )
@@ -272,22 +303,21 @@ define(function( require )
 	/**
 	 * Initialize
 	 */
-	return function NPCEngine()
-	{
-		Network.hookPacket( PACKET.ZC.PROPERTY_HOMUN,         onHomunInformation);
-		Network.hookPacket( PACKET.ZC.PROPERTY_HOMUN2,        onHomunInformation);
-		Network.hookPacket( PACKET.ZC.PROPERTY_HOMUN3,        onHomunInformation);
-		Network.hookPacket( PACKET.ZC.PROPERTY_HOMUN4,        onHomunInformation);
-		Network.hookPacket( PACKET.ZC.PROPERTY_HOMUN5,        onHomunInformation);
-		Network.hookPacket( PACKET.ZC.CHANGESTATE_MER,        onHomunInformationUpdate);
-		Network.hookPacket( PACKET.ZC.FEED_MER,               onFeedResult);
-		Network.hookPacket( PACKET.ZC.MER_SKILLINFO_LIST,     onSkillList);
-		Network.hookPacket( PACKET.ZC.MER_SKILLINFO_UPDATE,   onSkillUpdate);
-		Network.hookPacket( PACKET.ZC.HO_PAR_CHANGE,          onParamsUpdate );
+	return function NPCEngine() {
+		Network.hookPacket(PACKET.ZC.PROPERTY_HOMUN, onHomunInformation);
+		Network.hookPacket(PACKET.ZC.PROPERTY_HOMUN2, onHomunInformation);
+		Network.hookPacket(PACKET.ZC.PROPERTY_HOMUN3, onHomunInformation);
+		Network.hookPacket(PACKET.ZC.PROPERTY_HOMUN4, onHomunInformation);
+		Network.hookPacket(PACKET.ZC.PROPERTY_HOMUN5, onHomunInformation);
+		Network.hookPacket(PACKET.ZC.CHANGESTATE_MER, onHomunInformationUpdate);
+		Network.hookPacket(PACKET.ZC.FEED_MER, onFeedResult);
+		Network.hookPacket(PACKET.ZC.MER_SKILLINFO_LIST, onSkillList);
+		Network.hookPacket(PACKET.ZC.MER_SKILLINFO_UPDATE, onSkillUpdate);
+		Network.hookPacket(PACKET.ZC.HO_PAR_CHANGE, onParamsUpdate);
 
-		// Network.hookPacket( PACKET.ZC.MER_INIT,     testing);
-		// Network.hookPacket( PACKET.ZC.MER_PROPERTY,     testing);
-		// Network.hookPacket( PACKET.ZC.MER_PAR_CHANGE,     testing);
-		// Network.hookPacket( PACKET.ZC.HOMUN_ACT,            onHomunAction);
+		// Network.hookPacket( PACKET.ZC.MER_INIT, testing);
+		// Network.hookPacket( PACKET.ZC.MER_PROPERTY, testing);
+		// Network.hookPacket( PACKET.ZC.MER_PAR_CHANGE, testing);
+		// Network.hookPacket( PACKET.ZC.HOMUN_ACT, onHomunAction);
 	};
 });


### PR DESCRIPTION
Add the hook HO_PAR_CHANGE to update homunculus state changes received from the server.
This updates the homunculus values e.g. HP and SP from normal recovery or healing spells, like Aid Potion.
This will also fix an issue, where the homunculus HP/SP bar did not update correctly.

![image](https://github.com/user-attachments/assets/f21af3d2-0475-4feb-85ee-8396d9a19be3)

Tested with packetVer: 20131223

TODO other param values for required updates.
TODO test with other packetVer and see if nothing else broke.