### PR TITLE
Fixed SignBoard Leak

### DIFF
--- a/src/Engine/MapEngine/Entity.js
+++ b/src/Engine/MapEngine/Entity.js
@@ -132,7 +132,7 @@ define(function (require) {
 					EffectManager.spam(EF_Init_Par);
 				}
 			}
-			if (entity.objecttype === Entity.TYPE_NPC || Entity.TYPE_WARP) {
+			if (entity.objecttype === Entity.TYPE_NPC || entity.objecttype === Entity.TYPE_NPC2 || entity.objecttype === Entity.TYPE_WARP) {
 				const mapName = getModule("Renderer/MapRenderer").currentMap.replace('.gat', '').toLowerCase();
 				let signboardData = DB.findSignboard(mapName, entity.position[0], entity.position[1], 1);
 				if (signboardData) {


### PR DESCRIPTION
This small edit fixes the SignBoard leaking to entities spawned nearby SignBoards.
Just as a note, the old condition always returned true, regardless of the situation.