### PR TITLE
fixes cutout in 3d rsm Models.js

### DIFF
--- a/src/Renderer/Map/Models.js
+++ b/src/Renderer/Map/Models.js
@@ -92,7 +92,7 @@ define( ['Utils/WebGL', 'Preferences/Map'], function( WebGL, Preferences )
 		void main(void) {
 			vec4 textureSample  = texture( uDiffuse,  vTextureCoord.st );
 
-			if (textureSample.a == 0.0) {
+			if (textureSample.a < 0.9) {
 				discard;
 			}
 
@@ -177,6 +177,13 @@ define( ['Utils/WebGL', 'Preferences/Map'], function( WebGL, Preferences )
 
 		gl.useProgram( _program );
 
+		// FIX 3D cutout
+		var wasBlendEnabled = gl.isEnabled(gl.BLEND);
+		var depthMask = gl.getParameter(gl.DEPTH_WRITEMASK);
+		gl.enable(gl.DEPTH_TEST);
+		gl.depthMask(true);
+		gl.disable(gl.BLEND);
+
 		// Bind matrix
 		gl.uniformMatrix4fv( uniform.uModelViewMat,  false, modelView );
 		gl.uniformMatrix4fv( uniform.uProjectionMat, false, projection );
@@ -227,6 +234,14 @@ define( ['Utils/WebGL', 'Preferences/Map'], function( WebGL, Preferences )
 		gl.disableVertexAttribArray( attribute.aVertexNormal );
 		gl.disableVertexAttribArray( attribute.aTextureCoord );
 		gl.disableVertexAttribArray( attribute.aAlpha );
+
+		// Restore blending to original state
+		if (wasBlendEnabled) {
+			gl.enable(gl.BLEND);
+		} else {
+			gl.disable(gl.BLEND);
+		}
+		gl.depthMask(depthMask);
 	}
 
 


### PR DESCRIPTION
fixes transparent contour, cutout, and alpha tolerance in 3d rsm Models.js 
Original:
<img width="1600" height="1179" alt="image" src="https://github.com/user-attachments/assets/765eac15-77aa-4977-867a-61fb676afd05" />
Fixed:
<img width="1253" height="890" alt="image" src="https://github.com/user-attachments/assets/6db2c6da-f2f9-40e3-a4df-6e8a54a39f3e" />
