### PR TITLE
fixes icon signboards rendering with blank textbox on load

### DIFF
--- a/src/UI/Components/EntitySignboard/EntitySignboard.css
+++ b/src/UI/Components/EntitySignboard/EntitySignboard.css
@@ -32,6 +32,7 @@
 }
 
 .EntitySignboard button .title {
+    display: none;
     position: relative;
     left: 30px;
     width: 122px;
@@ -48,6 +49,7 @@
 }
 
 .EntitySignboard .overlay {
+	display: none;
 	position: absolute;
 	top: 0px;
 	left: 26px;

--- a/src/UI/Components/EntitySignboard/EntitySignboard.js
+++ b/src/UI/Components/EntitySignboard/EntitySignboard.js
@@ -73,14 +73,15 @@ define(function(require)
 	{
 		this.ui.find('button').css('backgroundImage', 'url('+ url +')');
 		this.ui.find('.title, .overlay').text(title);
-
-		const titleElement = this.ui.find('.title');
-		const overlayElement = this.ui.find('.overlay');
+		var titleElement = this.ui.find('.title');
+		var overlayElement = this.ui.find('.overlay');
+		titleElement.show();
+		overlayElement.show();
 
 		// Check if the title is overflowing
-		if (!isOverflowing(titleElement[0])) {
+		if (!isOverflowing(titleElement[0]))
 			overlayElement.hide(); // Hide the overlay if no overflow
-		}
+
 	};
 
 


### PR DESCRIPTION
icon only signboards are rendering with blank textbox on render start, that fixes
<img width="175" height="33" alt="image" src="https://github.com/user-attachments/assets/d59c3e1a-aad3-4ef2-b904-869c7584066a" />
