### PR TITLE
Fix guild emblem request timing and prevent duplicate requests for own character

### DIFF
--- a/src/Engine/MapEngine/Entity.js
+++ b/src/Engine/MapEngine/Entity.js
@@ -172,7 +172,7 @@ define(function (require) {
 			EntityManager.add(entity.wug);
 		}
 
-		if (entity.GUID && entity.GID !== Session.Character.GID) {
+		if (entity.GUID && entity !== Session.Entity) {
 			Guild.requestGuildEmblem(entity.GUID, entity.GEmblemVer, function (image) {
 				entity.display.emblem = image;
 				entity.emblem.emblem = image;
@@ -899,7 +899,7 @@ define(function (require) {
 
 			entity.display.load = entity.display.TYPE.COMPLETE;
 
-			if (entity.GUID) {
+			if (entity.GUID && entity !== Session.Entity) {
 				Guild.requestGuildEmblem(entity.GUID, entity.GEmblemVer, function (image) {
 					entity.display.emblem = image;
 					entity.display.update(

--- a/src/Engine/MapEngine/Guild.js
+++ b/src/Engine/MapEngine/Guild.js
@@ -149,7 +149,7 @@ define(function( require )
 		}
 
 		if(PACKETVER.value >= 20170315){
-			if (!guild_id || guild_id === undefined || !Session.AID || Session.AID === 0 || Session.ServerName === undefined || !Session.WebToken)
+			if (!guild_id || guild_id === undefined || !Session.AID || Session.AID === 0 || !Session.ServerName || Session.ServerName === undefined || !Session.WebToken || Session.WebToken === undefined)
 				return;
 
 			var webAdress = Configs.get('webserverAdress', '127.0.0.1:8888');
@@ -502,12 +502,17 @@ define(function( require )
 	function onGuildInfo( pkt )
 	{
 		Guild.setGuildInformations( pkt );
-		GuildEngine.requestGuildEmblem(pkt.GDID, pkt.emblemVersion, function(image) {  
-			Session.Entity.display.emblem = image;  
-			Session.Entity.emblem.emblem = image;  
-			Session.Entity.emblem.update();  
-			Session.Entity.display.update(Session.Entity.display.STYLE.DEFAULT);  
-		});
+
+		// Before 2024 we didn't receive this package upon login, but now we do. (~AoShinHo check: https://github.com/rathena/rathena/pull/8574).
+		if(PACKETVER.value >= 20170315){
+			GuildEngine.requestGuildEmblem(pkt.GDID, pkt.emblemVersion, function(image) {
+				Session.Entity.display.emblem = image;  
+				Session.Entity.emblem.emblem = image;  
+				Session.Entity.emblem.update();  
+				Session.Entity.display.update(Session.Entity.display.STYLE.DEFAULT);
+				Guild.setEmblem.bind(image);
+			});
+		}
 	}
 
 

--- a/src/UI/Components/Guild/Guild.js
+++ b/src/UI/Components/Guild/Guild.js
@@ -27,6 +27,7 @@ define(function(require)
 	var Camera         = require('Renderer/Camera');
 	var Renderer       = require('Renderer/Renderer');
 	var Preferences    = require('Core/Preferences');
+	var PACKETVER      = require('Network/PacketVerManager');
 	var Client         = require('Core/Client');
 	var UIManager      = require('UI/UIManager');
 	var UIComponent    = require('UI/UIComponent');
@@ -391,7 +392,8 @@ define(function(require)
 		general.find('.exp .value').text(info.exp);
 		general.find('.tax .value').text(info.point);
 
-		Guild.onRequestGuildEmblem(info.GDID, info.emblemVersion, Guild.setEmblem.bind(this));
+		if (PACKETVER.value < 20170315)
+			Guild.onRequestGuildEmblem(info.GDID, info.emblemVersion, Guild.setEmblem.bind(this));
 
 		if (Session.isGuildMaster) {
 			general.find('.emblem_edit').show();


### PR DESCRIPTION
This PR fixes issues with guild emblem requests being made before session data is fully available and prevents unnecessary requests for the player's own character.

Changes:
Modified entity checks in Entity.js to use entity !== Session.Entity
Enhanced session validation in requestGuildEmblem to check for undefined Session
Made emblem request in onGuildInfo conditional on packet version >= 20170315
Prevented duplicate emblem requests in UI for modern packet versions

These changes resolve timing issues where emblem requests were made before Session values were available for webapi request, and eliminate redundant requests for the player's own guild emblem.