### PR TITLE
Convert BGRA ground tile colors to RGBA and skip canvas manipulation for ground tiles

### DIFF
--- a/src/Loaders/Ground.js
+++ b/src/Loaders/Ground.js
@@ -299,7 +299,9 @@ define( ['Utils/BinaryReader', 'Utils/gl-matrix'], function( BinaryReader, glMat
 
 				// Check tile up
 				if (cell.tile_up > -1) {
-					data.set(tiles[cell.tile_up].color, (x + y * width) * 4);
+					// Colors are stored in BGRA format, convert to RGBA for WebGL
+					const [b, g, r, a] = tiles[cell.tile_up].color;
+					data.set([r, g, b, a], (x + y * width) * 4);
 				}
 			}
 		}

--- a/src/Utils/WebGL.js
+++ b/src/Utils/WebGL.js
@@ -198,6 +198,16 @@ define( ['Utils/Texture', 'Core/Configs'], function( Texture, Configs )
 		});
 	}
 
+	/**
+	 * Check if the context is a WebGL2 context
+	 *
+	 * @param {object} gl context
+	 * @return {boolean}
+	 */
+	function isWebGL2(gl)
+	{
+		return gl && window['WebGL2RenderingContext'] !== undefined && gl instanceof WebGL2RenderingContext;
+	}
 
 	/**
 	 * Export
@@ -206,6 +216,7 @@ define( ['Utils/Texture', 'Core/Configs'], function( Texture, Configs )
 		getContext:          getContext,
 		createShaderProgram: createShaderProgram,
 		toPowerOfTwo:        toPowerOfTwo,
-		texture:             texture
+		texture:             texture,
+		isWebGL2:		 	 isWebGL2,
 	};
 });


### PR DESCRIPTION
This PR does two things:
- It fixes the way ground tile colors were being read, from RGBA to BGRA (and then converted to RGBA), which caused weird patches of bluish color in some maps (see attached picture).
- If webgl2 is supported, skip the whole canvas/powerOf2 logic and use the data in the uint8array directly

<img width="1252" height="496" alt="image" src="https://github.com/user-attachments/assets/fbeff1bb-960d-42ef-b260-049a1216730c" />
