### PR TITLE
fix: guarantee NPC store close packet for all PACKETVER versions

### DIFF
--- a/src/UI/Components/NpcStore/NpcStore.js
+++ b/src/UI/Components/NpcStore/NpcStore.js
@@ -96,6 +96,11 @@ define(function (require) {
 	var _type;
 
 	/**
+	 * @var {boolean} whether the close packet was already sent to the server
+	 */
+	var _closePacketSent = false;
+
+	/**
 	 * Initialize component
 	 */
 	NpcStore.init = function init() {
@@ -105,13 +110,7 @@ define(function (require) {
 		var AvailableItemsWindow = ui.find('.AvailableItemsWindow');
 		var PurchaseResult = ui.find('.PurchaseResult');
 
-		if (PACKETVER.value >= 20131223) {
-			ui.find('.btn.cancel').click(function () {
-				NpcStore.closeStore();
-			});
-		} else {
-			ui.find('.btn.cancel').click(this.remove.bind(this));
-		}
+		ui.find('.btn.cancel').click(this.remove.bind(this));
 
 		// Client do not send packet
 		ui.find('.btn.buy, .btn.sell').click(this.submit.bind(this));
@@ -169,6 +168,8 @@ define(function (require) {
 	 * Player should not be able to move when the store is opened
 	 */
 	NpcStore.onAppend = function onAppend() {
+		_closePacketSent = false;
+
 		Client.loadFile(
 			DB.INTERFACE_PATH + 'checkbox_' + (_preferences.select_all ? 1 : 0) + '.bmp',
 			function (data) {
@@ -216,6 +217,11 @@ define(function (require) {
 		this.ui.find('.content').empty();
 		this.ui.find('.total .result').text(0);
 		this.ui.find('.totalP .resultP').text(0);
+
+		// Ensure the server knows the store is closed (prevents movement lock)
+		if (!_closePacketSent) {
+			NpcStore.StoreClosePacket(_type);
+		}
 	};
 
 	/**
@@ -226,10 +232,6 @@ define(function (require) {
 	NpcStore.onKeyDown = function onKeyDown(event) {
 		if ((event.which === KEYS.ESCAPE || event.key === 'Escape') && this.ui.is(':visible')) {
 			this.remove();
-
-			if (PACKETVER.value >= 20131223) {
-				NpcStore.StoreClosePacket(_type);
-			}
 		}
 	};
 
@@ -1188,22 +1190,34 @@ define(function (require) {
 		InputBox.remove();
 
 		let pkt;
-		switch (type) {
-			case NpcStore.Type.MARKETSHOP:
-				pkt = new PACKET.CZ.NPC_MARKET_CLOSE();
-				inputWindow.show();
-				outputWindow.show();
-				break;
-			case NpcStore.Type.BARTER_MARKET:
-				pkt = new PACKET.CZ.NPC_BARTER_MARKET_CLOSE();
-				break;
-			case NpcStore.Type.BARTER_MARKET_EXTENDED:
-				pkt = new PACKET.CZ.NPC_EXPANDED_BARTER_MARKET_CLOSE();
-				break;
-			default:
-				pkt = new PACKET.CZ.NPC_TRADE_QUIT();
-				break;
+
+		if (PACKETVER.value < 20131223) {
+			// Before 20131223, NPC_TRADE_QUIT didn't exist.
+			// Send an empty buy/sell list to end the NPC trade state.
+			if (type === NpcStore.Type.SELL) {
+				pkt = new PACKET.CZ.PC_SELL_ITEMLIST();
+			} else {
+				pkt = new PACKET.CZ.PC_PURCHASE_ITEMLIST();
+			}
+		} else {
+			switch (type) {
+				case NpcStore.Type.MARKETSHOP:
+					pkt = new PACKET.CZ.NPC_MARKET_CLOSE();
+					inputWindow.show();
+					outputWindow.show();
+					break;
+				case NpcStore.Type.BARTER_MARKET:
+					pkt = new PACKET.CZ.NPC_BARTER_MARKET_CLOSE();
+					break;
+				case NpcStore.Type.BARTER_MARKET_EXTENDED:
+					pkt = new PACKET.CZ.NPC_EXPANDED_BARTER_MARKET_CLOSE();
+					break;
+				default:
+					pkt = new PACKET.CZ.NPC_TRADE_QUIT();
+					break;
+			}
 		}
+		_closePacketSent = true;
 		Network.sendPacket(pkt);
 	};
 


### PR DESCRIPTION
Problem:
After opening and closing an NPC shop (buy/sell), the player was permanently unable to move. The rAthena server blocks movement while sd->npc_id is set, and it was never cleared because the client did not send a close signal in several exit paths (ESC key, Cancel button, sell result).

Root cause:
The close packet (NPC_TRADE_QUIT, 0x9d4) only exists since PACKETVER
20131223. On older clients like 2013-06-18aRagexe.exe (PACKETVER 20130618), it was either skipped or caused a server disconnect.

Solution:
- Added _closePacketSent flag to track whether the close signal was already sent, preventing duplicate packets.
- Added a safety net in onRemove() that sends the close packet if no other code path did, covering all exit scenarios.
- For PACKETVER < 20131223: sends an empty CZ.PC_PURCHASE_ITEMLIST or CZ.PC_SELL_ITEMLIST instead. The server interprets an empty list as "no transaction" and releases the NPC state normally.
- For PACKETVER >= 20131223: unchanged behavior, still uses NPC_TRADE_QUIT, NPC_MARKET_CLOSE, NPC_BARTER_MARKET_CLOSE, or NPC_EXPANDED_BARTER_MARKET_CLOSE as appropriate.

Compatibility:
This change is fully backward and forward compatible. Newer PACKETVER clients follow the exact same code path as before. The only addition is the onRemove() safety net which guarantees the packet is sent regardless of how the store window is closed.