### PR TITLE
Fix #611: Adjusted chatbox key handling to skip battle‑mode shortcuts…

### DIFF
--- a/src/UI/Components/ChatBox/ChatBox.js
+++ b/src/UI/Components/ChatBox/ChatBox.js
@@ -781,7 +781,16 @@ define(function(require)
 			ChatBoxSettings.updateTab(ChatBox.activeTab, this.value);
 		});
 
-		var isChatInputFocused = (document.activeElement === messageBox[0] || document.activeElement === nickBox[0]);
+		var activeElement = document.activeElement;
+		var isChatInputFocused = (activeElement === messageBox[0] || activeElement === nickBox[0]);
+		var isOtherTextInputFocused = activeElement &&
+			!isChatInputFocused &&
+			((activeElement.tagName && activeElement.tagName.match(/input|select|textarea/i)) ||
+				activeElement.isContentEditable);
+
+		if (isOtherTextInputFocused) {
+			return true;
+		}
 
 		switch (event.which) {
 

--- a/src/UI/Components/InputBox/InputBox.js
+++ b/src/UI/Components/InputBox/InputBox.js
@@ -56,7 +56,16 @@ define(function(require)
 	 * Input Post-Render callback
 	 * Should append data, focus, select text, etc...
 	 */
-	InputBox.onAppend = function OnAppend() {};
+	InputBox.onAppend = function OnAppend()
+	{
+		var input = this.ui.find('input');
+		if (input.length) {
+			input.focus();
+			if (input.val()) {
+				input.select();
+			}
+		}
+	};
 
 
 	/**


### PR DESCRIPTION
Fix bug #611
… when another text input is focused, and made InputBox auto‑focus its field on open so keystrokes land there instead of triggering skills. This keeps numeric hotkeys from firing while typing in modal input.