### PR TITLE
fix: off-by-one error in packet boundary checks

### DIFF
--- a/src/Network/NetworkManager.js
+++ b/src/Network/NetworkManager.js
@@ -283,7 +283,7 @@ define(function( require )
 			offset = fp.tell();
 
 			// Not enough bytes...
-			if (offset + 2 >= fp.length) {
+			if (offset + 2 > fp.length) {
 				_save_buffer = new Uint8Array( buffer, offset, fp.length - offset);
 				return;
 			}
@@ -295,7 +295,7 @@ define(function( require )
 
 			if (packet_len < 0) {
 				// Not enough bytes...
-				if (offset + 4 >= fp.length) {
+				if (offset + 4 > fp.length) {
 					_save_buffer = new Uint8Array( buffer, offset, fp.length - offset );
 					return;
 				}


### PR DESCRIPTION
When a variable-length packet arrives with exactly 4 bytes (e.g., empty character list), the check 'offset + 4 >= fp.length' incorrectly waits for more data instead of processing the complete packet.

Changed >= to > on both boundary checks so packets with exactly the minimum required bytes are processed immediately.