### PR TITLE
Fixes light direction and ground shading in maps

### DIFF
--- a/src/Renderer/Map/Ground.js
+++ b/src/Renderer/Map/Ground.js
@@ -102,7 +102,7 @@ function(      WebGL,         Texture,   Preferences,            Configs )
 			vec4 lDirection  = uModelViewMat * vec4( uLightDirection, 0.0);
 			vec3 dirVector   = normalize(lDirection.xyz);
 			float dotProduct = dot( uNormalMat * aVertexNormal, dirVector );
-			vLightWeighting  = max( dotProduct, 0.1 );
+			vLightWeighting  = max( dotProduct, 1.0 );
 		}
 	`;
 
@@ -144,7 +144,7 @@ function(      WebGL,         Texture,   Preferences,            Configs )
 
 			if (vTileColorCoord.st != vec2(0.0,0.0)) {
 				texture    *= texture2D( uTileColor, vTileColorCoord.st);
-				lightWeight = vLightWeighting;
+				//lightWeight = vLightWeighting; // Note: This is not used in the original client
 			}
 
 			vec3 Ambient    = uLightAmbient * uLightOpacity;

--- a/src/Renderer/Map/Models.js
+++ b/src/Renderer/Map/Models.js
@@ -62,7 +62,7 @@ define( ['Utils/WebGL'], function( WebGL )
 			vec4 lDirection  = uModelViewMat * vec4( uLightDirection, 0.0);
 			vec3 dirVector   = normalize(lDirection.xyz);
 			float dotProduct = dot( uNormalMat * aVertexNormal, dirVector );
-			vLightWeighting  = max( dotProduct, 0.5 );
+			vLightWeighting  = max( dotProduct, 0.15 );
 		}
 	`;
 
@@ -97,7 +97,7 @@ define( ['Utils/WebGL'], function( WebGL )
 			}
 
 			vec3 Ambient    = uLightAmbient * uLightOpacity;
-			vec3 Diffuse    = uLightDiffuse * vLightWeighting;
+			vec3 Diffuse    = uLightDiffuse * clamp(vLightWeighting * 1.5, 0.0, 1.0);
 			vec4 LightColor = vec4( Ambient + Diffuse, 1.0);
 
 			gl_FragColor    = texture * clamp(LightColor, 0.0, 1.0);

--- a/src/Renderer/MapRenderer.js
+++ b/src/Renderer/MapRenderer.js
@@ -40,8 +40,10 @@ define(function( require )
 	var Sky            = require('Renderer/Effects/Sky');
 	var Damage         = require('Renderer/Effects/Damage');
 	var MapPreferences = require('Preferences/Map');
-	const PACKETVER   = require('Network/PacketVerManager');
-
+	const glMatrix     = require('Utils/gl-matrix');
+	const PACKETVER    = require('Network/PacketVerManager');
+	
+	const mat4         = glMatrix.mat4;
 
 	/**
 	 * Renderer Namespace
@@ -217,9 +219,16 @@ define(function( require )
 		var longitude        = this.light.longitude * Math.PI / 180;
 		var latitude         = this.light.latitude  * Math.PI / 180;
 
-		this.light.direction[0] = -Math.cos(longitude) * Math.sin(latitude);
-		this.light.direction[1] = -Math.cos(latitude);
-		this.light.direction[2] = -Math.sin(longitude) * Math.sin(latitude);
+		const dirMat4 = mat4.create();
+		// Original client first rotates around X then Y, but then multiplies matrixes in reverse order
+		// Which means we have to rotate Y first then X
+		mat4.rotateY(dirMat4, dirMat4, longitude);
+		mat4.rotateX(dirMat4, dirMat4, latitude);
+		const dirVec = mat4.multiplyVec3([0, 1, 0], dirMat4);
+
+		this.light.direction[0] = -dirVec[0];
+		this.light.direction[1] = -dirVec[1];
+		this.light.direction[2] = -dirVec[2];
 	}
 
 

--- a/src/Utils/gl-matrix.js
+++ b/src/Utils/gl-matrix.js
@@ -305,6 +305,26 @@ define( ['Vendors/gl-matrix'], function( glMatrix )
 
 
 	/**
+	 * Multiplies a vec3 by a mat4
+	 * The last component of the vec3 is assumed to be 1.0
+	 * 
+	 * @param {vec3} vec 3 position vector
+	 * @param {mat4} mat 4x4 matrix
+	 * 
+	 * @returns {vec3} resulting vector
+	 */
+	glMatrix.mat4.multiplyVec3 = function(vec, mat) {
+		const out = new Float32Array(3);
+		const x = vec[0], y = vec[1], z = vec[2];
+
+		out[0] = mat[0] * x + mat[4] * y + mat[8] * z + mat[12];
+		out[1] = mat[1] * x + mat[5] * y + mat[9] * z + mat[13];
+		out[2] = mat[2] * x + mat[6] * y + mat[10] * z + mat[14];
+		return out;
+	}
+
+
+	/**
 	 * Export
 	 */
 	return glMatrix;


### PR DESCRIPTION
Fixes calculation of light direction, which caused a disparity between shaded models and shadowmaps.
Forced high light intensity to fix maps rendering too dark and models not displaying any shade.

Attached example picture of the new lightning, shades and ground fixes.
<img width="2103" height="1056" alt="image" src="https://github.com/user-attachments/assets/e241e65f-00e0-4b3e-8866-40f9d8a3cdca" />
