### PR TITLE
chore: updates item preview and info UI for client button style

### DIFF
--- a/src/UI/Components/ItemInfo/ItemInfo.css
+++ b/src/UI/Components/ItemInfo/ItemInfo.css
@@ -1,5 +1,5 @@
 .ItemInfo { position:absolute; top:0px; left:0px; width:280px; background-repeat:no-repeat; background-color:transparent; }
-.ItemInfo .container { height:120px; position:relative; box-shadow: white 0px 0px 0px 3px inset, rgb(192, 192, 192) 0px 0px 0px 4px inset; background-repeat: no-repeat; background-color: white; border-radius: 5px; }
+.ItemInfo .container { height:140px; position:relative; box-shadow: white 0px 0px 0px 3px inset, rgb(192, 192, 192) 0px 0px 0px 4px inset; background-repeat: no-repeat; background-color: white; border-radius: 5px; }
 .ItemInfo .event_view { position: absolute; }
 .ItemInfo .event_view .view { position:absolute; width:42px; height:20px; background-repeat:no-repeat; background-color:transparent; border:none; top:6px; left:6px; }
 .ItemInfo .collection { position:absolute; top:11px; left:10px; width:75px; height:100px; background-repeat:no-repeat; background-color:transparent; }
@@ -34,8 +34,8 @@
 }
 
 .ItemInfo .preview-action {
-	padding-top: 116px;
-	padding-left: 18px;
+	padding-top: 115px;
+	padding-left: 9px;
 }
 
 .moveinfo-label {
@@ -56,4 +56,13 @@
     color: #183984;
     white-space: nowrap;
     border-radius: 8px;
+}
+
+.ItemInfo .btn_mounting {
+    border: 0;
+    width: 80px;
+    height: 20px;
+    background-repeat: no-repeat;
+    background-color: transparent;
+    font-size: 11px;
 }

--- a/src/UI/Components/ItemInfo/ItemInfo.html
+++ b/src/UI/Components/ItemInfo/ItemInfo.html
@@ -1,6 +1,9 @@
 <div class="ItemInfo">
      <div class="container" data-background="basic_interface/collection_bg.bmp">
          <div class="collection"></div>
+         <div class="preview-action">
+            <button class="btn_mounting" data-background="equip_preview\btn_mounting_normal.bmp" data-down="equip_preview\btn_mounting_press.bmp" data-hover="equip_preview\btn_mounting_over.bmp" type="button" data-text="2922"></button>
+         </div>
          <div class="event_view">
             <button class="view" data-background="btn_view.bmp" data-down="btn_view_a.bmp" data-hover="btn_view_b.bmp"></button>
             <span class="overlay_open" data-text="1294">Read</span>

--- a/src/UI/Components/ItemInfo/ItemInfo.js
+++ b/src/UI/Components/ItemInfo/ItemInfo.js
@@ -480,8 +480,8 @@ define(function(require)
 		var description = ItemInfo.ui.find('.description');
 		var descriptionInner = ItemInfo.ui.find('.description-inner');
 		var containerHeight = height;
-		var minHeight = 120;
-		var maxHeight = descriptionInner.height() + 45 > 120 ? Math.min(descriptionInner.height() + 45, 448) : 120;
+		var minHeight = 140;
+		var maxHeight = descriptionInner.height() + 45 > 140 ? Math.min(descriptionInner.height() + 45, 448) : 140;
 
 		if (containerHeight <= minHeight) {
 			containerHeight = minHeight;
@@ -536,23 +536,17 @@ define(function(require)
 
 	function updatePreviewButton(item)
 	{
-		var itemInfoContainer = ItemInfo.ui.find('.container');
-		itemInfoContainer.find('.preview-action').remove();
-
+		let previewButton = ItemInfo.ui.find('.btn_mounting');
 		if (!canPreviewItem(item)) {
+			previewButton.hide();
 			return;
 		}
 
-		var previewAction = jQuery('<div class="preview-action"></div>');
-		var previewButton = jQuery('<button class="ui-btn preview-button" type="button">Preview</button>');
-
+		previewButton.show();
 		previewButton.on('click', function(event) {
 			event.stopImmediatePropagation();
 			toggleItemPreview(item);
 		});
-
-		previewAction.append(previewButton);
-		itemInfoContainer.append(previewAction);
 	}
 
 	function canPreviewItem(item)

--- a/src/UI/Components/ItemPreview/ItemPreview.css
+++ b/src/UI/Components/ItemPreview/ItemPreview.css
@@ -58,7 +58,11 @@
 	height: 20px;
 }
 .ItemPreview .controls .reset {
-	width: 42px;
-	height: 20px;
+    border: 0;
+    width: 80px;
+    height: 20px;
+    background-repeat: no-repeat;
+    background-color: transparent;
+    font-size: 11px;
 	margin: 0 2px;
 }

--- a/src/UI/Components/ItemPreview/ItemPreview.html
+++ b/src/UI/Components/ItemPreview/ItemPreview.html
@@ -1,6 +1,6 @@
 <div id="ItemPreview" class="ItemPreview">
 	<div class="titlebar" data-background="basic_interface/titlebar_mid.bmp">
-		<span class="title"></span>
+		<span class="title" data-text="2960"></span>
 		<button
 			class="close"
 			data-background="basic_interface/sys_close_off.bmp"
@@ -18,9 +18,10 @@
 			></button>
 			<button
 				class="reset"
-				data-background="btn_reset.bmp"
-				data-hover="btn_reset_a.bmp"
-				data-down="btn_reset_b.bmp"
+				data-background="equip_preview\btn_mounting_normal.bmp" 
+				data-down="equip_preview\btn_mounting_press.bmp" 
+				data-hover="equip_preview\btn_mounting_over.bmp" 
+				data-text="2975"
 			></button>
 			<button
 				class="rot_right"

--- a/src/UI/Components/ItemPreview/ItemPreview.js
+++ b/src/UI/Components/ItemPreview/ItemPreview.js
@@ -157,8 +157,6 @@ define(function(require)
 		_previewLocation = getItemLocation(item);
 		_previewSpriteId = getPreviewSpriteId(item, it);
 		_direction = 0;
-
-		this.ui.find('.title').text(DB.getItemName(item) || 'Preview');
 	};
 
 


### PR DESCRIPTION
- Replaces the preview and reset buttons with client style. 
- The ItemInfo preview button is now always present but shown/hidden as needed-
- ItemPreview title uses a data-text attribute for localization.