### PR TITLE
fix npc script clear; in the NpcBox component

### DIFF
--- a/src/UI/Components/NpcBox/NpcBox.js
+++ b/src/UI/Components/NpcBox/NpcBox.js
@@ -32,7 +32,6 @@ define(function(require)
 	var NpcBox = new UIComponent( 'NpcBox', htmlText, cssText );
 
 
-
 	/**
 	 * @var {boolean} does the box need to be clean up?
 	 */
@@ -42,7 +41,7 @@ define(function(require)
 	/**
 	 * @var {integer} NPC GID
 	 */
-	var _ownerID = 0;
+	NpcBox.ownerID = 0;
 
 
 	/**
@@ -171,7 +170,7 @@ define(function(require)
 		this.ui.find('.content').text('');
 
 		_needCleanUp = false;
-		_ownerID     = 0;
+		NpcBox.ownerID = 0;
 
 		// Cutin system
 		var cutin = document.getElementById('cutin');
@@ -224,7 +223,7 @@ define(function(require)
 	NpcBox.setText = function SetText( text, gid )
 	{
 		var content = this.ui.find('.content');
-		_ownerID    = gid;
+		NpcBox.ownerID = gid;
 
 		if (_needCleanUp) {
 			_needCleanUp = false;
@@ -242,7 +241,7 @@ define(function(require)
 	 */
 	NpcBox.addNext = function addNext( gid )
 	{
-		_ownerID = gid;
+		NpcBox.ownerID = gid;
 		this.ui.find('.next').show();
 	};
 
@@ -254,7 +253,7 @@ define(function(require)
 	 */
 	NpcBox.addClose = function addClose( gid )
 	{
-		_ownerID = gid;
+		NpcBox.ownerID = gid;
 		this.ui.find('.close').show();
 	};
 
@@ -266,7 +265,7 @@ define(function(require)
 	{
 		_needCleanUp = true;
 		this.ui.find('.next').hide();
-		this.onNextPressed( _ownerID );
+		this.onNextPressed( NpcBox.ownerID );
 	};
 
 
@@ -277,7 +276,7 @@ define(function(require)
 	{
 		_needCleanUp = true;
 		this.ui.find('.close').hide();
-		this.onClosePressed( _ownerID );
+		this.onClosePressed( NpcBox.ownerID );
 	};
 
 


### PR DESCRIPTION
Fixes the npc script command "clear;" (rathena) in the NpcBox component, with the use of public ownerID prop, for NPC.onCloseScript hook to have access to it. Problem was that the original _ownerID was private.
Now the NPC dialog is properly cleared when the "clear;" NPC command is send to the client.
Tested with packetvet 20131223 and rathena server.