### PR TITLE
fix(roulette): fix UI component not appended before use

### DIFF
--- a/src/Network/PacketRegister.js
+++ b/src/Network/PacketRegister.js
@@ -684,6 +684,7 @@ define(["./PacketStructure"], function (PACKET) {
 		0xa1c: PACKET.ZC.ACK_ROULETTE_INFO, // Roulette - item list
 		0xa1e: PACKET.ZC.ACK_CLOSE_ROULETTE, // Roulette - close response
 		0xa20: PACKET.ZC.ACK_GENERATE_ROULETTE, // Roulette - spin result
+		0xa22: PACKET.ZC.RECV_ROULETTE_ITEM, // Roulette - receive item result
 		0xa23: PACKET.ZC.ALL_ACH_LIST, // ?
 		0xa24: PACKET.ZC.ACH_UPDATE,
 		0xa25: PACKET.CZ.REQ_ACH_REWARD,

--- a/src/Network/PacketStructure.js
+++ b/src/Network/PacketStructure.js
@@ -15785,6 +15785,25 @@ define(['Utils/BinaryWriter', './PacketVerManager', 'Utils/Struct', 'Core/Config
 	};
 	PACKET.ZC.ACK_GENERATE_ROULETTE.size = 21;
 
+	// 0xA21 - CZ_RECV_ROULETTE_ITEM (request to receive roulette item)
+	PACKET.CZ.RECV_ROULETTE_ITEM = function PACKET_CZ_RECV_ROULETTE_ITEM() {
+		this.condition = 0; // 0 = normal, 1 = losing
+	};
+	PACKET.CZ.RECV_ROULETTE_ITEM.prototype.build = function() {
+		var pkt_len = 3;
+		var pkt_buf = new BinaryWriter(pkt_len);
+		pkt_buf.writeShort(0x0a21);
+		pkt_buf.writeUChar(this.condition);
+		return pkt_buf;
+	};
+
+	// 0xA22 - ZC_RECV_ROULETTE_ITEM (receive roulette item result)
+	PACKET.ZC.RECV_ROULETTE_ITEM = function PACKET_ZC_RECV_ROULETTE_ITEM(fp, end) {
+		this.result = fp.readUChar();           // 1 byte - Result (0=success, 1=failed, 2=overcount, 3=overweight)
+		this.additionItemID = fp.readUShort();  // 2 bytes - AdditionItemID
+	};
+	PACKET.ZC.RECV_ROULETTE_ITEM.size = 5;
+
 
 	/**
 	 * Export

--- a/src/UI/Components/Roulette/Roulette.js
+++ b/src/UI/Components/Roulette/Roulette.js
@@ -441,6 +441,30 @@ define(function(require)
 
 
 	/**
+	 * Handle item received from server
+	 */
+	Roulette.onItemReceived = function onItemReceived(pkt)
+	{
+		// Update UI to show item was received
+		Roulette.updateUI();
+		
+		// Optionally show a notification
+		// ChatBox.addText( 'Roulette item received!', ChatBox.TYPE.INFO, ChatBox.FILTER.PUBLIC_LOG );
+	};
+
+
+	/**
+	 * Request to receive the roulette item
+	 */
+	Roulette.requestReceiveItem = function requestReceiveItem(condition)
+	{
+		var pkt = new PACKET.CZ.RECV_ROULETTE_ITEM();
+		pkt.condition = condition || 0; // 0 = normal, 1 = losing
+		Network.sendPacket(pkt);
+	};
+
+
+	/**
 	 * Export
 	 */
 	return UIManager.addComponent(Roulette);


### PR DESCRIPTION
- Add Roulette.append() check before calling onOpen, onRouletteInfo, onGenerateRoulette
- Add missing packets 0xA21 (CZ_RECV_ROULETTE_ITEM) and 0xA22 (ZC_RECV_ROULETTE_ITEM)
- Register ZC_RECV_ROULETTE_ITEM in PacketRegister
- Add onRecvRouletteItem handler in MapEngine/Roulette
- Add onItemReceived and requestReceiveItem functions in UI component

Fixes: Cannot read properties of undefined (reading show) error when server sends ZC_ACK_OPEN_ROULETTE packet