### PR TITLE
fix: use Session entity types on mobile ui and Shorten fadein/out effect

### DIFF
--- a/src/UI/Background.js
+++ b/src/UI/Background.js
@@ -252,12 +252,12 @@ define( function( require )
 			.stop()
 			.css( 'opacity', 0.01 )
 			.appendTo('body')
-			.animate({ opacity: 1.0 }, 500, function(){
+			.animate({ opacity: 1.0 }, 150, function(){
 				callback();
 
 				_overlay
 					.stop()
-					.animate({ opacity: 0.01 }, 500, function(){
+					.animate({ opacity: 0.01 }, 150, function(){
 						_overlay.remove();
 					});
 			});

--- a/src/UI/Components/MobileUI/MobileUI.js
+++ b/src/UI/Components/MobileUI/MobileUI.js
@@ -438,11 +438,10 @@ define(function (require) {
 	 */
 	function autoTarget() {
 		var Player = Session.Entity;
-		var Entity = Player.constructor;
 
 		var entityFocus = EntityManager.getFocusEntity();
 
-		var closestEntity = EntityManager.getClosestEntity(Player, Entity.TYPE_MOB);
+		var closestEntity = EntityManager.getClosestEntity(Player, Session.Entity.constructor.TYPE_MOB);
 
 		if (closestEntity) {
 
@@ -534,7 +533,7 @@ define(function (require) {
 		}
 
 		// Find the nearest item
-		const closestItem = EntityManager.getClosestEntity(player, EntityManager.TYPE_ITEM);
+		const closestItem = EntityManager.getClosestEntity(player, Session.Entity.constructor.TYPE_ITEM);
 
 		if (!closestItem) {
 			return;


### PR DESCRIPTION
- Reduce overlay fade durations from 500ms to 150ms to speed up UI transitions.
- In MobileUI, use Session.Entity.constructor.TYPE_MOB and Session.Entity.constructor.TYPE_ITEM for closest-entity lookups