### PR TITLE
Potential fix for code scanning alert no. 616: Unused loop iteration variable

### DIFF
--- a/src/UI/Components/WorldMap/WorldMap.js
+++ b/src/UI/Components/WorldMap/WorldMap.js
@@ -603,7 +603,7 @@ define(function (require) {
         });
 
         WorldMap.ui.find('.worldmap .section').removeClass('membersonmap');
-        for (const [mapId, members] of Object.entries(_partyMembersByMap)) {
+        for (const mapId of Object.keys(_partyMembersByMap)) {
             WorldMap.ui.find('.worldmap .section#' + mapId).addClass('membersonmap');
         }
     };


### PR DESCRIPTION
In general, to fix an unused loop iteration variable, either use the variable as intended in the loop body, or stop binding it (or rename it to something like _ if you explicitly want to show it is unused). Here, the code never uses the members array inside the loop; the class is added per mapId only. The safest fix without changing functionality is to only iterate over the keys of _partyMembersByMap instead of destructuring key and value.

Concretely, in src/UI/Components/WorldMap/WorldMap.js around line 606, replace:

for (const [mapId, members] of Object.entries(_partyMembersByMap)) {
    WorldMap.ui.find('.worldmap .section#' + mapId).addClass('membersonmap');
}
with a loop that only binds the mapId, for example:

for (const mapId of Object.keys(_partyMembersByMap)) {
    WorldMap.ui.find('.worldmap .section#' + mapId).addClass('membersonmap');
}
No new imports, methods, or definitions are needed; this simply removes the unused variable and keeps the observable behavior the same.