### PR TITLE
fix: load guild emblem for the player's own entity

### DIFF
--- a/src/Engine/MapEngine/Entity.js
+++ b/src/Engine/MapEngine/Entity.js
@@ -177,11 +177,12 @@ define(function (require) {
 			EntityManager.add(entity.wug);
 		}
 
-		if (entity.GUID && entity !== Session.Entity) {
+		if (entity.GUID) {
 			Guild.requestGuildEmblem(entity.GUID, entity.GEmblemVer, function (image) {
 				entity.display.emblem = image;
 				entity.emblem.emblem = image;
 				entity.emblem.update();
+				entity.display.refresh(entity);
 
 				if (Session.mapState.isSiege && entity.GUID !== Session.Entity.GUID) {
 					entity.emblem.display = true;
@@ -1029,7 +1030,7 @@ define(function (require) {
 
 			entity.display.load = entity.display.TYPE.COMPLETE;
 
-			if (entity.GUID && entity !== Session.Entity) {
+			if (entity.GUID) {
 				Guild.requestGuildEmblem(entity.GUID, entity.GEmblemVer, function (image) {
 					entity.display.emblem = image;
 					entity.display.update(

--- a/src/Engine/MapEngine/Guild.js
+++ b/src/Engine/MapEngine/Guild.js
@@ -549,6 +549,16 @@ define(function (require) {
 
 		Session.Entity.GUID = pkt.GDID;
 		Session.Entity.GEmblemVer = pkt.emblemVersion;
+
+		// Request emblem for the player's own entity
+		if (pkt.GDID && pkt.emblemVersion) {
+			GuildEngine.requestGuildEmblem(pkt.GDID, pkt.emblemVersion, function (image) {
+				Session.Entity.display.emblem = image;
+				Session.Entity.emblem.emblem = image;
+				Session.Entity.emblem.update();
+				Session.Entity.display.refresh(Session.Entity);
+			});
+		}
 	}
 
 	/**


### PR DESCRIPTION
Previously, the guild emblem was only requested for other entities, excluding the local player (Session.Entity). This caused the player to never see their own guild emblem displayed.

Remove the `entity !== Session.Entity` check in Entity.js to allow emblem loading for all entities, and add an explicit emblem request in Guild.js when the player receives their guild data. Also call display.refresh() to ensure the visual update is applied immediately.

