### PR TITLE
Fix getMapName crash when lastMap is undefined

### DIFF
--- a/src/DB/DBManager.js
+++ b/src/DB/DBManager.js
@@ -4949,6 +4949,9 @@ define(function (require) {
 	 * @return {string} map location
 	 */
 	DB.getMapName = function getMapName(mapname, defaultName) {
+		if (!mapname) {
+			return (typeof defaultName === 'undefined' ? DB.getMessage(187) : defaultName);
+		}
 		var map = mapname.replace('.gat', '.rsw');
 
 		if (!(map in MapTable) || !MapTable[map].name) {

--- a/src/UI/Components/CharSelect/CharSelect/CharSelect.js
+++ b/src/UI/Components/CharSelect/CharSelect/CharSelect.js
@@ -463,7 +463,7 @@ define(function(require)
 		$charinfo.find('.exp').text( info.exp );
 		$charinfo.find('.hp').text( info.hp );
 		$charinfo.find('.sp').text( info.sp );
-		$charinfo.find('.map').text( DB.getMapName( (info.lastMap || '').replace('.gat','.rsw') ) );
+		$charinfo.find('.map').text( DB.getMapName(info.lastMap, '') || '' );
 		$charinfo.find('.str').text( info.Str );
 		$charinfo.find('.agi').text( info.Agi );
 		$charinfo.find('.vit').text( info.Vit );


### PR DESCRIPTION
Older CHARACTER_INFO formats (blockSize < 124) don't include lastMap. getMapName() called .replace() on undefined, causing a TypeError.

- Add null guard in DB.getMapName for undefined/empty mapname
- CharSelect V1: pass default '' like V2/V3/V4 already do