### PR TITLE
fix(chat): allow INSERT shortcut on chat out of focus and configurable chat focus behavior 

### DIFF
--- a/applications/tools/builder-web.js
+++ b/applications/tools/builder-web.js
@@ -302,6 +302,7 @@ window.ROConfigBase = {
     saveFiles: true,
     ThirdPersonCamera: false,
     transitionDuration: 500,
+    restoreChatFocus: false,
 };
 `;
 	fs.writeFileSync(dist + platform + '/Config.js', configContent, { encoding: 'utf8' });

--- a/src/DB/DBManager.js
+++ b/src/DB/DBManager.js
@@ -6914,23 +6914,16 @@ define(function (require) {
 		let content = null;
 
 		// parse ITEMLINK and ITEM format
-		if (itemLink.includes('<ITEMLINK>') || itemLink.includes('<ITEM>')) {
-			content =
-				itemLink.match(/<ITEMLINK>(.*?)<INFO>(.*?)<\/INFO><\/ITEMLINK>/) ||
-				itemLink.match(/<ITEM>(.*?)<INFO>(.*?)<\/INFO><\/ITEM>/);
-			if (content) {
-				item.ITID = content[2];
-				item.name = content[1];
-				return item;
-			}
-
-			// return unknown item
+		content = itemLink.match(/<(ITEMLINK|ITEM)>([\s\S]*?)<INFO>([\s\S]*?)<\/INFO><\/\1>/);
+		if (content) {
+			const [, , name, id] = content;
+			item.ITID = id;
+			item.name = name;
 			return item;
 		}
 
-		if (itemLink.includes('<ITEML>')) {
-			content = itemLink.match(/<ITEML>(.*?)<\/ITEML>/);
-		} else {
+		content = itemLink.match(/<ITEML>([\s\S]*?)<\/ITEML>/);
+		if (!content) {
 			return item;
 		}
 

--- a/src/UI/Components/ChatBox/ChatBox.js
+++ b/src/UI/Components/ChatBox/ChatBox.js
@@ -221,21 +221,24 @@ define(function (require) {
 			return false;
 		});
 
-		this.ui.find('.input-chatbox').blur(
-			function () {
-				Events.setTimeout(
-					function () {
-						var active = document.activeElement;
-						var movedInsideChatbox = active && jQuery(active).closest('#chatbox').length;
-						var isTextInput = active && active.tagName && active.tagName.match(/input|select|textarea/i);
-						if (!movedInsideChatbox && !isTextInput) {
-							this.ui.find('.input-chatbox').focus();
-						}
-					}.bind(this),
-					1000
-				);
-			}.bind(this)
-		);
+		if (require('Core/Configs').get('restoreChatFocus', false)) {
+			this.ui.find('.input-chatbox').blur(
+				function () {
+					Events.setTimeout(
+						function () {
+							var active = document.activeElement;
+							var movedInsideChatbox = active && jQuery(active).closest('#chatbox').length;
+							var isTextInput =
+								active && active.tagName && active.tagName.match(/input|select|textarea/i);
+							if (!movedInsideChatbox && !isTextInput) {
+								this.ui.find('.input-chatbox').focus();
+							}
+						}.bind(this),
+						1000
+					);
+				}.bind(this)
+			);
+		}
 
 		// Move caret to end of text
 		this.ui.find('.input-chatbox').on('click focus', function () {
@@ -782,7 +785,8 @@ define(function (require) {
 			KEYS.ALT ||
 			KEYS.SHIFT ||
 			KEYS.CTRL ||
-			(keyId >= KEYS.F1 && keyId <= KEYS.F24)
+			(keyId >= KEYS.F1 && keyId <= KEYS.F24) ||
+			KEYS.INSERT
 		) {
 			return BattleMode.process(keyId);
 		}

--- a/src/UI/Components/NpcBox/NpcBox.js
+++ b/src/UI/Components/NpcBox/NpcBox.js
@@ -22,7 +22,7 @@ define(function (require) {
 	var Navigation = require('UI/Components/Navigation/Navigation');
 	var htmlText = require('text!./NpcBox.html');
 	var cssText = require('text!./NpcBox.css');
-	var PACKETVER = require('Network/PacketVerManager');
+
 	/**
 	 * Create NpcBox component
 	 */
@@ -73,11 +73,10 @@ define(function (require) {
 		if (typeof text !== 'string') {
 			text = String(text);
 		}
+		// PACKETVER.value < 20151104 ITEMLINK else ITEM
 		return text.replace(
-			PACKETVER.value < 20151104
-				? /<ITEMLINK>(.*?)<INFO>(.*?)<\/INFO><\/ITEMLINK>/g
-				: /<ITEM>(.*?)<INFO>(.*?)<\/INFO><\/ITEM>/g,
-			function (match, itemName, itemId) {
+			/<(ITEMLINK|ITEM)>([\s\S]*?)<INFO>([\s\S]*?)<\/INFO><\/\1>/g,
+			function (match, tag, itemName, itemId) {
 				return '<span class="item-link" data-item-id="' + itemId + '">' + itemName + '</span>';
 			}
 		);


### PR DESCRIPTION
This patch fixes chat keyboard handling to allow INSERT key shortcuts to work properly when chat is out of focus and makes chat auto-focus behavior configurable.  
  
### Changes:  
- **ChatBox**: Add INSERT key to `processBattleMode` to allow sit/stand shortcuts while chat is unfocused
- **ChatBox**: Make auto-focus behavior configurable via `restoreChatFocus` setting (disabled by default)
- **Config**: Add `restoreChatFocus: false` to default configuration  (this focus persistent chat is an patch behavior from nemo and optional)
- **DBManager**: Improve item link parsing with simplified regex for ITEMLINK/ITEM tags
- **NpcBox**: Update item tag processing to support both ITEMLINK and ITEM formats  

### Fixes:  
- INSERT key (sit/stand) now works when chat input is unfocused  
- Chat no longer steals focus after clicking elsewhere when `restoreChatFocus` is false  
- Better compatibility with different item link formats across client versions  
  