### PR TITLE
revert: Remove SpatialGrid dirty tracking optimization

### DIFF
--- a/src/Renderer/EntityManager.js
+++ b/src/Renderer/EntityManager.js
@@ -32,15 +32,12 @@ define(function (require) {
 	var SpatialGrid = {
 		cellSize: GraphicsSettings.culling ? GraphicsSettings.viewArea : 20,
 		cells: {},
-		dirty: false,
-		lastFrameCount: 0,
-		
+
 		/**
 		 * Clear the grid
 		 */
 		clear: function() {
 			this.cells = {};
-			this.dirty = false;
 		},
 
 		/**
@@ -56,21 +53,6 @@ define(function (require) {
 				this.cells[key] = [];
 			}
 			this.cells[key].push(entity);
-			this.dirty = true;
-		},
-
-		/**
-		 * Check if grid needs rebuild
-		 */
-		needsRebuild: function(entityCount) {
-			// Rebuild if:
-			// 1. Entity count changed (entities added/removed)
-			// 2. Grid was marked dirty (entities moved)
-			// 3. First frame (no cells yet)
-			if (this.lastFrameCount !== entityCount || Object.keys(this.cells).length === 0) {
-				return true;
-			}
-			return false;
 		},
 
 		/**
@@ -381,16 +363,11 @@ define(function (require) {
 			return;
 		}
 		SpatialGrid.cellSize = GraphicsSettings.culling ? GraphicsSettings.viewArea : 20;
-		
-		// Phase 1 Optimization: Only rebuild grid if entity count changed or entities moved
-		// This avoids O(N) rebuild every frame when entities are static
-		if (SpatialGrid.needsRebuild(_list.length)) {
-			SpatialGrid.clear();
-			for(i = 0, count = _list.length; i < count; ++i) {
-				SpatialGrid.add(_list[i]);
-			}
-			SpatialGrid.lastFrameCount = _list.length;
-			SpatialGrid.dirty = false;
+		// Note: Rebuilding grid every frame is O(N), but usually N is < 1000.
+		// This allows us to sort only visible entities O(K log K) where K << N.
+		SpatialGrid.clear();
+		for(i = 0, count = _list.length; i < count; ++i) {
+			SpatialGrid.add(_list[i]);
 		}
 
 		// Get only visible entities


### PR DESCRIPTION
The Phase 1 optimization was breaking the renderer because the dirty flag was never updated when entity coordinates changed, causing the grid to never be rebuilt when entities moved.

Rebuilding the grid every frame is acceptable since N is typically < 1000 entities, and the optimization added unnecessary complexity without proper coordinate change tracking.