### PR TITLE
PvP Timer Fix

### DIFF
--- a/src/UI/Components/PvPCount/PvPCount.css
+++ b/src/UI/Components/PvPCount/PvPCount.css
@@ -4,6 +4,8 @@
 	bottom: 0px;
 	width: 240px;
 	height: 96px;
+	pointer-events: none;
+	z-index: 1000 !important;
 }
 
 #PvPCount .pvp-rank-canvas {

--- a/src/UI/Components/PvPTimer/PvPTimer.css
+++ b/src/UI/Components/PvPTimer/PvPTimer.css
@@ -6,6 +6,8 @@
 	text-align: center;
 	width: 360px;
 	height: 250px;
+	pointer-events: none;
+	z-index: 1000 !important;
 }
 
 #PvPTimer .pvp-timer-canvas {


### PR DESCRIPTION
Fix area on pvp timer and count can't be clicked or mouse event doesn't pass through
Timer should always be on top no matter any other UI has been dragged over it

<img width="392" height="518" alt="Screenshot 2026-01-15 170417" src="https://github.com/user-attachments/assets/0d7de2f3-6b9c-47c3-9014-5da66aeb3d23" />
<img width="335" height="546" alt="Screenshot 2026-01-15 170450" src="https://github.com/user-attachments/assets/9b2fd06f-b9eb-485a-af22-a40e0d85072f" />

Thanks to **players from MaeloRO** for reporting