### PR TITLE
Add tooltips to advanced graphics settings for better user experience

### DIFF
--- a/src/UI/Components/GraphicsOption/GraphicsOption.html
+++ b/src/UI/Components/GraphicsOption/GraphicsOption.html
@@ -91,7 +91,9 @@
 		<div class="tab-content" id="advanced">
 			<table>
 				<tr>
-					<td>Pixel Perfect Sprites</td>
+					<td title="Force nearest neighbor filtering for pixel-perfect sprite rendering">
+						Pixel Perfect Sprites
+					</td>
 					<td>
 						<label>
 							<input class="pixel-perfect" type="checkbox" />
@@ -100,7 +102,7 @@
 					</td>
 				</tr>
 				<tr>
-					<td>Bloom</td>
+					<td title="Add a glowing bloom effect to bright areas">Bloom</td>
 					<td>
 						<label style="display: inline-block; margin-right: 20px">
 							<input class="bloom" type="checkbox" />
@@ -120,7 +122,7 @@
 					</td>
 				</tr>
 				<tr>
-					<td>Blur</td>
+					<td title="Apply a blur effect to the screen">Blur</td>
 					<td>
 						<label style="display: inline-block; margin-right: 20px">
 							<input class="blur" type="checkbox" />
@@ -152,7 +154,7 @@
 					</td>
 				</tr>
 				<tr>
-					<td>Contr. Adapt. Sharp. (CAS)</td>
+					<td title="Contrast Adaptive Sharpening for enhanced details">Contr. Adapt. Sharp. (CAS)</td>
 					<td>
 						<label style="display: inline-block; margin-right: 20px">
 							<input class="casEnabled" type="checkbox" />
@@ -184,7 +186,7 @@
 					</td>
 				</tr>
 				<tr>
-					<td>FXAA</td>
+					<td title="Fast Approximate Anti-Aliasing for smoother edges">FXAA</td>
 					<td>
 						<label style="display: inline-block; margin-right: 20px">
 							<input class="fxaaEnabled" type="checkbox" />
@@ -216,7 +218,7 @@
 					</td>
 				</tr>
 				<tr>
-					<td>Cartoon</td>
+					<td title="Cartoon rendering effect for stylized visuals">Cartoon</td>
 					<td>
 						<label style="display: inline-block; margin-right: 20px">
 							<input class="cartoonEnabled" type="checkbox" />
@@ -248,7 +250,7 @@
 					</td>
 				</tr>
 				<tr>
-					<td>Vibrance</td>
+					<td title="Increase color intensity and saturation">Vibrance</td>
 					<td>
 						<label style="display: inline-block; margin-right: 20px">
 							<input class="vibranceEnabled" type="checkbox" />
@@ -268,7 +270,7 @@
 					</td>
 				</tr>
 				<tr>
-					<td>Culling</td>
+					<td title="Hide objects outside the viewing area to improve performance">Culling</td>
 					<td>
 						<label style="display: inline-block; margin-right: 20px">
 							<input class="culling" type="checkbox" />


### PR DESCRIPTION
This PR adds descriptive tooltips (title attributes) to all graphics options in the Advanced tab of the Graphics Settings panel. When users hover over option labels like "Pixel Perfect Sprites", "Bloom", "Blur", etc., they will now see helpful explanations of what each setting does. This improves discoverability and understanding of the various post-processing and performance options available.