### PR TITLE
Fix entry effect triggering on wrong packet type

### DIFF
--- a/src/Engine/MapEngine/Entity.js
+++ b/src/Engine/MapEngine/Entity.js
@@ -214,16 +214,16 @@ define(function (require) {
 
 		if (entity.objecttype === Entity.TYPE_PC &&
 			!(entity._effectState & StatusState.EffectState.INVISIBLE) &&
-			(pkt instanceof PACKET.ZC.NOTIFY_STANDENTRY || pkt instanceof PACKET.ZC.NOTIFY_STANDENTRY2 || pkt instanceof PACKET.ZC.NOTIFY_STANDENTRY3
-				|| pkt instanceof PACKET.ZC.NOTIFY_STANDENTRY4 || pkt instanceof PACKET.ZC.NOTIFY_STANDENTRY5 || pkt instanceof PACKET.ZC.NOTIFY_STANDENTRY6
-				|| pkt instanceof PACKET.ZC.NOTIFY_STANDENTRY7 || pkt instanceof PACKET.ZC.NOTIFY_STANDENTRY8 || pkt instanceof PACKET.ZC.NOTIFY_STANDENTRY9)
+			(pkt instanceof PACKET.ZC.NOTIFY_NEWENTRY || pkt instanceof PACKET.ZC.NOTIFY_NEWENTRY2 || pkt instanceof PACKET.ZC.NOTIFY_NEWENTRY3
+				|| pkt instanceof PACKET.ZC.NOTIFY_NEWENTRY4 || pkt instanceof PACKET.ZC.NOTIFY_NEWENTRY5 || pkt instanceof PACKET.ZC.NOTIFY_NEWENTRY6
+				|| pkt instanceof PACKET.ZC.NOTIFY_NEWENTRY7 || pkt instanceof PACKET.ZC.NOTIFY_NEWENTRY8 || pkt instanceof PACKET.ZC.NOTIFY_NEWENTRY9)
 		) {
 			var EF_Init_Par = {
 				ownerAID: entity.GID,
 				position: entity.position
 			};
 
-			if (PACKETVER.value < 20030715) {
+			if (PACKETVER.value < 20090922) {
 				EF_Init_Par.effectId = EffectConst.EF_ENTRY;
 				EffectManager.spam(EF_Init_Par);
 			} else {


### PR DESCRIPTION
The entry effect (EF_ENTRY/EF_ENTRY2) was incorrectly triggered for STANDENTRY packets instead of NEWENTRY packets. This caused characters to appear with a teleport effect when simply walking into view range.

Based on rAthena/AEGIS packet semantics:
- STANDENTRY: Entity is standing idle when you move into their view
- NEWENTRY: Entity spawned/teleported/logged in (actual appearance)
- MOVEENTRY: Entity is walking when encountered

The entry effect should only play for NEWENTRY (actual spawns/teleports), not STANDENTRY (you walked into their view) or MOVEENTRY (they walked into your view).

Also updated PACKETVER threshold from 20030715 to 20090922 for EF_ENTRY vs EF_ENTRY2, based on when these packets were introduced:
- 20090921: ZC_NOTIFY_STANDENTRY4
- 20091111: ZC_NOTIFY_STANDENTRY5
- 20100308: ZC_NOTIFY_STANDENTRY6