### PR TITLE
Implement Missing Item Move Info UI

### DIFF
--- a/src/DB/DBManager.js
+++ b/src/DB/DBManager.js
@@ -366,6 +366,11 @@ define(function (require) {
 			loadTable('data/questid2display.txt', '#', 6, parseQuestEntry, onLoad());
 		}
 
+		// Load ItemMoveInfo and attach to ItemTable
+		if (PACKETVER.value >= 20150422) {
+			loadMoveInfoTable(onLoad());
+		}
+
 		// Forging/Creation
 		loadTable('data/metalprocessitemlist.txt', '#', 2, function (index, key, val) { (ItemTable[key] || (ItemTable[key] = {})).processitemlist = val.split("\n"); }, onLoad());
 
@@ -452,6 +457,66 @@ define(function (require) {
 		}, onEnd);
 	}
 
+
+	/**
+	 * Load ItemMoveInfoV5.txt and attach move info to ItemTable
+	 *
+	 * @param {function} onEnd
+	 */
+	function loadMoveInfoTable(onEnd) {
+		Client.loadFile('data/ItemMoveInfoV5.txt', function (data) {
+			console.log('Loading file "ItemMoveInfoV5.txt"...');
+
+			const lines = data.split(/\r?\n/);
+			let count = 0;
+
+			for (let line of lines) {
+				line = line.trim();
+				if (!line || line.startsWith('//')) continue;
+
+				// Remove inline comments
+				const commentIndex = line.indexOf('//');
+				if (commentIndex !== -1) {
+					line = line.slice(0, commentIndex).trim();
+				}
+
+				const cols = line.split(/\s+/);
+				if (cols.length < 9) {
+					console.warn('Invalid ItemMoveInfo line:', line);
+					continue;
+				}
+
+				const [
+					key,
+					drop,
+					exchange,
+					storage,
+					cart,
+					npcSale,
+					mail,
+					auction,
+					guildStorage
+				] = cols;
+
+				const item = ItemTable[key] || (ItemTable[key] = {});
+
+				item.moveInfo = {
+					Drop: drop === '1',
+					Exchange: exchange === '1',
+					Storage: storage === '1',
+					Cart: cart === '1',
+					NPCSale: npcSale === '1',
+					Mail: mail === '1',
+					Auction: auction === '1',
+					GuildStorage: guildStorage === '1'
+				};
+
+				count++;
+			}
+
+			onEnd();
+		}, onEnd);
+	};
 
 	/**
 	  * LoadXML to json object

--- a/src/UI/Components/ItemInfo/ItemInfo.css
+++ b/src/UI/Components/ItemInfo/ItemInfo.css
@@ -32,3 +32,23 @@
 .ItemInfo .title.damaged {
     text-shadow: red 1px 1px 0px;
 }
+
+.moveinfo-label {
+    color: #000000;
+    display: block;
+    text-decoration: underline;
+}
+
+#moveinfo-tooltip {
+    position: absolute;
+    display: none;
+    pointer-events: none;
+    z-index: 9999;
+    background: #e6e7ef;
+    border: 2px solid #bdbdee;
+    padding: 6px 8px;
+    font-size: 12px;
+    color: #183984;
+    white-space: nowrap;
+    border-radius: 8px;
+}

--- a/src/UI/Components/ItemInfo/ItemInfo.html
+++ b/src/UI/Components/ItemInfo/ItemInfo.html
@@ -22,3 +22,5 @@
 		</div>
 	</div>
 </div>
+
+<div id="moveinfo-tooltip"></div>


### PR DESCRIPTION
Added missing: https://github.com/MrAntares/roBrowserLegacy/issues/590

<img width="344" height="494" alt="Screenshot 2025-12-25 185752" src="https://github.com/user-attachments/assets/e560259e-aab7-4a83-90f4-4fc3ed210543" />

<img width="332" height="323" alt="Screenshot 2025-12-25 190947" src="https://github.com/user-attachments/assets/1317d25d-bdd5-414b-bdde-1ffb97822be3" />

Notes:
- Don't know if should be locked with Packetver as this is just reliant with the txt file inside the GRF
- Unknown if there are other version of name for the txt file
- Patch notes related to this: https://ragnarok.fandom.com/wiki/RO_Patch_(2015_Apr._22)