### PR TITLE
Fix Pet Loading Race Condition with Context Function

### DIFF
--- a/src/DB/DBManager.js
+++ b/src/DB/DBManager.js
@@ -2418,7 +2418,7 @@ define(function (require) {
 	* @param {String} name of table in lua file
 	* @param {function} callback to run once the file is loaded
 	* @param {function} onEnd to run once the file is loaded
-	* @param {function} contextFunc - Function to execute after parsing but before unmounting  
+	* @param {function?} contextFunc - Function to execute after parsing but before unmounting  
 	*
 	* @author alisonrag
 	*/


### PR DESCRIPTION
Added optional context function parameter to loadLuaTable to ensure proper execution order when loading pet data, fixing race condition where jobtbl was not available in Lua context when petinfo.lub executed.

