### PR TITLE
Handle snap windows. Add command /window (wi) : Toggles snapping/magnetism between windows

### DIFF
--- a/src/Controls/ProcessCommand.js
+++ b/src/Controls/ProcessCommand.js
@@ -20,6 +20,7 @@ define(function (require) {
 	const PACKETVER = require("Network/PacketVerManager");
 	const Network = require("Network/NetworkManager");
 	const ControlPreferences = require("Preferences/Controls");
+	const UIPreferences = require("Preferences/UI");
 	const AudioPreferences = require("Preferences/Audio");
 	const MapPreferences = require("Preferences/Map");
 	const CameraPreferences = require("Preferences/Camera");
@@ -269,6 +270,21 @@ define(function (require) {
 				ControlPreferences.save();
 				return;
 			},
+		},
+		window: {
+			description: "Toggles snapping/magnetism between windows",
+			callback: function () {
+				UIPreferences.windowmagnet = !UIPreferences.windowmagnet;
+				this.addText(
+					"Window magnet " +
+						(UIPreferences.windowmagnet ? "ON" : "OFF"),
+					this.TYPE.INFO,
+					this.FILTER.PUBLIC_LOG
+				);
+				UIPreferences.save();
+				return;
+			},
+			aliases: ["wi"],
 		},
 
 		stand: {

--- a/src/Preferences/UI.js
+++ b/src/Preferences/UI.js
@@ -1,0 +1,19 @@
+/**
+ * Preferences/UI.js
+ *
+ * UI user preferences
+ *
+ */
+define( ['Core/Preferences'], function( Preferences )
+{
+	'use strict';
+
+
+	/**
+	 * Export
+	 */
+	return Preferences.get( 'UI', {
+		windowmagnet: true
+	}, 1.0 );
+
+});


### PR DESCRIPTION
<img width="597" height="248" alt="image" src="https://github.com/user-attachments/assets/072eb2bf-356c-4998-a2db-bcae635f6087" />

Currently, only snap to borders window work. Update to handle snap between windows, add command `/window`