### PR TITLE
- Updating container setup to focus only on node environment;

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,64 @@
-FROM node:23.10.0-alpine
+FROM node:20.10.0 AS dev
 
 LABEL org.opencontainers.image.description="Creates a environment to host the NodeJS and NPM environment."
 
 USER root
 
-RUN apk add --update alpine-sdk && \
+RUN apt update -y -q && apt install build-essential -y -q && \
   mkdir -p /app && \
   npm install wsproxy -g
 
 WORKDIR /app
 
-USER 1000
-
 EXPOSE 8000
 
-ENTRYPOINT ["/bin/bash"]
+ENTRYPOINT ["/bin/bash", "-l", "-c", "sleep", "360h"]
+
+FROM php:8.3-apache AS dist-server
+
+LABEL org.opencontainers.image.description="Creates a environment to serve the dist files using Apache"
+
+WORKDIR /var/www/html
+
+USER root
+
+RUN apt-get update -y -qq && \
+  a2enmod rewrite && \
+  a2enmod headers
+
+# For some IDEs this line is treated as wrongly configured, but this is a bug !
+# This heredoc format is supported by Docker.
+RUN cat <<EOF > /etc/apache2/sites-enabled/dist.conf
+<VirtualHost *:8080>
+    ServerAdmin webmaster@robrowser.legacy
+    DocumentRoot /var/www/html
+
+    # Allow directory access
+    <Directory /var/www/html>
+        Options Indexes FollowSymLinks
+        AllowOverride None
+        Require all granted
+    </Directory>
+
+    <FilesMatch "\.(html|js|css|png|jpg|gif|svg|webp|ico|woff|woff2|ttf|otf|eot|mp4|webm|ogg|mp3|json)$">
+        Require all granted
+    </FilesMatch>
+
+    # Set default file
+    DirectoryIndex index.html
+
+    # MIME types for JavaScript and other files
+    AddType application/javascript .js
+
+    # Enable CORS if needed
+    <IfModule mod_headers.c>
+        Header set Access-Control-Allow-Origin "*"
+    </IfModule>
+</VirtualHost>
+EOF
+
+RUN echo "Listen 8080" >> /etc/apache2/ports.conf
+
+EXPOSE 8080
+
+USER www-data

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,17 @@
-FROM node:20.10.0 as client
+FROM node:23.10.0-alpine
+
+LABEL org.opencontainers.image.description="Creates a environment to host the NodeJS and NPM environment."
 
 USER root
 
-RUN apt update -y -qq && apt install build-essential -y -qq && mkdir -p /app
-
-RUN npm install wsproxy -g
+RUN apk add --update alpine-sdk && \
+  mkdir -p /app && \
+  npm install wsproxy -g
 
 WORKDIR /app
 
+USER 1000
+
 EXPOSE 8000
 
-ENTRYPOINT "/bin/bash"
-
-FROM php:8.1-apache as server
-
-LABEL org.opencontainers.image.description="Creates a environment to serve PHP files for the Remote Client API."
-
-WORKDIR /var/www/html
-
-USER root
-
-RUN apt-get update -y -qq
-
-RUN a2enmod rewrite && \
-    a2enmod headers
-
-EXPOSE 80
-
-USER www-data
+ENTRYPOINT ["/bin/bash"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,6 +3,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      target: dev
     ports:
       - "8000:8000"
       # You can use to serve wsproxy.
@@ -10,5 +11,15 @@ services:
     volumes:
       - ./:/app
     tty: true
-    command: ['sleep', '360h']
+
+  serve-dist:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: dist-server
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./dist/Web:/var/www/html
+
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,32 +1,14 @@
-version: '3.8'
-
 services:
   ro-browser:
     build:
       context: .
       dockerfile: Dockerfile
-      target: client
     ports:
       - "8000:8000"
+      # You can use to serve wsproxy.
+      #- "5999:5999"
     volumes:
       - ./:/app
     tty: true
     command: ['sleep', '360h']
-    networks:
-        - "ro-browser"
-
-  remote-client-api:
-    build:
-      context: .
-      dockerfile: Dockerfile
-      target: server
-    volumes:
-      - ./client:/var/www/html
-    ports:
-        - "80:80"
-    networks:
-        - "ro-browser"
-
-networks:
-    ro-browser:
 


### PR DESCRIPTION
 - Updating container setup to focus only on node environment;
 - Now the container setup serves the dist/Web directory (if files are present) on port 8080;
 - Now the dev container (with NodeJS), sleeps by default when executing it;
