### PR TITLE
Fix race condition when rendering attachments before sprite frames are loaded

### DIFF
--- a/src/Renderer/Entity/EntityAttachments.js
+++ b/src/Renderer/Entity/EntityAttachments.js
@@ -181,7 +181,7 @@ function(     Client,            Renderer,            SpriteRenderer,           
 			spr = Client.loadFile(attachment.spr);
 			act = Client.loadFile(attachment.act);
 
-			if (!spr || !act) {
+			if (!spr || !act || !spr.frames) {
 				return clean;
 			}
 

--- a/src/Renderer/Entity/EntityRender.js
+++ b/src/Renderer/Entity/EntityRender.js
@@ -661,7 +661,7 @@ define( function( require )
 	function renderLayer( layer, spr, pal, size, pos, type, isBlendModeOne )
 	{
 		// If there is nothing to render
-		if (layer.index < 0 || !spr || !spr.frames || layer.index >= spr.frames.length || !spr.frames[layer.index]) {
+		if (layer.index < 0) {
 			return;
 		}
 
@@ -681,6 +681,11 @@ define( function( require )
 		// RGBA is at the end of the spr.
 		else if (layer.spr_type === 1) {
 			index += spr.old_rgba_index;
+		}
+
+		if (!spr.frames[index]) {  
+			console.warn('[renderLayer] - Frame index ' + index + ' not found in sprite');  
+			return;  
 		}
 
 		var frame  = spr.frames[ index ];


### PR DESCRIPTION
<img width="2316" height="566" alt="image" src="https://github.com/user-attachments/assets/c8ab845e-423f-4cbb-a532-347b5ed8c32f" />


Fix race condition in attachment rendering with async sprite loading

Attachment rendering could run before spr.frames was initialized, causing
"Cannot read properties of undefined" at render time.

Recent Uint32Array optimizations reduced processing latency and exposed an
existing async loading race. Rendering is now skipped until sprite frames
are available.
