### PR TITLE
Improved FPS cap and FPS counter logic

### DIFF
--- a/src/UI/Components/FPS/FPS.css
+++ b/src/UI/Components/FPS/FPS.css
@@ -1,3 +1,15 @@
 #FPS { position:absolute; top:100px; left:100px; font-size:12px; background:white; border-radius:2px; }
 #FPS .titlebar { width:100%; height:17px; background-color:white; background-repeat:repeat-x; border-radius:3px 3px 0px 0px; }
 #FPS .titlebar .left { margin-left:3px; float:left; }
+
+.fps-good {
+	color: #006400;
+}
+
+.fps-warn {
+	color: #ff9800;
+}
+
+.fps-bad {
+	color: #f44336;
+}


### PR DESCRIPTION
renderer: switch render loop to requestAnimationFrame with internal frame limiting

- Replace setInterval-based render loop with requestAnimationFrame.
- Implement frameLimit throttling inside the render loop to preserve behavior.
- Improve frame pacing and reduce jitter by syncing with browser compositor.
- Add drift compensation to keep frame timing stable over time.
- Cancel previous timers safely before starting the render loop.
- Add defensive guards so faulty render callbacks don’t break rendering.

fps: make FPS counter passive and avoid costly DOM updates

- Update FPS text only when value actually changes.
- Replace inline style changes with CSS classes (fps-good / fps-warn / fps-bad).
- Reduce unnecessary reflows and repaints caused by the FPS UI.
- Keep FPS logic as a passive render observer with no impact on rendering.

Overall, this reduces micro-stutter and improves frame-time stability,
especially on low-end and older hardware.
