### PR TITLE
fix: Show complete skill tree in mini mode

### DIFF
--- a/src/UI/Components/SkillList/SkillList/SkillList.js
+++ b/src/UI/Components/SkillList/SkillList/SkillList.js
@@ -285,13 +285,11 @@ define(function (require) {
 			var element = '<div class="counterSkill">' + count + '</div>';
 			skillPosition.forEach(function (items, list) {
 				if (items[skillId] !== undefined) {
-					if (!_preferences.mini) {
-						var skillbox = SkillList.ui.find('#positionSkills' + list + ' .s' + items[skillId]);
-						if (skillbox.children().hasClass('disabled') || showAll) {
-							skillbox.addClass('needleSkill');
-							if (count !== null) {
-								skillbox.append(element);
-							}
+					var skillbox = SkillList.ui.find('#positionSkills' + list + ' .s' + items[skillId]);
+					if (skillbox.children().hasClass('disabled') || showAll) {
+						skillbox.addClass('needleSkill');
+						if (count !== null) {
+							skillbox.append(element);
 						}
 					}
 				}
@@ -503,6 +501,35 @@ define(function (require) {
 					// show preview skill
 					if (box.is(':empty')) {
 						box.append(element);
+					}
+					var miniBox = SkillList.ui.find('#minitab' + list);
+					if (miniBox.length && !miniBox.find('.skill.id' + key).length) {
+						var miniElement = jQuery(
+							'<tr class="skill id' +
+								key +
+								' disabled" data-index="' +
+								key +
+								'">' +
+								'<td class="icon"><img src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" width="24" height="24" /></td>' +
+								'<td class="levelupcontainer"></td>' +
+								'<td class="selectable">' +
+								'<div class="name">' +
+								jQuery.escape(sk.SkillName) +
+								'<br/>' +
+								'<span class="level">Lv : <span class="current">0</span></span>' +
+								'</div>' +
+								'</td>' +
+								'<td class="selectable type">' +
+								'<div class="consume">Passive</div>' +
+								'</td>' +
+								'</tr>'
+						);
+
+						miniBox.append(miniElement);
+
+						Client.loadFile(DB.INTERFACE_PATH + 'item/' + sk.Name + '.bmp', function (data) {
+							miniElement.find('.icon img').attr('src', data);
+						});
 					}
 				}
 
@@ -1041,21 +1068,19 @@ define(function (require) {
 	 */
 	function onResetChoice() {
 		rememberChoice.forEach(function (count, skillId) {
-			if (!_preferences.mini) {
-				var skillbox = SkillList.ui.find('.skillCol.s' + skillDependencyTree[skillId].position);
-				if (!hasSkills?.[skillId]?.level) {
-					skillbox.children().addClass('disabled');
-				}
-				skillbox.find('.selectable').show();
-				skillbox
-					.find('.current')
-					.empty()
-					.append(hasSkills?.[skillId]?.level ?? 0);
-				skillbox
-					.find('.max')
-					.empty()
-					.append(hasSkills?.[skillId]?.level ?? 0);
+			var skillbox = SkillList.ui.find('.skillCol.s' + skillDependencyTree[skillId].position);
+			if (!hasSkills?.[skillId]?.level) {
+				skillbox.children().addClass('disabled');
 			}
+			skillbox.find('.selectable').show();
+			skillbox
+				.find('.current')
+				.empty()
+				.append(hasSkills?.[skillId]?.level ?? 0);
+			skillbox
+				.find('.max')
+				.empty()
+				.append(hasSkills?.[skillId]?.level ?? 0);
 		});
 		totalCounter = 0;
 		SkillList.ui.find('.skpoints_count').text(_points);


### PR DESCRIPTION
In mini mode, only already-obtained skills were displayed, hiding the complete skill tree from users. This made it impossible to plan skill progression in the compact view.
before:
<img width="377" height="383" alt="image" src="https://github.com/user-attachments/assets/d8eb6be3-8c8c-49dd-b938-49429cdaaf85" />

after:
<img width="330" height="336" alt="image" src="https://github.com/user-attachments/assets/0c4be1b6-0613-4d02-87b6-f30b52ba6aef" />
official client shows all