### PR TITLE
Reduce memory cleanup intervals to minimize pagefile usage

### DIFF
--- a/src/Core/MemoryManager.js
+++ b/src/Core/MemoryManager.js
@@ -26,7 +26,7 @@ define( ['Core/MemoryItem'], function( MemoryItem )
 	 * Remove files from memory if not used until a period of time
 	 * @var {number}
 	 */
-	var _rememberTime = 2 * 60 * 1000; // 2 min
+	var _rememberTime = 30 * 1000; // 30s
 
 
 	/**
@@ -36,9 +36,9 @@ define( ['Core/MemoryItem'], function( MemoryItem )
 
 
 	/**
-	 * @var {number} perform the clean up every 30 secs
+	 * @var {number} perform the clean up every 10 secs
 	 */
-	var _cleanUpInterval = 30 * 1000;
+	var _cleanUpInterval = 10 * 1000;
 
 	/**
 	 * Async cleanup state tracking.


### PR DESCRIPTION
Reduces `MemoryManager` cache retention and cleanup frequency to decrease virtual memory paging on low-RAM systems.

## Changes
- `_rememberTime`: 2 min → 30 sec 
- `_cleanUpInterval`: 30 sec → 10 sec

## Rationale
On systems with limited RAM, the current 2-minute cache retention causes excessive pagefile usage as memory gets paged to disk. Faster cleanup reduces paging overhead by:
- Freeing RAM 4x quicker (30s vs 120s)
- Running cleanup 3x more frequently (10s vs 30s)
- Minimizing disk I/O from virtual memory swapping

## Trade-offs
- Slightly increased CPU from frequent cleanup (irrelevant due we still using requestIdleCallback)

Benefits outweigh costs on low-RAM systems where pagefile thrashing causes significant performance degradation.
