### PR TITLE
fix: Add PACKETVER check for Roulette icon visibility

### DIFF
--- a/src/UI/Components/Roulette/Roulette.js
+++ b/src/UI/Components/Roulette/Roulette.js
@@ -24,6 +24,7 @@ define(function(require)
 	var MiniMap            = require('UI/Components/MiniMap/MiniMap');
 	var Network            = require('Network/NetworkManager');
 	var PACKET             = require('Network/PacketStructure');
+	var PACKETVER          = require('Network/PacketVerManager');
 	var jQuery             = require('Utils/jquery');
 	var htmlText           = require('text!./Roulette.html');
 	var cssText            = require('text!./Roulette.css');
@@ -141,6 +142,11 @@ define(function(require)
 	{
 		// Check if roulette is enabled in ROConfig
 		if (ROConfig.enableRoulette === false) {
+			return;
+		}
+		
+		// Check if PACKETVER >= 20141008 (Roulette requires this version)
+		if (PACKETVER.value < 20141008) {
 			return;
 		}
 		


### PR DESCRIPTION
- Import PacketVerManager to check client version
- Only show Roulette icon if PACKETVER >= 20141008
- Prevents disconnect when clicking icon with incompatible client version
- Aligns with rAthena roulette system requirements (PACKETVER >= 20141008)

Fixes issue where users with older client versions would get disconnected when clicking the roulette icon, as the server doesn't recognize the CZ_REQ_OPEN_ROULETTE (0x0A19) packet on older versions.