### PR TITLE
Only show slot if item has

### DIFF
--- a/src/DB/DBManager.js
+++ b/src/DB/DBManager.js
@@ -2811,7 +2811,7 @@ define(function (require) {
 			str += postfix;
 		}
 
-		if (it.slotCount && showslots && showItemSlots) {
+		if (it.slotCount > 0 && showslots && showItemSlots) {
 			str += ' [' + it.slotCount + ']';
 		}
 


### PR DESCRIPTION
The current item always shows the slot count event 0 slot.
<img src="https://github.com/user-attachments/assets/96d18c05-f4e3-4ee8-9646-41bb15a889be" width="250">

Update to only show slot count if the item has that
<img src="https://github.com/user-attachments/assets/9dbeb0ef-dc43-4ccc-9279-9e9a6d6a3e07" width="250">
