### PR TITLE
fix: 3d effects respecting depth

### DIFF
--- a/src/DB/Effects/EffectTable.js
+++ b/src/DB/Effects/EffectTable.js
@@ -2509,6 +2509,7 @@ define(function( require )
 			size: 35,      // widthSize 3.5f
 			toSrc: true,   // PT3DTEX_CHKTARGETPOS
 			blendMode: 2,  // RF_EMISSIVE (Aprox. Additive)
+			overlay: true,
 			alphaMax: 0.66 // 170/255 on C++
 		},{
 			type: '3D',
@@ -2524,6 +2525,7 @@ define(function( require )
 			duration: 200,  // Aprox. 20 frames on C++
 			size: 45,       // widthSize 4.5f
 			toSrc: true,   // PT3DTEX_CHKTARGETPOS
+			overlay: true,
 			blendMode: 2  // RF_EMISSIVE (Aprox. Additive)
 		}],
 
@@ -2537,6 +2539,7 @@ define(function( require )
 			blendMode: 2,   // RF_EMISSIVE (Aprox. Additive)
 			rotateToTarget: true, 
 			fadeOut: true,
+			overlay: true,
 			attachedEntity: true
 		},{
 			type: '3D',
@@ -2551,6 +2554,7 @@ define(function( require )
 			duration: 300, // duration 300 on C++ is equal to 3000ms on ROB but it's the total duration of all hits, ROB parse each
 			size: 75,       // widthSize 7.5f * 10
 			blendMode: 2,   // RF_EMISSIVE (Aprox. Additive)
+			overlay: true,
 			attachedEntity: true
 		}],
 
@@ -6981,6 +6985,7 @@ define(function( require )
 			blendMode: 2,   // RF_EMISSIVE (Aprox. Additive)
 			rotateToTarget: true, 
 			fadeOut: true,
+			overlay: true,
 			attachedEntity: true
 		},{
 			type: '3D',
@@ -6995,6 +7000,7 @@ define(function( require )
 			duration: 300, // duration 300 on C++ is equal to 3000ms on ROB but it's the total duration of all hits, ROB parse each
 			size: 75,       // widthSize 7.5f * 10
 			blendMode: 2,   // RF_EMISSIVE (Aprox. Additive)
+			overlay: true,
 			attachedEntity: true
 		}],
 

--- a/src/Renderer/Effects/SpiritSphere.js
+++ b/src/Renderer/Effects/SpiritSphere.js
@@ -242,7 +242,6 @@ define(function( require ) {
 
         gl.vertexAttribPointer( attribute.aPosition,     2, gl.FLOAT, false, 4*4,  0   );
         gl.vertexAttribPointer( attribute.aTextureCoord, 2, gl.FLOAT, false, 4*4,  2*4 );
-        gl.depthMask(true);
     };
 
     SpiritSphere.prototype.render = function render( gl, tick )

--- a/src/Renderer/Effects/ThreeDEffect.js
+++ b/src/Renderer/Effects/ThreeDEffect.js
@@ -59,6 +59,9 @@ function (WebGL, Client, SpriteRenderer, EntityManager, Altitude, Camera) {
 			}
 		}
 
+		// When true, draw as an overlay: no depth test and no ray-plane correction.
+		this.overlay = effect.overlay ? true : false;
+
 		this.alphaMax = (!isNaN(effect.alphaMax)) ? Math.max(Math.min(effect.alphaMax, 1), 0) : 1;
 		this.alphaMax = Math.max(Math.min(this.alphaMax + (!isNaN(effect.alphaMaxDelta) ? effect.alphaMaxDelta * EF_Inst_Par.duplicateID : 0), 1), 0);
 
@@ -640,14 +643,18 @@ function (WebGL, Client, SpriteRenderer, EntityManager, Altitude, Camera) {
 					renderer.offset[1] = layer.pos[1] + ctE[1];
 					renderer.size[0] = width;
 					renderer.size[1] = height;
-					SpriteRenderer.setDepth(false, false, true, function(){
-						renderer.render();
+
+					// default true, false, false
+					SpriteRenderer.setDepth(this.overlay === false, false, this.overlay === true, function(){
+						SpriteRenderer.render();
 					});
+
 					++i;
 				} while (i < layercount);
 			}
 		} else {
-			SpriteRenderer.setDepth(false, false, true, function(){
+			// default true, false, false
+			SpriteRenderer.setDepth(this.overlay === false, false, this.overlay === true, function(){
 				SpriteRenderer.render();
 			});
 		}

--- a/src/Renderer/Effects/TwoDEffect.js
+++ b/src/Renderer/Effects/TwoDEffect.js
@@ -554,6 +554,7 @@ function (WebGL, Texture, glMatrix, Client, SpriteRenderer, EntityManager, Camer
 			SpriteRenderer.angle = angle;
 		} else SpriteRenderer.angle = this.angle;
 
+		// default true, true, false
 		SpriteRenderer.setDepth(this.overlay === false, this.overlay === false, this.overlay === true, function(){
 			SpriteRenderer.render();
 		});			

--- a/src/Renderer/Entity/EntityRender.js
+++ b/src/Renderer/Entity/EntityRender.js
@@ -249,7 +249,7 @@ define(function (require) {
 				});
 			}
 
-			var canWriteDepth = self.objecttype === Entity.TYPE_PC || self.objecttype === Entity.TYPE_MOB || self.objecttype === Entity.TYPE_NPC || self.objecttype === Entity.TYPE_MERC;
+			var canWriteDepth = self.objecttype === Entity.TYPE_PC || self.objecttype === Entity.TYPE_MERC;
 
 			SpriteRenderer.setDepth(true, canWriteDepth, false, function () {
 


### PR DESCRIPTION
fix 3d effects respecting z-indexes wall clipping, add bypass to overlayed effects, removed sprites with no head from depth writing, cleaned depth management manual from SpiritSphere