### PR TITLE
Potential fix for code scanning alert no. 597: Useless conditional

### DIFF
--- a/src/UI/Components/Inventory/InventoryV3/InventoryV3.js
+++ b/src/UI/Components/Inventory/InventoryV3/InventoryV3.js
@@ -1346,10 +1346,8 @@ define(function(require)
 		}
 
 		// If item is present, send request to client
-		if (itemforexpand) {
-			var pkt = new PACKET.CZ.REQ_OPEN_MSGBOX_EXTEND_BODYITEM_SIZE();
-			Network.sendPacket(pkt);
-		}
+		var pkt = new PACKET.CZ.REQ_OPEN_MSGBOX_EXTEND_BODYITEM_SIZE();
+		Network.sendPacket(pkt);
 	};
 
 


### PR DESCRIPTION
the variable item is already validated with if (!itemforexpand) { return false; }