### PR TITLE
fix update cached info in onHomunInformationUpdate method

### DIFF
--- a/src/Engine/MapEngine/Homun.js
+++ b/src/Engine/MapEngine/Homun.js
@@ -135,12 +135,13 @@ define(function (require) {
 				break;
 
 			case 1:
+				_info.nRelationship = pkt.data;
 				HomunInformations.setIntimacy(pkt.data);
 				break;
 
 			case 2:
 				HomunInformations.setHunger(pkt.data);
-				entity.life.hunger = pkt.data;
+				_info.nFullness = entity.life.hunger = pkt.data;
 				entity.life.hunger_max = 100;
 				entity.life.update();
 				break;


### PR DESCRIPTION
Also update the _info cache in onHomunInformationUpdate when homun hunger/intimacy state changes, so the next onParamsUpdate UI update will also show updated state from the other packet hook method.