### PR TITLE
Potential fix for code scanning alert no. 588: Useless conditional

### DIFF
--- a/src/Engine/MapEngine/Entity.js
+++ b/src/Engine/MapEngine/Entity.js
@@ -613,20 +613,19 @@ define(function (require) {
 					target = pkt.damage ? dstEntity : srcEntity;
 
 					// damage or miss display
-					if (target) {
-						if (dstEntity.objecttype === Entity.TYPE_MOB || dstEntity.objecttype === Entity.TYPE_NPC_ABR || dstEntity.objecttype === Entity.TYPE_NPC_BIONIC) {
-							if (pkt.damage > 0) {
-								var EF_Init_Par = {
-									effectId: EffectConst.EF_HIT1,
-									ownerAID: pkt.targetGID,
-									startTick: Renderer.tick + pkt.attackMT,
-								};
-								EffectManager.spam(EF_Init_Par);
-							}
+					if (dstEntity.objecttype === Entity.TYPE_MOB || dstEntity.objecttype === Entity.TYPE_NPC_ABR || dstEntity.objecttype === Entity.TYPE_NPC_BIONIC) {
+						if (pkt.damage > 0) {
+							var EF_Init_Par = {
+								effectId: EffectConst.EF_HIT1,
+								ownerAID: pkt.targetGID,
+								startTick: Renderer.tick + pkt.attackMT,
+							};
+							EffectManager.spam(EF_Init_Par);
 						}
+					}
 
-						var type = null;
-						switch (pkt.action) {
+					var type = null;
+					switch (pkt.action) {
 
 							// Single damage
 							case 10: // critical
@@ -683,7 +682,6 @@ define(function (require) {
 								});
 								break;
 
-						}
 					}
 				}
 


### PR DESCRIPTION
In general, to fix a useless conditional where a variable is always truthy, you either (a) change the condition to test what you actually care about (e.g., a property, a length, or a null check), or (b) remove the conditional and execute the inner block unconditionally if it is indeed always intended to run.

Here, target is always one of two entity objects and is always truthy when this block executes. The surrounding logic already ensures dstEntity exists (if (dstEntity) { ... }), and we are using srcEntity methods directly, so there is no meaningful case where target would be falsy. The simplest fix that does not alter behavior is to remove the if (target) wrapper and keep its body directly in the if (dstEntity) block, leaving the assignment to target intact (since target is likely used later in the omitted lines). Concretely, in src/Engine/MapEngine/Entity.js, around lines 613–687, delete the if (target) { line and its matching closing brace, and outdent the enclosed logic by one level. No new imports, methods, or definitions are required.

<img width="434" height="141" alt="image" src="https://github.com/user-attachments/assets/74a7a35f-302b-4c03-ad3b-fabdeb475ea5" />
<img width="608" height="676" alt="image" src="https://github.com/user-attachments/assets/0b7cbbf0-f46b-4106-b220-b7a93043d188" />
