### PR TITLE
Fix: Effects disappearing on entity death and add missing drain effects

### DIFF
--- a/src/DB/Effects/EffectTable.js
+++ b/src/DB/Effects/EffectTable.js
@@ -998,7 +998,7 @@ define(function( require )
 			attachedEntity: true,
 			blue: 1,
 			duration: 200,
-			delayLate: 200,
+			delayLate: 250,
 			//duplicate: -1,
 			fadeIn: true,
 			fadeOut: true,
@@ -1018,7 +1018,7 @@ define(function( require )
 		},
 		{
 			type: '3D',
-			duration: 200,
+			duration: 250,
 			duplicate: 5,
 			timeBetweenDupli: 20,
 			absoluteSpriteName: 'data/sprite/\xc0\xcc\xc6\xd1\xc6\xae/particle1',
@@ -1028,7 +1028,7 @@ define(function( require )
 			sizeStart: 100.0,
 			sizeEnd: 500.0,
 			zOffsetStart: 3,
-			arc: 3.0,
+			arc: 4.0,
 			retreat: 3.0,
 			soulStrikePattern: true
 		}],
@@ -2703,18 +2703,19 @@ define(function( require )
 
 		117: [{  	//EF_WATERBALL2	waterball moving to target  
 			type: '3D',    
-			duration: 1000,
+			duration: 500,
 			duplicate: 20,
 			timeBetweenDupli: 50,  
 			absoluteSpriteName: 'data/sprite/\xc0\xcc\xc6\xd1\xc6\xae/waterball',  
 			playSprite: true,  
 			fromSrc: true,
 			rotateToTarget: true,  
+			fadeOut: true,
 			size: 50.0,
 			zOffsetStart: 5,
 			zOffsetEnd: 0,
-			arc: 4,
-			retreat: 6,
+			arc: 7.5,
+			retreat: 5.0,
 			wav: 'effect/wizard_waterball_chulung'
 		}],
 
@@ -3520,8 +3521,55 @@ define(function( require )
 			attachedEntity: true
 		}],
 
-		216: [{}],	//EF_BLOODDRAIN
-		217: [{}],	//EF_ENERGYDRAIN
+		216: [{	//EF_BLOODDRAIN (Dracula / Beast Strafe)
+			type: '3D',
+			duration: 600,
+			duplicate: 5,
+			timeBetweenDupli: 0,
+			absoluteSpriteName: 'data/sprite/\xc0\xcc\xc6\xd1\xc6\xae/particle1',
+			playSprite: true,
+
+			toSrc: true,
+			rotateToTarget: true,
+			
+			// Blood Red
+			red: 1.0,
+			green: 0.4,
+			blue: 0.4,
+			
+			sizeStart: 150.0,
+			sizeEnd: 180.0,
+
+			zOffsetStart: 5,
+			arc: 3.0,
+			retreat: 3.0,
+			drainPattern: true
+		}],
+
+		217: [{	//EF_ENERGYDRAIN (Wizard Soul Drain)
+			type: '3D',
+			duration: 600,
+			duplicate: 5,
+			timeBetweenDupli: 0,
+			absoluteSpriteName: 'data/sprite/\xc0\xcc\xc6\xd1\xc6\xae/particle1',
+			playSprite: true,
+
+			toSrc: true,
+			rotateToTarget: true,
+			
+			// Dark Blue
+			red: 0.4,
+			green: 0.4,
+			blue: 1.0,
+			
+			sizeStart: 150.0,
+			sizeEnd: 180.0,
+			
+			zOffsetStart: 5,
+			arc: 3.0,
+			retreat: 3.0,
+			drainPattern: true
+		}],
 
 
 		218: [{	//EF_POTION_CON	Concentration Potion
@@ -6331,7 +6379,32 @@ define(function( require )
 			wav: 'effect/\xb8\xcd\xc8\xa3\xb0\xe6\xc6\xc4\xbb\xea',
 		}],
 		//377: [{}],	//EF_BASH3D2	   Matyr's Reckoning 2
-		//378: [{}],	//EF_ENERGYDRAIN2	   Soul Drain (1st Part)
+
+		378: [{	//EF_ENERGYDRAIN2          Soul Drain (1st Part)
+			type: '3D',
+			duration: 600,
+			duplicate: 5,
+			timeBetweenDupli: 0,
+			absoluteSpriteName: 'data/sprite/\xc0\xcc\xc6\xd1\xc6\xae/particle1',
+			playSprite: true,
+			
+			fromSrc: true,
+			toSrc: true,
+			rotateToTarget: true,
+			
+			// Cyan (Based on C++ random(81) + 160 simplified here)
+			red: 0.8,
+			green: 0.8,
+			blue: 1.0,
+			
+			sizeStart: 160.0,
+			sizeEnd: 190.0,
+			
+			zOffsetStart: 5,
+			arc: 3.0,
+			retreat: 3.0,
+			drainPattern: true
+		}],
 		//379: [{}],	//EF_TRANSBLUEBODY	   Soul Drain (2nd Part)
 
 		380: [{	//EF_MAGICCRASHER	   Magic Crasher
@@ -6378,7 +6451,31 @@ define(function( require )
 			attachedEntity: true
 		}],
 
-		//383: [{}],	//EF_ENERGYDRAIN3	   Health Conversion
+		383: [{	//EF_ENERGYDRAIN3 (Health Conversion)
+			type: '3D',
+			duration: 600,
+			duplicate: 5,
+			timeBetweenDupli: 0,
+			absoluteSpriteName: 'data/sprite/\xc0\xcc\xc6\xd1\xc6\xae/particle1',
+			playSprite: true,
+			
+			fromSrc: true,
+			toSrc: true,
+			rotateToTarget: true,
+			
+			// Green
+			red: 0.7,
+			green: 1.0,
+			blue: 0.7,
+			
+			sizeStart: 140.0,
+			sizeEnd: 170.0,
+			
+			zOffsetStart: 5,
+			arc: 3.0,
+			retreat: 3.0,
+			drainPattern: true
+		}],
 
 		384: [{	//EF_LINELINK2	   Soul Change (Sound Effect)
 			wav: 'effect/\xbc\xd2\xbf\xef\x20\xc3\xbc\xc0\xce\xc1\xf6',
@@ -6794,7 +6891,7 @@ define(function( require )
 			attachedEntity: true,
 			blue: 1,
 			duration: 200,
-			delayLate: 200,
+			delayLate: 250,
 			//duplicate: -1,
 			fadeIn: true,
 			fadeOut: true,
@@ -6814,7 +6911,7 @@ define(function( require )
 		},
 		{
 			type: '3D',
-			duration: 200,
+			duration: 250,
 			duplicate: 5,
 			timeBetweenDupli: 20,
 			absoluteSpriteName: 'data/sprite/\xc0\xcc\xc6\xd1\xc6\xae/particle5',
@@ -6824,8 +6921,8 @@ define(function( require )
 			sizeStart: 100.0,
 			sizeEnd: 500.0,
 			zOffsetStart: 3,
-			arc: 3.0,
-			retreat: 3.0,
+			arc: 4.0,
+			retreat: 4.0, //soulstrike2 have a little retreat upper
 			soulStrikePattern: true
 		}],
 

--- a/src/DB/Skills/SkillEffect.js
+++ b/src/DB/Skills/SkillEffect.js
@@ -217,8 +217,8 @@
 	 SkillEffect[SK.NPC_SUMMONSLAVE]                = {};		//Follower Summons
 	 SkillEffect[SK.NPC_EMOTION]                    = {};		//Emotion
 	 SkillEffect[SK.NPC_TRANSFORMATION]             = {};		//Transformation
-	 SkillEffect[SK.NPC_BLOODDRAIN]                 = {};		//Sucking Blood
-	 SkillEffect[SK.NPC_ENERGYDRAIN]                = {};		//Energy Drain
+	 SkillEffect[SK.NPC_BLOODDRAIN]                 = {effectIdOnCaster: 216};		//Sucking Blood
+	 SkillEffect[SK.NPC_ENERGYDRAIN]                = {effectIdOnCaster: 217};		//Energy Drain
 	 SkillEffect[SK.NPC_KEEPING]                    = {effectId: 214};		//Keeping
 	 SkillEffect[SK.NPC_DARKBREATH]                 = {effectId: 212};		//Dark Breath
 	 SkillEffect[SK.NPC_DARKBLESSING]               = {};		//Dark Blessing
@@ -371,6 +371,7 @@
 	 // High Wizard
 	 SkillEffect[SK.HW_MAGICCRASHER]                = {effectId: 380};		//Stave Crasher
 	 SkillEffect[SK.HW_MAGICPOWER]                  = {hideCastAura: true, beginCastEffectId: 16, effectId: 'ef_magicpower'};		//Mystical Amplification
+	 SkillEffect[SK.HW_SOULDRAIN]                   = {effectIdOnCaster: 217};
 	 // Paladin
 	 SkillEffect[SK.PA_PRESSURE]                    = {beforeHitEffectId: 365};		//Gloria Domini
 	 SkillEffect[SK.PA_SACRIFICE]                   = {effectId: 366};		// Martyr's Reckoning
@@ -380,7 +381,7 @@
 	 SkillEffect[SK.CH_TIGERFIST]                   = {effectIdOnCaster: 263, effectId: [377, 'quake']};		//Glacier Fist
 	 SkillEffect[SK.CH_CHAINCRUSH]                  = {effectId: 512};		//Chain Crush Combo
 	 // Professor
-	 SkillEffect[SK.PF_HPCONVERSION]                = {effectId: 383};		//Indulge
+	 SkillEffect[SK.PF_HPCONVERSION]                = {effectId: 383, effectIdOnCaster: 378 /*, successEffectIdOnCaster: 379 */};		//Indulge
 	 SkillEffect[SK.PF_SOULCHANGE]                  = {effectId: 384, successEffectId: 385};		//Soul Exhale
 	 SkillEffect[SK.PF_SOULBURN]                    = {effectId: 406};		//Soul Siphon
 	 // Asassin Cross

--- a/src/Renderer/Effects/ThreeDEffect.js
+++ b/src/Renderer/Effects/ThreeDEffect.js
@@ -271,10 +271,13 @@ function (WebGL, Client, SpriteRenderer, EntityManager, Altitude, Camera) {
 
 		this.rotateWithCamera = effect.rotateWithCamera ? true : false;
 
-		if (effect.soulStrikePattern) { 
-			if (!EF_Inst_Par.duplicateID) {  
-				var hitIndex = Math.floor((this.startTick / effect.duration) % 5);  
-          
+		if (effect.soulStrikePattern || effect.drainPattern) { 
+			if (!EF_Inst_Par.duplicateID || effect.drainPattern) {
+				var hitIndex = Math.floor((this.startTick / effect.duration) % 5);
+
+				if(effect.drainPattern)
+					hitIndex = EF_Inst_Par.duplicateID + 1;
+
 				var offsetAngle = (hitIndex * 72);  
 				var offsetRadius = 2;  
           
@@ -283,8 +286,8 @@ function (WebGL, Client, SpriteRenderer, EntityManager, Altitude, Camera) {
 
 				this._soulOffsetX      = offsetX;  
 				this._soulOffsetY      = offsetY;  
-				this._soulRetreat      = (this.retreat || 0) * (1 + hitIndex * 0.2);  
-				this._soulArc          = (this.arc || 0) * (1 + hitIndex * 0.1);  
+				this._soulRetreat      = (this.retreat || 0) * (1 + hitIndex * 0.2) + (effect.drainPattern? randBetween(0, 2) : 0);  
+				this._soulArc          = (this.arc || 0) * (1 + hitIndex * 0.1) + (effect.drainPattern? randBetween(0, 2) : 0);  
 				this._soulAngle        = offsetAngle;  
 				_soulStrikeFirstEffect = this;
 			} else {  

--- a/src/Renderer/Entity/EntityAura.js
+++ b/src/Renderer/Entity/EntityAura.js
@@ -111,9 +111,11 @@ define(['DB/Effects/EffectConst', 'Preferences/Map', 'Core/Configs'],
 			effectManager.remove(null, this.entity.GID, normalEffects);
 			// free aura - needs to be separate to avoid circular dependency
 			this.free();
-			// reset constructors so aura effects re-init on next load
-			effectManager.resetConstructor('TwoDEffect');
-			effectManager.resetConstructor('ThreeDEffect');
+			setTimeout(function() {  
+				// reset constructors so aura effects re-init on next load
+				effectManager.resetConstructor('TwoDEffect');
+				effectManager.resetConstructor('ThreeDEffect');
+			}, 5000);
 		};
 
 		/**


### PR DESCRIPTION
Fixed critical bug where EntityAura.remove() was incorrectly instantly clearing all effects when entities died, not just aura effects. Added missing Blood Drain, Soul Drain & Health Conversion effects and improved existing waterball2 and soulstrike effects.

Bug Fix in EntityAura.js
The core issue was in EntityAura.prototype.remove() where effectManager.resetConstructor() was called immediately after removing effects EntityAura.js:111-119 . This caused all active effects to disappear when entities died because:
effectManager.remove(null, this.entity.GID, normalEffects) removes ALL effects matching the normalEffects list
resetConstructor() was called immediately, cleaning up effect constructors while effects were still running
Added 5-second delay to resetConstructor() calls using setTimeout() EntityAura.js:111-119 , allowing effects to complete before constructor cleanup.

New Effects of PP_3DPARTICLESPLINE:
EF_BLOODDRAIN (216): Red particle effect with drainPattern
EF_ENERGYDRAIN (217): Blue Soul Drain effect for Wizards
EF_ENERGYDRAIN2 (378): Cyan effect for Health Conversion (part 1)
EF_ENERGYDRAIN3 (383): Green Health Conversion effect


https://github.com/user-attachments/assets/f27e2f70-101f-4be5-81e6-d8e03d1d6003


https://github.com/user-attachments/assets/1d8264ad-d007-4e69-91f9-4bf47e014856

