### PR TITLE
Fix EntityAttachments not rendering after depth correction patch

### DIFF
--- a/src/Renderer/Entity/EntityAttachments.js
+++ b/src/Renderer/Entity/EntityAttachments.js
@@ -226,8 +226,9 @@ function(     Client,            Renderer,            SpriteRenderer,           
 
 			// render layers
 			SpriteRenderer.setDepthMask(false);
+			var useBlendOne = (attachment.file === 'torch_01');
 			for (i = 0, count = layers.length; i < count; ++i) {
-				this.entity.renderLayer(layers[i], spr, spr, 1.0, position, false, attachment.file === 'torch_01');
+				this.entity.renderLayer(layers[i], spr, spr, 1.0, position, false, useBlendOne);
 			}
 			SpriteRenderer.setDepthMask(true);
 			return clean;


### PR DESCRIPTION
fix entity attachments not rendering due new depth mask code
patch when it broked: https://github.com/MrAntares/roBrowserLegacy/commit/bbfc7054d37f27e74ba79d45f8b8385fb21a0c76

before:
<img width="1348" height="944" alt="image" src="https://github.com/user-attachments/assets/6094ce49-6117-4125-85cf-ed816755f4ce" />
fixed:
<img width="707" height="677" alt="image" src="https://github.com/user-attachments/assets/ef781a53-36be-40d5-8d58-bc470131c949" />
add blending to torch:
<img width="987" height="867" alt="image" src="https://github.com/user-attachments/assets/2d2eda7c-3e56-408e-9c0e-d7649455007b" />
