### PR TITLE
adds vscode auto-format info to GLSL

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,12 @@
 {  
-    "files.associations": {  
-        "*.vs": "glsl",  
-        "*.fs": "glsl",  
-        "*.vert": "glsl",  
-        "*.frag": "glsl"  
-    }  
+	"files.associations": {
+		"*.vs": "glsl",
+		"*.fs": "glsl",
+		"*.vert": "glsl",
+		"*.frag": "glsl"
+	},
+	"[glsl]": {
+		"editor.tabSize": 4,
+		"editor.insertSpaces": true
+	}
 }


### PR DESCRIPTION
tip to reformat a document without 3rdparty extension:
CTRL+A, Tab, Shift Tab