### PR TITLE
feat: add Docker deployment support (slim + full images, multi-platform)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+dist
+.git
+.github
+doc
+*.md
+# Exclude all .env files at any depth
+**/.env*
+# Prevent accidentally baking Config.local.js into the image — must be mounted at runtime
+applications/pwa/Config.local.js

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,0 +1,283 @@
+# Docker Deployment
+
+roBrowserLegacy ships two Docker image variants and a unified server
+([roBrowserLegacy-RemoteClient-JS](https://github.com/FranciscoWallison/roBrowserLegacy-RemoteClient-JS))
+that handles three responsibilities in a single process:
+
+- Serving the roBrowserLegacy web client as static files
+- Serving GRF game assets over HTTP (the "Remote Client")
+- Proxying WebSocket connections to the rAthena TCP game server
+
+---
+
+## Image variants
+
+| Variant  | Tag suffix                 | Size    | GRF assets                 |
+| -------- | -------------------------- | ------- | -------------------------- |
+| **slim** | `-slim` e.g. `:1.0.0-slim` | ~400 MB | Must be mounted at runtime |
+| **full** | _(none)_ e.g. `:1.0.0`     | ~5 GB   | Baked in at build time     |
+
+> **The slim image is recommended for most deployments.**
+>
+> GRF files (`.grf`) are copyrighted by Gravity Co., Ltd. Baking them into a
+> publicly distributed Docker image would constitute redistribution of
+> copyrighted game assets, which is not permitted. The full image should only
+> be used in **private, self-hosted registries** where the image is never
+> pushed to a public registry.
+>
+> The full image is also only built when `GRF_BASE_URL`, `S3_ACCESS_KEY_ID`,
+> and `S3_SECRET_ACCESS_KEY` secrets are configured in your CI environment.
+> If these secrets are absent, only the slim image is built - the full job
+> skips gracefully with no build failure.
+
+Both variants are built from `Dockerfile.remoteclient`. Build and publish
+them to your own container registry using the instructions in
+[Building images locally](#building-images-locally) or set up a CI pipeline
+following the [CI/CD](#cicd-github-actions) section below.
+
+---
+
+## Quick start
+
+### 1. Create your server config
+
+```bash
+cp applications/pwa/Config.local.js.example Config.local.js
+```
+
+Edit `Config.local.js` - at minimum set:
+
+```js
+address:   '127.0.0.1',   // your rAthena login server IP
+port:      6900,
+packetver: 20200401,       // must match your rAthena PACKETVER
+renewal:   true,           // true = Renewal, false = Pre-renewal/Classic
+```
+
+> **`forceUseAddress: true` is critical** for any non-localhost deployment.
+> Without it, the client uses the internal IP returned by the char/map server
+> packets, which is unreachable outside the server's local network.
+
+### 2. Run the full image (GRFs baked in)
+
+```bash
+ROBROWSER_TAG=1.0.0 docker compose -f docker-compose.remoteclient.yaml up -d
+```
+
+### 3. Run the slim image (GRFs mounted from host)
+
+Uncomment the GRF volume mounts in `docker-compose.remoteclient.yaml`, set `GRF_PATH`, then:
+
+```bash
+ROBROWSER_TAG=1.0.0-slim \
+GRF_PATH="/path/to/kRO client" \
+docker compose -f docker-compose.remoteclient.yaml up -d
+```
+
+Or directly with `docker run`:
+
+```bash
+GRF="/path/to/kRO client"
+
+docker run -d --name robrowserlegacy --network host \
+  -v "${GRF}/data.grf:/app/resources/data.grf:ro" \
+  -v "${GRF}/rdata.grf:/app/resources/rdata.grf:ro" \
+  -v "${GRF}/DATA.INI:/app/resources/DATA.INI:ro" \
+  -v "${GRF}/BGM:/app/BGM:ro" \
+  -v "$(pwd)/Config.local.js:/robrowser/Config.local.js:ro" \
+  ghcr.io/<your-github-user>/robrowserlegacy:latest-slim
+```
+
+### 4. Open the game
+
+```
+http://localhost:3338/
+```
+
+---
+
+## Configuration reference
+
+`Config.local.js` is loaded by the browser at runtime and merged over the
+defaults in `src/Config.js`. Copy `applications/pwa/Config.local.js.example`
+to get started.
+
+| Field             | Description                                                                |
+| ----------------- | -------------------------------------------------------------------------- |
+| `address`         | Login server IP or hostname                                                |
+| `port`            | Login server port (default: `6900`)                                        |
+| `packetver`       | Must match rAthena `PACKETVER` (e.g. `20200401`)                           |
+| `renewal`         | `true` for Renewal, `false` for Pre-renewal/Classic                        |
+| `socketProxy`     | WebSocket proxy URL - points at this container (`ws://localhost:3338/ws/`) |
+| `remoteClient`    | GRF asset server URL - points at this container (`http://localhost:3338/`) |
+| `forceUseAddress` | **Set `true`** for any containerised or NAT deployment                     |
+| `skipIntro`       | Skip the intro video (`false` by default)                                  |
+| `skipServerList`  | Auto-select first server (`false` by default)                              |
+
+> **Remote access:** If your browser is on a different machine than the
+> container, replace `localhost` with the container host's IP or hostname in
+> `socketProxy` and `remoteClient`, and set `CLIENT_PUBLIC_URL` to the same
+> base URL when running the container.
+
+---
+
+## Networking
+
+By default the embedded WebSocket proxy only forwards to `127.0.0.1:6900`,
+`127.0.0.1:6121`, and `127.0.0.1:5121`. This means the container must be able
+to reach rAthena on localhost.
+
+**Host networking (Linux, simplest)**
+
+```bash
+docker run -d --network host ...
+```
+
+rAthena and the container share the host network stack so `127.0.0.1` works
+as-is. Not available on Docker Desktop for macOS/Windows.
+
+**Bridge networking or remote rAthena (Kubernetes, Docker Compose, macOS/Windows)**
+
+Set `WS_ALLOWED_TARGETS` to the real host:port list of your rAthena server:
+
+```bash
+docker run -d \
+  -e WS_ALLOWED_TARGETS="10.0.0.5:6900,10.0.0.5:6121,10.0.0.5:5121" \
+  -e CLIENT_PUBLIC_URL="http://<your-host>:3338" \
+  ...
+```
+
+On Docker Desktop (macOS/Windows) use the magic hostname:
+
+```bash
+-e WS_ALLOWED_TARGETS="host.docker.internal:6900,host.docker.internal:6121,host.docker.internal:5121"
+```
+
+> **Security note:** `WS_ALLOWED_TARGETS` is an explicit allowlist. Only
+> `host:port` pairs listed here can be reached through the proxy - arbitrary
+> targets are still rejected.
+
+> **Dependency note:** `WS_ALLOWED_TARGETS` support requires
+> [FranciscoWallison/roBrowserLegacy-RemoteClient-JS#14](https://github.com/FranciscoWallison/roBrowserLegacy-RemoteClient-JS/pull/14)
+> to be merged upstream. The `Dockerfile.remoteclient` in this PR will be
+> updated to pin to that commit once it is merged.
+
+### Container environment variables
+
+| Variable              | Default                    | Description                                                                               |
+| --------------------- | -------------------------- | ----------------------------------------------------------------------------------------- |
+| `PORT`                | `3338`                     | Port the server listens on                                                                |
+| `CLIENT_PUBLIC_URL`   | `http://localhost:3338`    | Public base URL of this container (used for CORS)                                         |
+| `WS_ALLOWED_TARGETS`  | _(empty - localhost only)_ | Comma-separated `host:port` list the WS proxy may forward to. See [Networking](#networking). |
+| `ENABLE_WSPROXY`      | `true`                     | Enable the embedded WebSocket proxy                                                       |
+| `ENABLE_STATIC_SERVE` | `true`                     | Serve the roBrowserLegacy web client as static files                                      |
+| `CACHE_MAX_FILES`     | `10000`                    | Max number of GRF files to keep in memory cache                                           |
+| `CACHE_MAX_MEMORY_MB` | `2048`                     | Memory budget for the GRF file cache                                                      |
+| `CACHE_WARM_UP`       | `true`                     | Pre-populate cache on startup                                                             |
+| `CACHE_WARM_UP_LIMIT` | `500`                      | Max files to pre-load during warm-up                                                      |
+
+---
+
+## Building images locally
+
+### Slim (no GRFs, ~400 MB)
+
+```bash
+docker buildx build \
+  -f Dockerfile.remoteclient \
+  --build-arg BUILD_VERSION=dev \
+  -t robrowserlegacy:dev-slim \
+  --load .
+```
+
+### Full (GRFs baked in, ~5 GB)
+
+GRF assets are fetched from a private HTTPS endpoint using
+[BuildKit secrets](https://docs.docker.com/build/building/secrets/) - they are
+never written to any image layer or visible in `docker history`.
+
+Prepare tarballs once from your kRO client directory:
+
+```bash
+KRO="/path/to/kRO client"
+tar -czf ragnarok-grfs.tar.gz -C "$KRO" data.grf rdata.grf DATA.INI
+tar -czf ragnarok-bgm.tar.gz  -C "$KRO" BGM
+# Upload both to your HTTPS host
+```
+
+Then build:
+
+```bash
+S3_ACCESS_KEY_ID=your-key \
+S3_SECRET_ACCESS_KEY=your-secret \
+GRF_BASE_URL=https://your-host/bucket/prefix \
+docker buildx build \
+  -f Dockerfile.remoteclient \
+  --build-arg BUILD_VERSION=1.0.0 \
+  --secret id=grf_base_url,env=GRF_BASE_URL \
+  --secret id=s3_access_key_id,env=S3_ACCESS_KEY_ID \
+  --secret id=s3_secret_access_key,env=S3_SECRET_ACCESS_KEY \
+  --target full \
+  -t robrowserlegacy:1.0.0 \
+  --load .
+```
+
+---
+
+## CI/CD (GitHub Actions)
+
+`docker.yml` builds and publishes both variants to GHCR on every tag push.
+
+Required repository secrets:
+
+| Secret                 | Description                           |
+| ---------------------- | ------------------------------------- |
+| `GRF_BASE_URL`         | Base HTTPS URL of the GRF asset store |
+| `S3_ACCESS_KEY_ID`     | S3/MinIO access key ID                |
+| `S3_SECRET_ACCESS_KEY` | S3/MinIO secret access key            |
+
+If the GRF secrets are absent, only the slim image is built - the full job
+skips gracefully.
+
+Trigger a build by pushing a semver tag:
+
+```bash
+git tag v1.0.0 && git push origin v1.0.0
+```
+
+Images published:
+
+```
+ghcr.io/<owner>/robrowserlegacy:1.0.0        # full, linux/amd64 + linux/arm64
+ghcr.io/<owner>/robrowserlegacy:1.0.0-slim   # slim, linux/amd64 + linux/arm64
+ghcr.io/<owner>/robrowserlegacy:latest       # full, latest tag
+ghcr.io/<owner>/robrowserlegacy:latest-slim  # slim, latest tag
+```
+
+---
+
+## What assets are needed
+
+| File        | Required | Notes                                                      |
+| ----------- | -------- | ---------------------------------------------------------- |
+| `data.grf`  | Yes      | Main game assets - textures, maps, sprites, DB tables      |
+| `rdata.grf` | Yes      | kRO-specific patches                                       |
+| `DATA.INI`  | Yes      | Tells the server which GRF files to load and in what order |
+| `BGM/`      | No       | Background music MP3s - game is silent without it          |
+
+`data/`, `System/`, and `AI/` directories from the kRO client are **not
+needed** - their contents are already inside `data.grf` for a standard
+unmodified client. Custom servers with patched loose files can mount them as
+additional volumes.
+
+---
+
+## Health check
+
+Both image variants include a `HEALTHCHECK` that polls `http://localhost:PORT/`
+every 30 seconds with a 60-second start period (to allow GRF indexing to
+complete). Use `docker ps` to monitor status:
+
+```
+robrowserlegacy   Up 2 minutes (healthy)
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,51 @@
+FROM node:20.10.0 AS builder
+
+LABEL org.opencontainers.image.description="Builds roBrowserLegacy JS bundles and HTML."
+
+USER root
+
+RUN apt-get update -y -qq && \
+    apt-get install -y -qq build-essential && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Install dependencies first (layer-cached separately from source)
+COPY package*.json ./
+RUN npm install
+
+# Copy source and build
+COPY . .
+RUN npm run build:all
+
+# Copy Config.local.js into the dist output so it's served alongside index.html.
+# NOTE: Config.local.js is excluded from the build context via .dockerignore to
+# prevent accidental secret baking. It must always be mounted at runtime.
+# See applications/pwa/Config.local.js.example for the template.
+
+# ---
+
 FROM node:20.10.0 AS dev
 
 LABEL org.opencontainers.image.description="Creates a environment to host the NodeJS and NPM environment."
 
 USER root
 
-RUN apt update -y -q && apt install build-essential -y -q && \
-  mkdir -p /app && \
-  npm install wsproxy -g
+RUN apt-get update -y -qq && \
+    apt-get install -y -qq build-essential && \
+    rm -rf /var/lib/apt/lists/* && \
+    mkdir -p /app && \
+    npm install wsproxy -g
 
 WORKDIR /app
 
 EXPOSE 8000
 
-ENTRYPOINT ["/bin/bash", "-l", "-c", "sleep", "360h"]
+# Fixed: previously was ["/bin/bash", "-l", "-c", "sleep", "360h"] which passes
+# "sleep" as the -c script and "360h" as $0, causing bash to exit immediately.
+ENTRYPOINT ["/bin/bash", "-c", "sleep 360h"]
+
+# ---
 
 FROM php:8.3-apache AS dist-server
 
@@ -23,8 +56,10 @@ WORKDIR /var/www/html
 USER root
 
 RUN apt-get update -y -qq && \
-  a2enmod rewrite && \
-  a2enmod headers
+    a2enmod rewrite && \
+    a2enmod headers && \
+    a2dissite 000-default && \
+    rm -rf /var/lib/apt/lists/*
 
 # For some IDEs this line is treated as wrongly configured, but this is a bug !
 # This heredoc format is supported by Docker.
@@ -33,16 +68,12 @@ RUN cat <<EOF > /etc/apache2/sites-enabled/dist.conf
     ServerAdmin webmaster@robrowser.legacy
     DocumentRoot /var/www/html
 
-    # Allow directory access
+    # Disable directory listing
     <Directory /var/www/html>
-        Options Indexes FollowSymLinks
+        Options -Indexes +FollowSymLinks
         AllowOverride None
         Require all granted
     </Directory>
-
-    <FilesMatch "\.(html|js|css|png|jpg|gif|svg|webp|ico|woff|woff2|ttf|otf|eot|mp4|webm|ogg|mp3|json)$">
-        Require all granted
-    </FilesMatch>
 
     # Set default file
     DirectoryIndex index.html
@@ -50,7 +81,7 @@ RUN cat <<EOF > /etc/apache2/sites-enabled/dist.conf
     # MIME types for JavaScript and other files
     AddType application/javascript .js
 
-    # Enable CORS if needed
+    # Enable CORS
     <IfModule mod_headers.c>
         Header set Access-Control-Allow-Origin "*"
     </IfModule>
@@ -58,6 +89,9 @@ RUN cat <<EOF > /etc/apache2/sites-enabled/dist.conf
 EOF
 
 RUN echo "Listen 8080" >> /etc/apache2/ports.conf
+
+# Copy the built dist files from the builder stage
+COPY --from=builder --chown=www-data:www-data /app/dist/Web /var/www/html
 
 EXPOSE 8080
 

--- a/Dockerfile.remoteclient
+++ b/Dockerfile.remoteclient
@@ -1,0 +1,211 @@
+# syntax=docker/dockerfile:1
+# Supports linux/amd64 and linux/arm64 via multi-platform builds.
+#
+# roBrowserLegacy - two image targets:
+#
+#   slim  - roBrowserLegacy + remote-client server only (~400MB)
+#           Game assets must be mounted at runtime.
+#           docker run -d --network host \
+#             -v /path/to/kRO/data.grf:/app/resources/data.grf:ro \
+#             -v /path/to/kRO/rdata.grf:/app/resources/rdata.grf:ro \
+#             -v /path/to/kRO/DATA.INI:/app/resources/DATA.INI:ro \
+#             -v /path/to/kRO/BGM:/app/BGM:ro \
+#             -v /path/to/Config.local.js:/robrowser/Config.local.js:ro \
+#             ghcr.io/<your-github-user>/robrowserlegacy:<version>-slim
+#
+#   full  - slim + GRF assets baked in (~5GB)
+#           Requires GRF_BASE_URL + S3 credentials as BuildKit secrets at build time.
+#           docker run -d --network host \
+#             -v /path/to/Config.local.js:/robrowser/Config.local.js:ro \
+#             ghcr.io/<your-github-user>/robrowserlegacy:<version>
+#
+# Build args:
+#   BUILD_VERSION            - image version string e.g. 1.0.0 (default: dev)
+#   REMOTE_CLIENT_COMMIT     - pinned git commit of roBrowserLegacy-RemoteClient-JS
+#                              Update this to pick up upstream changes.
+#
+# BuildKit secrets (never written to any image layer or visible in docker history):
+#   s3_access_key_id     - S3/MinIO access key ID
+#   s3_secret_access_key - S3/MinIO secret access key
+#   grf_base_url         - base HTTPS URL for GRF asset download (full target only)
+#                          e.g. https://your-host/bucket/prefix
+#
+# GRF asset tarballs expected at grf_base_url:
+#   ragnarok-grfs.tar.gz  (~4GB) - data.grf + rdata.grf + DATA.INI  [required]
+#   ragnarok-bgm.tar.gz   (~350MB) - BGM/ directory                  [optional]
+#
+# Prepare tarballs from your kRO client directory:
+#   KRO="/path/to/kRO client"
+#   tar -czf ragnarok-grfs.tar.gz -C "$KRO" data.grf rdata.grf DATA.INI
+#   tar -czf ragnarok-bgm.tar.gz  -C "$KRO" BGM
+#
+# Config.local.js (mount at runtime for both targets):
+#   Set packetver, renewal, server address, socketProxy to match your rAthena server.
+#   See applications/pwa/Config.local.js.example for all options.
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Stage 1: build roBrowserLegacy JS bundles
+# Runs on the build machine platform for speed.
+# ─────────────────────────────────────────────────────────────────────────────
+FROM --platform=$BUILDPLATFORM node:20.10.0 AS robrowser-builder
+
+ARG BUILD_VERSION=dev
+
+RUN apt-get update -y -qq && apt-get install -y -qq build-essential && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm install
+
+COPY . .
+
+RUN npm run build:all
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Stage 2: download GRF assets (no-op if grf_base_url secret not provided)
+# Always runs on the build machine platform - only downloads files.
+# ─────────────────────────────────────────────────────────────────────────────
+FROM --platform=$BUILDPLATFORM alpine AS grf-downloader
+
+RUN apk add --no-cache aws-cli
+
+WORKDIR /grffiles
+
+# All credentials and the asset URL are injected via BuildKit secret mounts.
+# They are never written to any image layer or visible in docker history.
+# If grf_base_url secret is absent or empty, this stage is a no-op.
+# ragnarok-grfs.tar.gz is required; ragnarok-bgm.tar.gz is optional.
+RUN --mount=type=secret,id=s3_access_key_id \
+    --mount=type=secret,id=s3_secret_access_key \
+    --mount=type=secret,id=grf_base_url \
+    GRF_BASE_URL="$(cat /run/secrets/grf_base_url 2>/dev/null || true)"; \
+    if [ -n "${GRF_BASE_URL}" ]; then \
+      KEY_ID="$(cat /run/secrets/s3_access_key_id 2>/dev/null || true)"; \
+      SECRET="$(cat /run/secrets/s3_secret_access_key 2>/dev/null || true)"; \
+      if [ -z "${KEY_ID}" ] || [ -z "${SECRET}" ]; then \
+        echo "ERROR: S3 credentials not provided."; exit 1; \
+      fi; \
+      S3_HOST=$(echo "${GRF_BASE_URL}" | sed 's|https\?://||' | cut -d/ -f1); \
+      S3_PATH=$(echo "${GRF_BASE_URL}" | sed 's|https\?://[^/]*/||'); \
+      S3_BUCKET=$(echo "${S3_PATH}" | cut -d/ -f1); \
+      S3_PREFIX=$(echo "${S3_PATH}" | cut -d/ -f2-); \
+      echo "Downloading GRF assets from s3://${S3_BUCKET}/${S3_PREFIX}/ ..."; \
+      AWS_ACCESS_KEY_ID="${KEY_ID}" AWS_SECRET_ACCESS_KEY="${SECRET}" \
+      AWS_DEFAULT_REGION="us-east-1" \
+      AWS_REQUEST_CHECKSUM_CALCULATION="when_required" \
+      AWS_RESPONSE_CHECKSUM_VALIDATION="when_required" \
+        aws s3 cp "s3://${S3_BUCKET}/${S3_PREFIX}/ragnarok-grfs.tar.gz" ragnarok-grfs.tar.gz \
+          --endpoint-url "https://${S3_HOST}" && \
+      tar -xzf ragnarok-grfs.tar.gz && rm ragnarok-grfs.tar.gz && \
+      echo "GRF core assets extracted." && \
+      ( AWS_ACCESS_KEY_ID="${KEY_ID}" AWS_SECRET_ACCESS_KEY="${SECRET}" \
+        AWS_DEFAULT_REGION="us-east-1" \
+        AWS_REQUEST_CHECKSUM_CALCULATION="when_required" \
+        AWS_RESPONSE_CHECKSUM_VALIDATION="when_required" \
+          aws s3 cp "s3://${S3_BUCKET}/${S3_PREFIX}/ragnarok-bgm.tar.gz" ragnarok-bgm.tar.gz \
+            --endpoint-url "https://${S3_HOST}" && \
+        tar -xzf ragnarok-bgm.tar.gz && rm ragnarok-bgm.tar.gz && \
+        echo "BGM extracted." \
+      ) || echo "BGM not available - skipping."; \
+      echo "Download complete:" && ls -lh; \
+    else \
+      echo "grf_base_url secret not set - skipping GRF download."; \
+    fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Stage 3: slim - remote-client + roBrowserLegacy dist, no GRFs
+# This is the slim image target and the base layer for the full image.
+# ─────────────────────────────────────────────────────────────────────────────
+FROM node:20.10.0-slim AS slim
+
+ARG BUILD_VERSION=dev
+
+LABEL org.opencontainers.image.title="roBrowserLegacy"
+LABEL org.opencontainers.image.description="roBrowserLegacy: WebSocket proxy and static file server. Mount GRF assets and Config.local.js at runtime."
+LABEL org.opencontainers.image.version="${BUILD_VERSION}"
+LABEL org.opencontainers.image.source="https://github.com/MrAntares/roBrowserLegacy"
+LABEL ro.image.variant="slim"
+
+RUN apt-get update -y -qq && \
+    apt-get install -y -qq git && \
+    rm -rf /var/lib/apt/lists/*
+
+# Create a non-root user to run the server process
+RUN groupadd -r robrowser && useradd -r -g robrowser -d /app robrowser
+
+WORKDIR /app
+
+# Pin to a specific commit for reproducible builds.
+# To update: change REMOTE_CLIENT_COMMIT to a newer commit SHA.
+ARG REMOTE_CLIENT_COMMIT=b61971d119ebc55c66d5fa3c923e5286b5dbc893
+RUN git clone https://github.com/FranciscoWallison/roBrowserLegacy-RemoteClient-JS.git . && \
+    git checkout "${REMOTE_CLIENT_COMMIT}" && \
+    npm install --ignore-scripts && \
+    # Remove git history to reduce image size
+    rm -rf .git
+
+COPY --from=robrowser-builder /app/dist/Web /robrowser
+
+# Transfer ownership to non-root user
+RUN chown -R robrowser:robrowser /app /robrowser
+
+EXPOSE 3338
+
+ENV PORT=3338
+ENV NODE_ENV=production
+ENV ENABLE_WSPROXY=true
+ENV ENABLE_STATIC_SERVE=true
+ENV ROBROWSER_PATH=/robrowser
+# CLIENT_PUBLIC_URL: update to your public URL if not running locally
+ENV CLIENT_PUBLIC_URL=http://localhost:3338
+# WS_ALLOWED_TARGETS: comma-separated host:port list the WS proxy may forward to.
+# Defaults to localhost only (127.0.0.1:6900,127.0.0.1:6121,127.0.0.1:5121).
+# Override for non-host-network deployments, e.g.:
+#   -e WS_ALLOWED_TARGETS="10.0.0.5:6900,10.0.0.5:6121,10.0.0.5:5121"
+ENV WS_ALLOWED_TARGETS=""
+# Cache tuning: adjust based on available memory
+ENV CACHE_MAX_FILES=10000
+ENV CACHE_MAX_MEMORY_MB=2048
+ENV CACHE_WARM_UP=true
+ENV CACHE_WARM_UP_LIMIT=500
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
+    CMD node -e "require('http').get('http://localhost:${PORT}/', r => process.exit(r.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))"
+
+USER robrowser
+
+CMD ["npm", "run", "start:prod"]
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Stage 4: full - slim + baked-in GRF assets
+# Fails the build explicitly if GRF assets were not downloaded.
+# ─────────────────────────────────────────────────────────────────────────────
+FROM slim AS full
+
+ARG BUILD_VERSION=dev
+
+LABEL org.opencontainers.image.description="roBrowserLegacy: WebSocket proxy, static file server, and baked-in GRF game assets. Mount Config.local.js at runtime."
+LABEL ro.image.variant="full"
+
+# Switch to root temporarily to install GRF assets, then drop back to robrowser
+USER root
+
+COPY --from=grf-downloader /grffiles/ /app/resources-baked/
+
+RUN if [ -f /app/resources-baked/data.grf ]; then \
+      echo "Installing baked GRF assets..."; \
+      mkdir -p /app/resources; \
+      mv /app/resources-baked/data.grf  /app/resources/data.grf  2>/dev/null || true; \
+      mv /app/resources-baked/rdata.grf /app/resources/rdata.grf 2>/dev/null || true; \
+      mv /app/resources-baked/DATA.INI  /app/resources/DATA.INI  2>/dev/null || true; \
+      mv /app/resources-baked/BGM       /app/BGM                 2>/dev/null || true; \
+      chown -R robrowser:robrowser /app/resources /app/BGM 2>/dev/null || true; \
+      echo "GRF assets installed."; \
+    else \
+      echo "ERROR: No GRF assets found. Was grf_base_url secret set and credentials provided?"; \
+      exit 1; \
+    fi && \
+    rm -rf /app/resources-baked
+
+USER robrowser

--- a/applications/pwa/Config.local.js.example
+++ b/applications/pwa/Config.local.js.example
@@ -4,6 +4,10 @@
  * Copy this file to Config.local.js and customize as needed.
  * Values here will override those in Config.js.
  * Config.local.js is optional and will be silently ignored if not present.
+ *
+ * Docker / containerised deployments: mount this file at runtime:
+ *   docker run -v /path/to/Config.local.js:/robrowser/Config.local.js:ro ...
+ * See DOCKER.md for a complete deployment guide.
  */
 window.ROConfigLocal = {
 	// Example: Override server settings
@@ -20,7 +24,12 @@ window.ROConfigLocal = {
 			worldMapSettings: { episode: 12 },
 			packetKeys: false,
 			socketProxy: 'wss://connect.robrowser.com',
-			adminList: [2000000]
+			adminList: [2000000],
+
+			// forceUseAddress: true,  // Uncomment for any containerised or NAT deployment.
+			//                         // Prevents the client from using internal IPs returned
+			//                         // by char/map server packets, which are unreachable
+			//                         // outside the server's local network.
 		}
 	],
 

--- a/docker-compose.remoteclient.yaml
+++ b/docker-compose.remoteclient.yaml
@@ -1,0 +1,49 @@
+services:
+    # ─────────────────────────────────────────────────────────────────────────────
+    # roBrowserLegacy - production deployment using the remote-client image
+    #
+    # This compose file is for self-hosting roBrowserLegacy as a container.
+    # For local development, use docker-compose.yaml instead.
+    #
+    # BEFORE STARTING:
+    #   1. cp applications/pwa/Config.local.js.example Config.local.js
+    #   2. Edit Config.local.js: set address, packetver, renewal, socketProxy
+    #
+    # FULL image (GRFs baked in, ~5GB):
+    #   ROBROWSER_TAG=1.0.0 docker compose -f docker-compose.remoteclient.yaml up -d
+    #
+    # SLIM image (GRFs mounted at runtime, ~400MB):
+    #   Uncomment the GRF volume mounts below, set GRF_PATH, then:
+    #   ROBROWSER_TAG=1.0.0-slim GRF_PATH=/path/to/kRO \
+    #     docker compose -f docker-compose.remoteclient.yaml up -d
+    #
+    # Game URL: http://localhost:3338/
+    #
+    # See DOCKER.md for full documentation including Kubernetes and
+    # non-host-network deployments (macOS/Windows Docker Desktop).
+    # ─────────────────────────────────────────────────────────────────────────────
+    robrowser:
+        image: ghcr.io/<your-github-user>/robrowserlegacy:${ROBROWSER_TAG:?Set ROBROWSER_TAG to a version e.g. 1.0.0}
+        container_name: robrowserlegacy
+        restart: unless-stopped
+        network_mode: host
+        # Override CLIENT_PUBLIC_URL if accessing from another machine:
+        #   CLIENT_PUBLIC_URL=http://<your-server-ip>:3338
+        environment:
+            CLIENT_PUBLIC_URL: 'http://localhost:3338'
+            # Non-host-network deployments (Kubernetes, macOS/Windows Docker Desktop):
+            # uncomment and set to your rAthena server's host:port list.
+            # WS_ALLOWED_TARGETS: "10.0.0.5:6900,10.0.0.5:6121,10.0.0.5:5121"
+        volumes:
+            # Config.local.js MUST exist as a file before starting.
+            # If this file is absent, Docker creates it as a directory and
+            # the container will fail to serve the game configuration.
+            - ./Config.local.js:/robrowser/Config.local.js:ro
+
+            # ── Slim image only: uncomment and set GRF_PATH ─────────────────────
+            # GRF_PATH can be set in a .env file or exported before running compose.
+            #
+            # - ${GRF_PATH}/data.grf:/app/resources/data.grf:ro     # required
+            # - ${GRF_PATH}/rdata.grf:/app/resources/rdata.grf:ro   # required
+            # - ${GRF_PATH}/DATA.INI:/app/resources/DATA.INI:ro     # required
+            # - ${GRF_PATH}/BGM:/app/BGM:ro                         # optional (music)


### PR DESCRIPTION
## Summary

This PR adds production-ready Docker support for roBrowserLegacy, making it straightforward to self-host the client as a container alongside a rAthena server.

> **Dependency:** This PR depends on [FranciscoWallison/roBrowserLegacy-RemoteClient-JS#14](https://github.com/FranciscoWallison/roBrowserLegacy-RemoteClient-JS/pull/14) being merged first. That PR fixes three issues in the embedded WS proxy (configurable targets, TCP connect race condition, robustness improvements) that are required for non-host-network deployments (Kubernetes, Docker Compose bridge mode, macOS/Windows Docker Desktop). Once that PR is merged, the `REMOTE_CLIENT_COMMIT` pin in `Dockerfile.remoteclient` will be updated to that commit before this PR is merged.

---

### What's included

**\`Dockerfile\`** - fixes several issues in the existing file:
- Disabled the default Apache vhost on port 80 (\`a2dissite 000-default\`) which was causing dual-port exposure alongside the custom port 8080 vhost
- Fixed the \`dev\` stage \`ENTRYPOINT\` bug: \`["-l", "-c", "sleep", "360h"]\` passed \`"sleep"\` as the shell script and \`"360h"\` as \`$0\`, causing the container to exit immediately
- Used \`apt-get\` consistently with \`rm -rf /var/lib/apt/lists/*\` cache cleanup in all stages
- Disabled Apache directory listing (\`Options -Indexes\`)
- Wired the builder stage output into the \`dist-server\` stage via \`COPY --from=builder\` (the original had no \`COPY\` and no \`CMD\`, so the image served an empty directory and Apache never started)

**\`Dockerfile.remoteclient\`** - new unified image using [roBrowserLegacy-RemoteClient-JS](https://github.com/FranciscoWallison/roBrowserLegacy-RemoteClient-JS) that handles GRF asset serving, WebSocket proxying, and static file serving in a single process.

Two build targets:
- **\`slim\`** (~400MB): roBrowserLegacy JS bundles + remote-client server. GRF assets and \`Config.local.js\` must be mounted at runtime. **This is the recommended image and is always built.**
- **\`full\`** (~5GB): \`slim\` + GRF assets baked in at build time. **This target is intentionally not suitable for public registries** - GRF files are copyrighted by Gravity Co., Ltd. and baking them into a publicly distributed image would constitute redistribution of copyrighted assets. It is provided for private, self-hosted deployments only, and is only built when \`GRF_BASE_URL\`, \`S3_ACCESS_KEY_ID\`, and \`S3_SECRET_ACCESS_KEY\` CI secrets are configured - the full job skips gracefully if they are absent.

Both variants:
- Run as a non-root user (\`robrowser:robrowser\`)
- Support \`linux/amd64\` and \`linux/arm64\`
- Include a \`HEALTHCHECK\` with a 60-second start period (for GRF indexing)
- Pin roBrowserLegacy-RemoteClient-JS to a specific commit SHA for reproducible builds

**\`docker-compose.yaml\`** - usage instructions for both image variants

**\`applications/pwa/Config.local.js.example\`** - documents all client configuration options including the critical \`forceUseAddress: true\` flag required for any containerised deployment

**\`DOCKER.md\`** - full deployment documentation: quick start, config reference, networking notes (including Kubernetes/bridge/macOS), build instructions, asset preparation, and copyright guidance on the full image

**CI workflow fixes** (pre-existing bugs unrelated to Docker, fixed opportunistically):
- \`release.yml\`: \`actions/checkout@v5\` -> \`@v4\` (v5 does not exist); \`actions/setup-node@v6\` -> \`@v4\` (v6 does not exist); removed \`ref: 'master'\` hardcode that caused tag releases to build from \`master\` HEAD instead of the tagged commit; added \`update_existing_release: true\` to nightly so it does not fail after the first run
- \`build.yml\`: same action version fixes; added \`cache: 'npm'\` for faster PR builds
- \`analysis_codeql.yml\`: \`codeql-action@v4\` -> \`@v3\` (v4 does not exist)

---

### Design decisions

**Why one container for everything?**
The remote-client server already handles static file serving, GRF asset serving, and WebSocket proxying. Running it as a single container eliminates the need to orchestrate separate services and avoids CORS complexity.

**Why slim as the default?**
GRF files are Gravity's IP. The slim image contains no game assets - users supply their own legitimately-obtained client files via volume mount. This is the same model as the existing PHP remote client setup documented in the README, just containerised.

**Why \`network_mode: host\` as the default, with \`WS_ALLOWED_TARGETS\` for other deployments?**
The default \`docker-compose.yaml\` uses host networking on Linux because it is the simplest path when rAthena is on the same host. However, host networking does not work on Docker Desktop (macOS/Windows) and is unavailable in Kubernetes. The \`WS_ALLOWED_TARGETS\` environment variable (added in the companion RemoteClient-JS PR) enables bridge-mode and remote-host deployments by making the proxy allowlist configurable. See \`DOCKER.md\` for examples covering all three scenarios.

**Why is \`Config.local.js\` always a runtime mount?**
\`Config.local.js\` contains server-specific settings (\`address\`, \`packetver\`, \`renewal\`) that vary per deployment. Baking it into the image would require a new image build for every server config change. It is excluded from the build context via \`.dockerignore\` to prevent accidental baking.

**Why not include \`docker.yml\` (GitHub Actions workflow)?**
The CI workflow for building and publishing images requires private GRF asset hosting infrastructure and registry secrets specific to each deployer. It is maintained in the fork as a reference implementation. The build commands are fully documented in \`DOCKER.md\` for anyone who wants to set up their own pipeline.

---

### Testing

Built and validated locally and in a Kubernetes deployment (Talos Linux) with rAthena on a separate host:
- \`slim\` image: \`docker buildx build --target slim\` ✓
- Non-root user confirmed: \`docker inspect\` shows \`User: robrowser\` ✓
- Healthcheck confirmed: \`HEALTHCHECK CMD node -e ...\` with 60s start period ✓
- GRF indexing (628,822 files from \`data.grf\` + \`rdata.grf\`): server ready in ~12s ✓
- Game page, \`Config.local.js\`, and GRF asset requests all return HTTP 200 ✓
- Multi-platform (\`linux/amd64\` + \`linux/arm64\`) validated ✓
- Full image build skips gracefully when GRF secrets are absent ✓
- End-to-end gameplay (login -> char select -> map entry) validated via Kubernetes with \`WS_ALLOWED_TARGETS\` ✓