### PR TITLE
Potential fix for code scanning alert no. 600: Useless conditional

### DIFF
--- a/src/UI/Components/LaphineSys/LaphineSys.js
+++ b/src/UI/Components/LaphineSys/LaphineSys.js
@@ -395,9 +395,7 @@ define(function(require)
 			return false; // Exit the function early
 		}
 
-        if (item) {
-			onUpdateSubmitList(item);
-        }
+		onUpdateSubmitList(item);
 	};
 
 


### PR DESCRIPTION
In general, to fix a “useless conditional” where a variable is already known to be truthy/falsey, you either (a) remove the redundant if and execute the body unconditionally, or (b) remove the dead branch entirely if it’s never taken. Here, item is already validated at lines 724–727, so the if (item) condition at line 745 adds no extra safety.
<img width="750" height="786" alt="image" src="https://github.com/user-attachments/assets/e50ef76e-889d-4e5c-be5e-d5dfa530c370" />
