### PR TITLE
Implementation of Clock-Wipe Skill Cooldown Effect

### DIFF
--- a/src/UI/Components/ShortCut/ShortCut.css
+++ b/src/UI/Components/ShortCut/ShortCut.css
@@ -17,3 +17,15 @@
 
 .shortcut-tooltip { display:none; position:fixed; background-color:rgba(0,0,0,0.8); text-shadow:1px 1px black; color:white; padding:2px 6px; white-space:nowrap; z-index:10000; border-radius:2px; pointer-events:none; font-size:11px; line-height:1.2; }
 .shortcut-tooltip.show { display:block; }
+
+#ShortCut .cooldown-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 24px;
+    height: 24px;
+    pointer-events: none;
+    border-radius: 2px;
+    z-index: 999;
+    background: conic-gradient(rgba(0,0,0,0.75) 0deg, transparent 0deg);
+}


### PR DESCRIPTION
This PR replaces the static "cat paw"(**Doram Only?**) image and grayscale filter used for skill delays with a official **clock-wipe (radial)** animation.

* **CSS Update**: Added `#ShortCut .cooldown-overlay` with a `conic-gradient` background to handle the visual darkening.
* **Animation**: Implemented `requestAnimationFrame` to create a smooth, frame-by-frame radial wipe based on the remaining cooldown time.

<img width="224" height="49" alt="image" src="https://github.com/user-attachments/assets/052550c8-b774-407d-b954-ad2205dace1b" />
