### PR TITLE
Fix: Guild emblems disappearing when returning to character selection

### DIFF
--- a/src/Engine/CharEngine.js
+++ b/src/Engine/CharEngine.js
@@ -135,6 +135,7 @@ define(function( require )
 	 */
 	function reload()
 	{
+		require('Engine/MapEngine/Guild').guild_id = 0;
 		Network.close();
 		Background.setImage( 'bgi_temp.bmp', function() {
 			UIManager.removeComponents();

--- a/src/Engine/MapEngine/Guild.js
+++ b/src/Engine/MapEngine/Guild.js
@@ -147,6 +147,13 @@ define(function( require )
 
 		// Lower version, update it to the current
 		if (version <= emblem.version) {
+			EntityManager.forEach(function(entity){
+				if (entity.GUID === guild_id) {
+					entity.display.emblem = emblem.image;
+					entity.emblem.update(); 
+					entity.display.refresh(entity);
+				}
+			});
 			callback(emblem.image);
 			return;
 		}


### PR DESCRIPTION
## Problem  
Guild emblems would disappear below character names when returning to character selection and then back to the game. This happened because:  
  
1. `GuildEngine.guild_id` was not being reset when returning to character selection  
2. Cached emblems in the `_emblems` object were not being properly applied to entities when using cached versions  
  
## Solution  
This fix addresses both issues:  
  
1. **Reset guild state in CharEngine.reload()** - Added `GuildEngine.guild_id = 0` to properly clear guild state when returning to character selection [1](#4-0)   
  
2. **Update entities with cached emblems** - When `version <= emblem.version` (using cached emblem), now properly updates all entities with that guild ID by:  
   - Setting `entity.display.emblem` to the cached image  
   - Calling `entity.emblem.update()` to refresh the emblem display  
   - Calling `entity.display.refresh(entity)` to update the entity's display [2](#4-1)   
  