### PR TITLE
Adds a comprehensive z-index layer-based pipeline to entity rendering.

### DIFF
--- a/src/Renderer/Entity/EntityRender.js
+++ b/src/Renderer/Entity/EntityRender.js
@@ -320,6 +320,9 @@ define(function (require) {
 						// Draw Head
 						renderElement(self, self.files.head, 'head', _position, false);
 
+						// TB_Layer_Priority = {Default_Mid = 100, Default_Top = 200, Default_Bottom = 300, Default_Robe = 400 }
+						// Values*10 reference https://github.com/zhad3/zrenderer/blob/c10b337dfb9d44e33b146551191b3398630823b5/source/sprite.d#L84
+
 						// Hat Middle
 						if (self.accessory3 > 0 && self.accessory3 !== self.accessory) { // accessory already rendered, avoid render same item again
 							SpriteRenderer.zIndex = zOffset + 100;


### PR DESCRIPTION
adds z-indexes to passes from rendering entity sprite pipeline to make it render in properly order, that simulates a 2d bilboard plan drawing passes like official does, but we uses a 3d world, we need to manage z-order if we want 3d interactions with character sprites
<img width="563" height="565" alt="image" src="https://github.com/user-attachments/assets/c769ef1c-8137-42c4-8e3f-3e4c46db49a6" />

this fixes it:
<img width="239" height="287" alt="image" src="https://github.com/user-attachments/assets/9dd6e62a-caca-4528-998d-9d6f63a0940e" />
