### PR TITLE
feat: export registerPacket for plugin packet overrides

### DIFF
--- a/src/Network/NetworkManager.js
+++ b/src/Network/NetworkManager.js
@@ -516,6 +516,7 @@ define(function( require )
 			read:                 read,
 			setSocketFactory:     setSocketFactory,
 			defaultSocketFactory: defaultSocketFactory,
+			registerPacket:       registerPacket,
 			utils: {
 				longToIP: utilsLongToIP
 			}


### PR DESCRIPTION
Allows plugins to re-register packet parsers at runtime, enabling custom packet structure overrides without modifying core files.