### PR TITLE
add behavior to FileSystem.js be case-insensitive on getters

### DIFF
--- a/src/Core/FileSystem.js
+++ b/src/Core/FileSystem.js
@@ -369,7 +369,8 @@ define(function()
 			var i, count = _files.length;
 
 			for (i = 0; i < count; ++i) {
-				if (_files[i]._path === filename) {
+				// Not case sensitive...
+				if (_files[i]._path.toLowerCase() === filename.toLowerCase()) {
 					return _files[i];
 				}
 			}
@@ -410,7 +411,8 @@ define(function()
 			var i, count = _files.length;
 
 			for (i = 0; i < count; ++i) {
-				if (_files[i]._path === filename) {
+				// Not case sensitive...
+				if (_files[i]._path.toLowerCase() === filename.toLowerCase()) {
 					onload(_files[i]);
 					return;
 				}


### PR DESCRIPTION
add behavior to FileSystem.js be case-insensitive on getting files, it actually only search for it as case-insensitive, but fails here