### PR TITLE
feat: Improved ground lighting contrast when smoothlight is enabled

### DIFF
--- a/src/Controls/ProcessCommand.js
+++ b/src/Controls/ProcessCommand.js
@@ -206,11 +206,17 @@ define(function (require) {
 		},
 
 		smoothlight: {
-			description: "Toggles the posterization effect of the lightmap",
-			callback: function () {
-				MapPreferences.smoothlight = !MapPreferences.smoothlight;
-				MapPreferences.save();
-				return;
+			description: "Cycles the posterization effect of the lightmap: on, off, off with gamma correction",  
+			callback: function () {  
+				MapPreferences.smoothlight = (MapPreferences.smoothlight + 1) % 3;  
+				var messages = ["Posterization On", "Smoothlight On", "Smoothlight On with Gamma Correction"];  
+				this.addText(
+					messages[MapPreferences.smoothlight],  
+					this.TYPE.INFO,  
+					this.FILTER.PUBLIC_LOG  
+				);  
+				MapPreferences.save();  
+				return;  
 			},
 		},
 

--- a/src/Preferences/Map.js
+++ b/src/Preferences/Map.js
@@ -36,7 +36,7 @@ define( ['Core/Preferences'], function( Preferences )
 		 *
 		 * Toggle using "/smoothlight" in the chatbox
 		 */
-		smoothlight: false,
+		smoothlight: 0,
 
 
 		/**

--- a/src/Renderer/Map/Ground.js
+++ b/src/Renderer/Map/Ground.js
@@ -123,6 +123,7 @@ function(      WebGL,         Texture,   Preferences,            Configs )
 		uniform sampler2D uTileColor;
 		uniform bool uLightMapUse;
 		uniform bool uPosterize;
+		uniform bool uGammaCorrection;
 
 		uniform bool  uFogUse;
 		uniform float uFogNear;
@@ -159,9 +160,9 @@ function(      WebGL,         Texture,   Preferences,            Configs )
 				vec4 lightmap = texture( uLightmap, vLightmapCoord.st);
 				if(uPosterize) {
 					lightmap.rgb = posterize(lightmap.rgb);
-				}
-				else
+				} else if(uGammaCorrection){
 					lightmap.rgb = pow(lightmap.rgb, vec3(1.1));
+				}
 				textureSample.rgb *= lightmap.a;
 				textureSample.rgb += clamp(lightmap.rgb, 0.0, 1.0);
 			}
@@ -207,7 +208,8 @@ function(      WebGL,         Texture,   Preferences,            Configs )
 
 		// Render lightmap ?
 		gl.uniform1i(  uniform.uLightMapUse, Preferences.lightmap );
-		gl.uniform1i(  uniform.uPosterize, !Preferences.smoothlight );
+		gl.uniform1i(  uniform.uPosterize, Preferences.smoothlight === 0 );  
+		gl.uniform1i(  uniform.uGammaCorrection, Preferences.smoothlight === 2 );
 
 		// Fog settings
 		gl.uniform1i(  uniform.uFogUse,   fog.use && fog.exist );


### PR DESCRIPTION
This PR addresses an issue where the ground textures appear "washed out" or overly bright in dark areas when the smoothlight preference is active (i.e., when posterization is disabled).

When uPosterize is false, the WebGL linear interpolation of the lightmap tends to raise the brightness of mid-tones and shadows, leading to a loss of depth and contrast on the map surface.

I've introduced a subtle gamma correction using pow(lightmap.rgb, vec3(1.1)) in the fragment shader's non-posterized path. This darkens the mid-tones and shadows to more closely match the intended atmosphere of the maps. Since it's a power function, white values ($1.0$) remain $1.0$, preventing any color "burnout" or overexposure in bright areas.

after/before
<img width="1874" height="967" alt="image" src="https://github.com/user-attachments/assets/30322d96-c943-4d65-8d87-996bec812b68" />

posterized reference:
<img width="1600" height="803" alt="image" src="https://github.com/user-attachments/assets/ae13fddf-18a4-4051-acdf-d3ed968ea94e" />
