### PR TITLE
Potential fix for code scanning alert no. 395: Overwritten property

### DIFF
--- a/src/DB/Effects/EffectTable.js
+++ b/src/DB/Effects/EffectTable.js
@@ -11431,11 +11431,6 @@ define(function( require )
 			}
 		}],
 
-		'ef_great_echo': [{
-			wav: 'effect/\xbc\xa8\xc5\xcd\xbd\xba\xc5\xe8',
-			attachedEntity: true
-		}],
-
 		'ef_magicpower': [{
 			wav: 'effect/\xb8\xb6\xb9\xfd\xb7\xc2\x20\xc1\xf5\xc6\xf8',
 			attachedEntity: true


### PR DESCRIPTION
Potential fix for [https://github.com/AoShinRO/roBrowserLegacy/security/code-scanning/395](https://github.com/AoShinRO/roBrowserLegacy/security/code-scanning/395)

Generally, this problem is fixed by ensuring that each property key in an object literal is unique—either by removing the unused duplicate definition or by renaming one of the keys if both configurations must be accessible.

For this specific case in `src/DB/Effects/EffectTable.js`, the safest change that does not alter existing runtime behavior is to remove the earlier `'ef_great_echo'` entry at lines 11434–11437, because at present the later entry at 11720–11723 is what actually takes effect. Keeping the later one preserves the current behavior of any code that looks up `effects['ef_great_echo']`. We should delete the earlier block:

```js
		'ef_great_echo': [{
			wav: 'effect/\xbc\xa8\xc5\xcd\xbd\xba\xc5\xe8',
			attachedEntity: true
		}],
```

and leave the later `'ef_great_echo'` entry untouched. No new imports, methods, or other definitions are required; this is a straightforward removal.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
