### PR TITLE
Fix binary string handling (hash corruption)

### DIFF
--- a/src/Utils/BinaryReader.js
+++ b/src/Utils/BinaryReader.js
@@ -34,8 +34,14 @@ define(['./Struct', 'Utils/CodepageManager'], function (Struct, TextEncoding) {
 		var buffer;
 
 		if (typeof mixed === 'string') {
-			const buf = TextEncoding.encode(mixed, 'utf-8');
-			buffer = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
+			const len = mixed.length;
+			const uint8 = new Uint8Array(len);
+
+			for (let i = 0; i < len; i++) {
+				uint8[i] = mixed.charCodeAt(i);
+			}
+
+			buffer = uint8.buffer;
 		} else if (mixed instanceof ArrayBuffer) {
 			buffer = mixed;
 		} else if (mixed instanceof Uint8Array) {
@@ -239,7 +245,7 @@ define(['./Struct', 'Utils/CodepageManager'], function (Struct, TextEncoding) {
 
 		this.offset += len;
 
-		return TextEncoding.decode(bytes.subarray(0, realLen), 'utf-8'); // default server charset
+		return String.fromCharCode.apply(null, bytes.subarray(0, realLen));
 	};
 
 	/**

--- a/src/Utils/BinaryWriter.js
+++ b/src/Utils/BinaryWriter.js
@@ -68,20 +68,14 @@ define(['Utils/CodepageManager'], function (TextEncoding) {
 	 * @param {number} len
 	 */
 	DataView.prototype.setBinaryString = function SetBinaryString(offset, str, len) {
-		str = String(str);
-
-		let buf = TextEncoding.encode(str, 'utf-8');
-
-		if (len && buf.length > len) {
-			buf = buf.subarray(0, len);
+		if (len) {
+			str = String(str).substr(0, len);
 		}
 
-		const count = buf.length;
+		var i, count;
 
-		new Uint8Array(this.buffer, offset, count).set(buf);
-
-		if (len && count < len) {
-			new Uint8Array(this.buffer, offset + count, len - count).fill(0);
+		for (i = 0, count = str.length; i < count; ++i) {
+			this.setUint8(offset + i, str.charCodeAt(i) & 0xff);
 		}
 	};
 
@@ -286,21 +280,21 @@ define(['Utils/CodepageManager'], function (TextEncoding) {
 	) {
 		str = String(str);
 
-		let buf = TextEncoding.encode(str, 'utf-8');
+		let len = length ? Math.min(length, str.length) : str.length;
 
-		if (length && buf.length > length) {
-			buf = buf.subarray(0, length);
+		const buf = new Uint8Array(len);
+
+		for (let i = 0; i < len; i++) {
+			buf[i] = str.charCodeAt(i);
 		}
 
-		const count = buf.length;
+		new Uint8Array(this.view.buffer, this.offset, len).set(buf);
 
-		new Uint8Array(this.view.buffer, this.offset, count).set(buf);
-
-		if (length && count < length) {
-			new Uint8Array(this.view.buffer, this.offset + count, length - count).fill(0);
+		if (length && len < length) {
+			new Uint8Array(this.view.buffer, this.offset + len, length - len).fill(0);
 		}
 
-		this.offset += length || count;
+		this.offset += length || len;
 		return this;
 	};
 


### PR DESCRIPTION
This PR fixes an issue introduced in the previous changes where binary data (such as EXE hash values) was incorrectly treated as UTF-8 encoded text.

### ❗ What happened

In the previous update, `writeBinaryString` and related functions were modified to use UTF-8 encoding.
However, these fields are not actual strings — they represent raw binary data (e.g. MD5 hashes).

Encoding them as UTF-8 caused byte expansion (multi-byte sequences), which corrupted the expected fixed-length values (e.g. 16-byte hashes), leading to invalid packets.

* Reverted binary string handling to **raw byte operations (1:1 char → byte)**.
* Restored `charCodeAt`-based logic for binary writing.
* Updated `BinaryReader` to use `String.fromCharCode` instead of TextDecoding.
* Ensured fixed-length buffers (like hashes) remain intact and unmodified.

Sorry for the confusion and regression introduced in the previous changes 🙇
This should restore correct behavior for hash validation and other binary packet fields.

The improvements made are still valid, they only alter the correct behavior.