### PR TITLE
fixes sprite frame error frozen Renderer/Entity/EntityRender.js

### DIFF
--- a/src/Renderer/Entity/EntityRender.js
+++ b/src/Renderer/Entity/EntityRender.js
@@ -683,6 +683,11 @@ define( function( require )
 			index += spr.old_rgba_index;
 		}
 
+		if (!spr.frames[index]) {  
+			console.warn('[renderLayer] - Frame index ' + index + ' not found in sprite');  
+			return;  
+		}
+
 		var frame  = spr.frames[ index ];
 		var width  = frame.width;
 		var height = frame.height;


### PR DESCRIPTION
fixes the ability of 1 missing frame breaks the entire renderer
<img width="1873" height="944" alt="image" src="https://github.com/user-attachments/assets/168cc928-52e4-43ab-b419-82e985c3e711" />
