### PR TITLE
Feature enableHomunAutoFeed for older clients

### DIFF
--- a/api.js
+++ b/api.js
@@ -247,6 +247,11 @@
 		 * @var {boolean} Enable Check Attendance UI
 		 */
 		enableCheckAttendance: false,
+
+		/**
+		 * @var {boolean} Enable Homunculus Auto Feed for older PACKETVER than 20170920
+		 */
+		enableHomunAutoFeed: false,
 		
 		/**
 		 * @var {boolean} User interface version selection mode (PacketVer | PreRenewal | Renewal)

--- a/doc/README.md
+++ b/doc/README.md
@@ -346,6 +346,7 @@ function initialize() {
           enableRefineUI:  false,  // Enable Renewal Refine UI? (Requires client data (GRF) newer than 2016.10.12) (Should also enable in server side)
           enableDmgSuffix: false,  // Enable Damage Suffix (>1M = K, >100M = M) - Requires client data (GRF) newer or equals to 2019.05.08
           enableCheckAttendance: false, // Enable Check Attendance? (Requires PACKETVER 20180307 above)
+          enableHomunAutoFeed: false, // Enable Homunculus Auto Feed for older PACKETVER than 20170920
           loadLua:         false,  // Enable this option to load LUA tables (currently only item table) from client/System/...
           
           //clientHash:    '113e195e6c051bb1cfb12a644bb084c5', // Set fixed client hash value here (less secure, for development only)

--- a/src/Core/AIDriver.js
+++ b/src/Core/AIDriver.js
@@ -186,7 +186,7 @@ define(['Renderer/EntityManager', 'Renderer/Renderer', 'Vendors/fengari-web', 'R
     }
 
     window.TraceAI = function TraceAI(str) {
-        console.warn('TraceAI', str)
+        //console.warn('TraceAI', str)
     }
 
     window.GetTick = function GetTick() {

--- a/src/Core/AIDriver.js
+++ b/src/Core/AIDriver.js
@@ -186,7 +186,9 @@ define(['Renderer/EntityManager', 'Renderer/Renderer', 'Vendors/fengari-web', 'R
     }
 
     window.TraceAI = function TraceAI(str) {
-        //console.warn('TraceAI', str)
+        if (Configs.get('debugAI', false)) {
+            console.warn('TraceAI', str)
+        }
     }
 
     window.GetTick = function GetTick() {
@@ -278,7 +280,7 @@ define(['Renderer/EntityManager', 'Renderer/Renderer', 'Vendors/fengari-web', 'R
 
             case 4: // V_ATTACKRANGE ok
                 // Returns the attack range (Not implemented yet; temporarily set as 1 cell)
-                if(entity !== null){
+                if (entity !== null) {
                     return entity.attack_range || 1;
                 }
                 return 1;
@@ -291,7 +293,7 @@ define(['Renderer/EntityManager', 'Renderer/Renderer', 'Vendors/fengari-web', 'R
 
             case 6: // V_SKILLATTACKRANGE
                 // Returns the skill attack range (Not implemented yet)
-                if(entity !== null){
+                if (entity !== null) {
                     return entity.attack_range || 1;
                 }
                 return 1;
@@ -328,7 +330,7 @@ define(['Renderer/EntityManager', 'Renderer/Renderer', 'Vendors/fengari-web', 'R
 
             case 14: // V_SKILLATTACKRANGE_LEVEL
                 // Returns the skill attack range for the skill level (Not implemented yet)
-                if(entity !== null){
+                if (entity !== null) {
                     return entity.attack_range || 1;
                 }
                 return 1;

--- a/src/Engine/MapEngine/Homun.js
+++ b/src/Engine/MapEngine/Homun.js
@@ -162,6 +162,13 @@ define(function (require) {
 		});
 	};
 
+	HomunInformations.sendHomunFeed = function sendHomunFeed() {
+		var pkt = new PACKET.CZ.COMMAND_MER();
+		pkt.type = 0x22f;
+		pkt.command = 1;
+		Network.sendPacket(pkt);
+	};
+
 	HomunInformations.reqDeleteHomun = function reqDeleteHomun() {
 		// Are you sure that you want to delete?
 		UIManager.showPromptBox(DB.getMessage(356), 'ok', 'cancel', function () {


### PR DESCRIPTION
Feature to enable Homunculus Auto Feed for older PACKETVER than 20170920.
When PACKETVER is above 20170920, it will use the existing feature instead.

Default: Not enabled.

Config: enableHomunAutoFeed = boolean

Tested with PACKETVER 20131223

![image](https://github.com/user-attachments/assets/be4f9863-5c02-4853-bdd2-4bd247882c76)

Also, I disabled the TraceAI console log spam and set it to use the debugAI config param:
`window.TraceAI = function TraceAI(str) {
    if (Configs.get('debugAI', false)) {
        console.warn('TraceAI', str)
    }
}`