### PR TITLE
Potential fix for code scanning alert no. 385: Conflicting function declarations

### DIFF
--- a/src/UI/Components/Storage/StorageV3/Storage.js
+++ b/src/UI/Components/Storage/StorageV3/Storage.js
@@ -370,39 +370,6 @@ define(function (require) {
 		function resizing() {
 			var extraY = 31 + 19 - 30;
 			var h = Math.floor((Mouse.screen.y - top - extraY) / 32);
-
-			// Maximum and minimum window size
-			h = Math.min(Math.max(h, 8), 17);
-
-			if (h === lastHeight) {
-				return;
-			}
-
-			resizeHeight(h);
-			lastHeight = h;
-		}
-
-		// Start resizing
-		_Interval = setInterval(resizing, 30);
-
-		// Stop resizing on left click
-		jQuery(window).on('mouseup.resize', function (event) {
-			if (event.which === 1) {
-				clearInterval(_Interval);
-				jQuery(window).off('mouseup.resize');
-			}
-		});
-	}1
-
-	function onResize() {
-		var ui = Storage.ui;
-		var top = ui.position().top;
-		var lastHeight = 0;
-		var _Interval;
-
-		function resizing() {
-			var extraY = 31 + 19 - 30;
-			var h = Math.floor((Mouse.screen.y - top - extraY) / 32);
 			h = Math.min(Math.max(h, 8), 17);
 			if (h === lastHeight) return;
 			resizeHeight(h);


### PR DESCRIPTION
duplicated functions

Potential fix for [https://github.com/AoShinRO/roBrowserLegacy/security/code-scanning/385](https://github.com/AoShinRO/roBrowserLegacy/security/code-scanning/385)

In general, to fix conflicting function declarations in the same scope, you either remove the redundant declaration if they are duplicates, or rename one of them (or convert them to function expressions assigned to different variables) if they are intended to be different. The goal is that each function name refers to exactly one implementation in the scope.

Here, both stopPropagation functions are identical, and both onResize functions do the same thing, with just comment/formatting differences. The cleanest way to fix this without changing functionality is to keep one canonical implementation of each function and delete the duplicate block. Since the second onResize and stopPropagation are more compact but semantically equivalent to the first implementations, we should remove the entire first block (lines 359–395), including the stray 1 at the end, and keep the second definitions (lines 397–424). This preserves current runtime behavior (the code that the engine currently uses) while eliminating the conflicting declarations and the obvious artifact.

Concretely:

In src/UI/Components/Storage/StorageV3/Storage.js, delete the first stopPropagation function, the first onResize function (with its nested resizing), and the stray 1 immediately after the closing brace of the first onResize.
Leave the later stopPropagation and onResize implementations as they are.
No new methods, imports, or external definitions are needed; we are only removing duplicated code.
