### PR TITLE
chore: handles NaN altitude in entity position

### DIFF
--- a/src/Renderer/Entity/Entity.js
+++ b/src/Renderer/Entity/Entity.js
@@ -259,6 +259,9 @@ define( function( require )
 					this.position[0] = unit.PosDir[0];
 					this.position[1] = unit.PosDir[1];
 					this.position[2] = Altitude.getCellHeight(  unit.PosDir[0],  unit.PosDir[1] ) + (this.objecttype === Entity.TYPE_FALCON ? 5 : 0);
+					if (isNaN(this.position[2])) { // this can happens when map provided by client is different from server
+						this.position[2] = 0;
+					}
 					break;
 
 				case 'state':


### PR DESCRIPTION
Adds a check to set position[2] to 0 if the calculated altitude is NaN, which can occur when the client and server maps differ. This prevents invalid entity positions due to inconsistent map data.