### PR TITLE
feat: externalize ROConfig into separate Config.js file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /node_modules/
 /src/Plugins/*/
 /index.html
+Config.local.js
 /package-lock.json
 /GrannyModelViewer.js
 /GrfViewer.js

--- a/applications/pwa/Config.js
+++ b/applications/pwa/Config.js
@@ -1,0 +1,63 @@
+/**
+ * ROBrowser Configuration - Default Settings
+ *
+ * This file contains default configuration values.
+ * To override settings without modifying this file, create Config.local.js
+ * with your custom values in window.ROConfigLocal.
+ *
+ * Example Config.local.js:
+ *   window.ROConfigLocal = {
+ *       servers: [{ display: 'My Server', address: '192.168.1.1', ... }],
+ *       skipIntro: true
+ *   };
+ */
+window.ROConfigBase = {
+	type: 'FRAME',
+	application: 'ONLINE',
+	development: true,
+	remoteClient: 'https://grf.robrowser.com/',
+	servers: [
+		{
+			display: 'roBrowser Demo Server',
+			desc: 'demo server',
+			address: '127.0.0.1',
+			port: 6900,
+			version: 25,
+			langtype: 12,
+			packetver: 20130618,
+			renewal: false,
+			worldMapSettings: { episode: 12 },
+			packetKeys: false,
+			socketProxy: 'wss://connect.robrowser.com',
+			adminList: [2000000]
+		},
+		// ADD PUBLIC TEST SERVERS HERE WITH _M _F REGISTRATION
+	],
+	packetDump: false,
+	skipServerList: true,
+	skipIntro: false,
+	aura: {},
+	autoLogin: [],
+	BGMFileExtension: ['mp3'],
+	calculateHash: false,
+	CameraMaxZoomOut: 5,
+	charBlockSize: 0,
+	clientHash: null,
+	clientVersionMode: "PacketVer",
+	disableConsole: false,
+	enableBank: false,
+	enableCashShop: false,
+	enableCheckAttendance: false,
+	enableDmgSuffix: false,
+	enableHomunAutoFeed: false,
+	enableMapName: false,
+	FirstPersonCamera: false,
+	grfList: null,
+	hashFiles: [],
+	loadLua: false,
+	onReady: null,
+	plugins: {},
+	registrationweb: '',
+	saveFiles: true,
+	ThirdPersonCamera: false,
+};

--- a/applications/pwa/Config.local.js.example
+++ b/applications/pwa/Config.local.js.example
@@ -1,0 +1,32 @@
+/**
+ * ROBrowser Local Configuration Overrides
+ *
+ * Copy this file to Config.local.js and customize as needed.
+ * Values here will override those in Config.js.
+ * Config.local.js is optional and will be silently ignored if not present.
+ */
+window.ROConfigLocal = {
+	// Example: Override server settings
+	servers: [
+		{
+			display: 'My Private Server',
+			desc: 'custom server',
+			address: '127.0.0.1',
+			port: 6900,
+			version: 25,
+			langtype: 12,
+			packetver: 20130618,
+			renewal: false,
+			worldMapSettings: { episode: 12 },
+			packetKeys: false,
+			socketProxy: 'wss://connect.robrowser.com',
+			adminList: [2000000]
+		}
+	],
+
+	// Example: Skip intro screen
+	// skipIntro: true,
+
+	// Example: Custom remote client URL
+	// remoteClient: 'https://my-grf-server.com/',
+};

--- a/applications/pwa/index.html
+++ b/applications/pwa/index.html
@@ -49,62 +49,47 @@
 	</style>
 
 	<script type="text/javascript" src="../api/api.js"></script>
+	<script type="text/javascript" src="Config.js"></script>
+	<script type="text/javascript">
+		// Load optional Config.local.js for overrides (fails silently if not present)
+		(function() {
+			var script = document.createElement('script');
+			script.src = 'Config.local.js';
+			script.onerror = function() {
+				console.log('Config.local.js not found, using defaults from Config.js');
+			};
+			document.head.appendChild(script);
+		})();
+	</script>
 	<script type="text/javascript">
 
-		function initialize(gitHash) {
+		function deepMerge(target, source) {
+			for (var key in source) {
+				if (source.hasOwnProperty(key)) {
+					if (source[key] && typeof source[key] === 'object' && !Array.isArray(source[key])) {
+						target[key] = deepMerge(target[key] || {}, source[key]);
+					} else {
+						target[key] = source[key];
+					}
+				}
+			}
+			return target;
+		}
 
-			var ROConfig = {
+		function initialize(gitHash) {
+			// Merge Config.js defaults with Config.local.js overrides
+			var baseConfig = deepMerge({}, window.ROConfigBase || {});
+			if (window.ROConfigLocal) {
+				baseConfig = deepMerge(baseConfig, window.ROConfigLocal);
+			}
+
+			// Build ROConfig with dynamic values
+			var ROConfig = Object.assign({}, baseConfig, {
 				target: document.getElementById("robrowser"),
-				type: ROBrowser.TYPE.FRAME,
-				application: ROBrowser.APP.ONLINE,
-				development: true,
-				version: gitHash,
-				remoteClient: 'https://grf.robrowser.com/',
-				servers: [
-					{
-						display: 'roBrowser Demo Server',
-						desc: 'demo server',
-						address: '127.0.0.1',
-						port: 6900,
-						version: 25,
-						langtype: 12,
-						packetver: 20130618,
-						renewal: false,
-						worldMapSettings: { episode: 12 },
-						packetKeys: false,
-						socketProxy: 'wss://connect.robrowser.com',
-						adminList: [2000000]
-					},
-					// ADD PUBLIC TEST SERVERS HERE WITH _M _F REGISTRATION
-				],
-				packetDump: false,
-				skipServerList: true,
-				skipIntro: false,
-				aura: {},
-				autoLogin: [],
-				BGMFileExtension: ['mp3'],
-				calculateHash: false,
-				CameraMaxZoomOut: 5,
-				charBlockSize: 0,
-				clientHash: null,
-				clientVersionMode: "PacketVer",
-				disableConsole: false,
-				enableBank: false,
-				enableCashShop: false,
-				enableCheckAttendance: false,
-				enableDmgSuffix: false,
-				enableHomunAutoFeed: false,
-				enableMapName: false,
-				FirstPersonCamera: false,
-				grfList: null,
-				hashFiles: [],
-				loadLua: false,
-				onReady: null,
-				plugins: {},
-				registrationweb: '',
-				saveFiles: true,
-				ThirdPersonCamera: false,
-			};
+				type: ROBrowser.TYPE[baseConfig.type || 'FRAME'],
+				application: ROBrowser.APP[baseConfig.application || 'ONLINE'],
+				version: gitHash
+			});
 			var RO = new ROBrowser(ROConfig);
 			RO.start();
 		}

--- a/applications/tools/builder-web.js
+++ b/applications/tools/builder-web.js
@@ -150,102 +150,151 @@ function compile(appName, isMinify) {
 function createHTML(includeManifest = false) {
     const start = Date.now();
     let manifest = includeManifest ? `<link rel="manifest" href="./manifest.webmanifest">` : ``;
-    const body = `
-        <!DOCTYPE html>
-        <html>
-            <head>
-                    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
-                	<meta charset="UTF-8">
-                    <title>roBrowser [${package.version} - ${buildDate}]</title>
-                    <link rel="icon" type="./icon.png">
+    const body = `<!DOCTYPE html>
+<html>
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+        <meta charset="UTF-8">
+        <title>roBrowser [${package.version} - ${buildDate}]</title>
+        <link rel="icon" type="./icon.png">
 
-                    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-                    <meta name="HandheldFriendly" content="true">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+        <meta name="HandheldFriendly" content="true">
 
-                    <meta name="apple-mobile-web-app-capable" content="yes">
-                    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-                    <meta name="apple-mobile-web-app-title" content="roBrowser">
-                    <meta name="mobile-web-app-capable" content="yes">
+        <meta name="apple-mobile-web-app-capable" content="yes">
+        <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+        <meta name="apple-mobile-web-app-title" content="roBrowser">
+        <meta name="mobile-web-app-capable" content="yes">
 
-                    <meta name="description" content="roBrowser">
-                    <meta name="keywords" content="roBrowser">
-                    <meta name="author" content="roBrowser">
-                    <meta name="robots" content="index">
+        <meta name="description" content="roBrowser">
+        <meta name="keywords" content="roBrowser">
+        <meta name="author" content="roBrowser">
+        <meta name="robots" content="index">
 
-                    <meta name="theme-color" content="#ff8cb5">
+        <meta name="theme-color" content="#ff8cb5">
 
-                    <meta property="og:title" content="roBrowser">
-                    <meta property="og:description" content="roBrowser">
-                    <meta property="og:type" content="website">
-                    <meta property="og:locale" content="en_US">
+        <meta property="og:title" content="roBrowser">
+        <meta property="og:description" content="roBrowser">
+        <meta property="og:type" content="website">
+        <meta property="og:locale" content="en_US">
 
-                    <link rel="apple-touch-icon" href="./icon.png">
-                    ${manifest}
-            </head>
-            <body>
-                <script>
-                    window.addEventListener("load", (event) => {
-                        window.ROConfig = {
-                            development: false,
-                            remoteClient: 'https://grf.robrowser.com/',
-                            servers: [{
-                                display: 'roBrowser Demo Server',
-                                desc: 'roBrowser demo server',
-                                address: '127.0.0.1',
-                                port: 6900,
-                                version: 55,
-                                langtype: 1,
-                                packetver: 20130618,
-                                renewal: false,
-                                worldMapSettings: { episode: 12 },
-                                packetKeys: false,
-                                socketProxy: 'wss://connect.robrowser.com',
-                                adminList: [2000000]
-                            }],
-                            webserverAddress: 'http://127.0.0.1:8888',
-                            packetDump: false,
-                            skipServerList: true,
-                            skipIntro: false,
-                            aura: {},
-                            autoLogin: [],
-                            BGMFileExtension: ['mp3'],
-                            calculateHash: false,
-                            CameraMaxZoomOut: 5,
-                            charBlockSize: 0,
-                            clientHash: null,
-                            clientVersionMode: "PacketVer",
-                            disableConsole: false,
-                            enableBank: true,
-                            enableCashShop: true,
-                            enableCheckAttendance: true,
-                            enableDmgSuffix: true,
-                            enableHomunAutoFeed: true,
-                            enableMapName: true,
-                            enableRoulette: true,
-                            FirstPersonCamera: false,
-                            grfList: null,
-                            hashFiles: [],
-                            loadLua: false,
-                            customItemInfo: [],
-                            onReady: null,
-                            plugins: {},
-                            registrationweb: '',
-                            saveFiles: true,
-                            ThirdPersonCamera: false,
-                        };
+        <link rel="apple-touch-icon" href="./icon.png">
+        ${manifest}
+    </head>
+    <body>
+        <script src="Config.js"></script>
+        <script>
+            // Load optional Config.local.js for overrides (fails silently if not present)
+            (function() {
+                var script = document.createElement('script');
+                script.src = 'Config.local.js';
+                script.onerror = function() {
+                    console.log('Config.local.js not found, using defaults from Config.js');
+                };
+                document.head.appendChild(script);
+            })();
+        </script>
+        <script>
+            function deepMerge(target, source) {
+                for (var key in source) {
+                    if (source.hasOwnProperty(key)) {
+                        if (source[key] && typeof source[key] === 'object' && !Array.isArray(source[key])) {
+                            target[key] = deepMerge(target[key] || {}, source[key]);
+                        } else {
+                            target[key] = source[key];
+                        }
+                    }
+                }
+                return target;
+            }
 
-                        script = document.createElement('script');
-                        script.type = 'text/javascript';
-                        script.src = 'Online.js';
-                        document.getElementsByTagName('body')[0].appendChild(script);
-                    });
-                </script>
-            </body>
-        </html>
-    `;
+            window.addEventListener("load", (event) => {
+                // Merge Config.js defaults with Config.local.js overrides
+                var config = deepMerge({}, window.ROConfigBase || {});
+                if (window.ROConfigLocal) {
+                    config = deepMerge(config, window.ROConfigLocal);
+                }
+                window.ROConfig = config;
+
+                var script = document.createElement('script');
+                script.type = 'text/javascript';
+                script.src = 'Online.js';
+                document.getElementsByTagName('body')[0].appendChild(script);
+            });
+        </script>
+    </body>
+</html>
+`;
     fs.writeFileSync(dist + platform + '/index.html', body, { encoding: "utf8" });
+    createConfigJS();
     copyFolder('./src/UI/Components/Intro/images/', dist + platform + '/src/UI/Components/Intro/images/');
     console.log("index.html has been created in", (Date.now() - start), "ms.");
+}
+
+function createConfigJS() {
+    const configContent = `/**
+ * ROBrowser Configuration - Default Settings
+ *
+ * This file contains default configuration values.
+ * To override settings without modifying this file, create Config.local.js
+ * with your custom values in window.ROConfigLocal.
+ *
+ * Example Config.local.js:
+ *   window.ROConfigLocal = {
+ *       servers: [{ display: 'My Server', address: '192.168.1.1', ... }],
+ *       skipIntro: true
+ *   };
+ */
+window.ROConfigBase = {
+    development: false,
+    remoteClient: 'https://grf.robrowser.com/',
+    servers: [{
+        display: 'roBrowser Demo Server',
+        desc: 'roBrowser demo server',
+        address: '127.0.0.1',
+        port: 6900,
+        version: 55,
+        langtype: 1,
+        packetver: 20130618,
+        renewal: false,
+        worldMapSettings: { episode: 12 },
+        packetKeys: false,
+        socketProxy: 'wss://connect.robrowser.com',
+        adminList: [2000000]
+    }],
+    webserverAddress: 'http://127.0.0.1:8888',
+    packetDump: false,
+    skipServerList: true,
+    skipIntro: false,
+    aura: {},
+    autoLogin: [],
+    BGMFileExtension: ['mp3'],
+    calculateHash: false,
+    CameraMaxZoomOut: 5,
+    charBlockSize: 0,
+    clientHash: null,
+    clientVersionMode: "PacketVer",
+    disableConsole: false,
+    enableBank: true,
+    enableCashShop: true,
+    enableCheckAttendance: true,
+    enableDmgSuffix: true,
+    enableHomunAutoFeed: true,
+    enableMapName: true,
+    enableRoulette: true,
+    FirstPersonCamera: false,
+    grfList: null,
+    hashFiles: [],
+    loadLua: false,
+    customItemInfo: [],
+    onReady: null,
+    plugins: {},
+    registrationweb: '',
+    saveFiles: true,
+    ThirdPersonCamera: false,
+};
+`;
+    fs.writeFileSync(dist + platform + '/Config.js', configContent, { encoding: "utf8" });
 }
 
 function copyPwaFiles() {

--- a/doc/README.md
+++ b/doc/README.md
@@ -23,7 +23,9 @@ This guide has the goal to help you to Setup/Play RoBrowser. If there's any trou
   - [Remote Client](#remote-client)
 - [6. Adding Custom Plugins](#6-adding-custom-plugins)
 - [7. ROBrowser Settings Overview](#7-robrowser-settings-overview)
-  - [8. Play the Game](#8-play-the-game)
+  - [7.1 Configuration Files](#71-configuration-files)
+  - [7.2 Configuration Options](#72-configuration-options)
+- [8. Play the Game](#8-play-the-game)
 - [9. Troubleshooting](#9-troubleshooting)
   - [9.1 Troubleshooting: The screen is weird and/or the developer console (F12) says it can't load game assets](#91-troubleshooting-the-screen-is-weird-andor-the-developer-console-f12-says-it-cant-load-game-assets)
   - [9.2 Troubleshooting:  Screen is blank](#92-troubleshooting--screen-is-blank)
@@ -298,11 +300,47 @@ Some examples: https://github.com/MrAntares/roBrowserLegacy-plugins
 
 # 7. ROBrowser Settings Overview
 
+## 7.1 Configuration Files
+
+roBrowser uses a two-file configuration system that separates default settings from local customizations:
+
+| File | Purpose |
+|------|---------|
+| `Config.js` | Default configuration shipped with roBrowser. This file can be overwritten during updates/deployments. |
+| `Config.local.js` | **Optional.** Your local overrides that persist across updates. This file is gitignored. |
+
+### Setting Up Your Configuration
+
+1. **For basic setups**: Edit `Config.js` directly in `applications/pwa/`
+
+2. **For production/deployment setups** (recommended):
+   - Keep `Config.js` with sensible defaults
+   - Copy `Config.local.js.example` to `Config.local.js`
+   - Add your server-specific settings to `Config.local.js`
+
+Example `Config.local.js`:
+```js
+window.ROConfigLocal = {
+    servers: [{
+        display: 'My Server',
+        address: '192.168.1.100',
+        port: 6900,
+        packetver: 20180620,
+        socketProxy: 'wss://my-proxy.example.com'
+    }],
+    skipIntro: true,
+    remoteClient: 'https://my-grf-server.com/'
+};
+```
+
+Settings in `Config.local.js` are deep-merged with `Config.js`, so you only need to specify the values you want to override.
+
+## 7.2 Configuration Options
+
 Here you have a list with all of init variables on ROBrowser. Let's take a look:
 
 ```js
-function initialize() {
-      var ROConfig = {
+var ROConfig = {
       // GLOBAL VARIABLES
           type:          ROBrowser.TYPE.FRAME,  // Possible: .FRAME (instert into current document), .POPUP (open new window)
           target:        document.getElementById("robrowser"),  // When using TYPE.FRAME this is the id of the target iframe in the current document
@@ -374,13 +412,10 @@ function initialize() {
           ThirdPersonCamera: false,  // When true you can zoom in more and rotate camera around player more freely with mouse
           FirstPersonCamera: false,  // When true you can look from the player's head, like an FPS game and rotate camera without limit
           CameraMaxZoomOut: 5,  // How far can you zoom out the camera, default:5. Note: Extreme values can break camera and/or mouse.
-      };
-      var RO = new ROBrowser(ROConfig);
-      RO.start();
-  }
-  
-  window.addEventListener("load", initialize, false);  // When the webpage loads this will start roBrowser
+};
 ```
+
+> **Note:** When using `Config.js` and `Config.local.js`, use `window.ROConfigBase` and `window.ROConfigLocal` respectively. The `type` and `application` options should use string values (`'FRAME'`, `'ONLINE'`) which are converted to their constants at runtime.
 In case of the `langtype` option, we added support for some custom types:
 
 Normal


### PR DESCRIPTION
Move configuration out of inline HTML into Config.js with support for Config.local.js overrides. This allows default configs to be updated during deployments while preserving local server-specific settings.

- Add Config.js with window.ROConfigBase for default settings
- Add Config.local.js.example as a template for local overrides
- Update builder-web.js to generate Config.js during build
- Update index.html to load and deep-merge both config files
- Update Getting Started guide with configuration documentation
- Add Config.local.js to .gitignore