### PR TITLE
Buying Store Packet Fix

### DIFF
--- a/src/Network/PacketStructure.js
+++ b/src/Network/PacketStructure.js
@@ -10605,15 +10605,17 @@ define(['Utils/BinaryWriter', './PacketVerManager', 'Utils/Struct', 'Core/Config
 		this.AID = fp.readULong();
 		this.UniqueID = fp.readULong();
 		this.limitZeny = fp.readLong();
+
+		let itemSize = (PACKETVER.value >= 20181121 ? 11 : 9);
 		this.itemList = (function() {
-			var i, count = (end - fp.tell()) / 9 | 0,
+			var i, count = (end - fp.tell()) / itemSize | 0,
 				out = new Array(count);
 			for (i = 0; i < count; ++i) {
 				out[i] = {};
 				out[i].price = fp.readLong();
 				out[i].count = fp.readShort();
 				out[i].type = fp.readUChar();
-				out[i].ITID = fp.readUShort();
+				out[i].ITID = (PACKETVER.value >= 20181121 ? fp.readULong() : fp.readUShort());
 			}
 			return out;
 		})();


### PR DESCRIPTION
Added missing packet size changes based on PACKETVER value for PACKET.ZC.ACK_ITEMLIST_BUYING_STORE

Fixes https://github.com/MrAntares/roBrowserLegacy/issues/863

<img width="1403" height="383" alt="Screenshot 2026-02-07 203740" src="https://github.com/user-attachments/assets/e35e7a3a-caf0-446d-8cc7-1ba7be55f3d6" />
