### PR TITLE
fix: reorder z-indexes again

### DIFF
--- a/src/Renderer/Entity/EntityRender.js
+++ b/src/Renderer/Entity/EntityRender.js
@@ -308,28 +308,27 @@ define(function (require) {
 									: self.CartNum;
 
 								// Draw Cart
-								SpriteRenderer.zIndex = -1;
-								renderElement(self, self.files.cart_shadow, 'cartshadow', _position, false);
-								SpriteRenderer.zIndex = 100;
 								SpriteRenderer.runWithDepth(true, false, false, function () {
+									SpriteRenderer.zIndex = -1;
+									renderElement(self, self.files.cart_shadow, 'cartshadow', _position, false);
+									SpriteRenderer.zIndex = 1;
 									renderElement(self, self.files.cart[cartidx], 'cart', _position, false);
 								});
 							}
 
 							// Draw Robe
 							if (self.robe > 0) {
-								SpriteRenderer.zIndex = 150;
+								SpriteRenderer.zIndex = -200;
 								renderElement(self, self.files.robe, 'robe', _position, true);
 							}
 						}
 
-						SpriteRenderer.zIndex = 1000;
+						SpriteRenderer.zIndex = 150;
 						// Draw Body
 						renderElement(self, self.files.body, 'body', _position, true);
 
 						// Isometric Projection Body Offset
-						var zOffset = 1100;
-
+						var zOffset = 250;
 						SpriteRenderer.zIndex = zOffset + 50;
 
 						// Draw Head
@@ -403,7 +402,7 @@ define(function (require) {
 					break;
 				default:
 					SpriteRenderer.position[2] = SpriteRenderer.position[2] + 0.2;
-					SpriteRenderer.zIndex = 1000;
+					SpriteRenderer.zIndex = 150;
 					// Non-player entities:
 					// - Do not write depth to avoid breaking PC occlusion and internal layer issues
 					// - Still use depth test for correct ordering

--- a/src/Renderer/MapRenderer.js
+++ b/src/Renderer/MapRenderer.js
@@ -426,9 +426,6 @@ define(function (require) {
 		Models.render(gl, modelView, projection, normalMat, fog, light);
 		AnimatedModels.render(gl, modelView, projection, normalMat, fog, light, tick);
 
-		// Rendering water (before sprites due cloaks and cart can't overdraw them when looking front)
-		Water.render(gl, modelView, projection, fog, light, tick);
-
 		if (Mouse.intersect && Altitude.intersect(modelView, projection, _pos)) {
 			x = _pos[0];
 			y = _pos[1];
@@ -470,6 +467,9 @@ define(function (require) {
 
 		//Render Entities (no effects)
 		EntityManager.render(gl, modelView, projection, fog, false);
+
+		// Rendering water (after sprites, billboard projection pushes it to back)
+		Water.render(gl, modelView, projection, fog, light, tick);
 
 		// Rendering effects
 		Damage.render(gl, modelView, projection, fog, tick);


### PR DESCRIPTION
to fix recently bug found on behind model behavior:
<img width="267" height="380" alt="image" src="https://github.com/user-attachments/assets/6790062d-b938-4184-96d1-711c40ca7841" />

and evade old bug founds like:
<img width="231" height="227" alt="image" src="https://github.com/user-attachments/assets/def5e7c1-125b-4d2b-8c08-0f94179aea45" />
<img width="200" height="241" alt="image" src="https://github.com/user-attachments/assets/76e4da38-0002-4ae1-aad7-fabced3223b3" />

following the most close to official client behavior the result of this patch is:
<img width="350" height="414" alt="image" src="https://github.com/user-attachments/assets/2a92be55-96df-4abd-9fc4-00d10a169289" />
<img width="643" height="605" alt="image" src="https://github.com/user-attachments/assets/6af1d604-739f-4b14-9140-63a22b2cb7f0" />

behind model zoom in:
<img width="1214" height="854" alt="image" src="https://github.com/user-attachments/assets/a9647e89-296f-4865-8407-f8ce1594f7f8" />
behind model zoom out:
<img width="259" height="364" alt="image" src="https://github.com/user-attachments/assets/58d77252-55e8-4ef3-b2c1-c10f49d0d5c8" />

official client behavior:
<img width="760" height="588" alt="image" src="https://github.com/user-attachments/assets/a4347575-5ae1-4a3e-bb1b-3bf70bf7e7ea" />
<img width="577" height="481" alt="image" src="https://github.com/user-attachments/assets/756a2604-4083-4001-88c0-d5ab6c02b36a" />

and brings back the "swim" behavior:
<img width="525" height="391" alt="image" src="https://github.com/user-attachments/assets/d2735f47-3b8c-4f80-9488-9b5e08752efa" />
