### PR TITLE
Fix: Non-Profitable Entities (NPCs) disappear when returning to an area.

### DIFF
--- a/src/Engine/MapEngine/Entity.js
+++ b/src/Engine/MapEngine/Entity.js
@@ -375,6 +375,7 @@ define(function (require) {
 			}
 
 			entity.remove(pkt.type);
+			EntityManager.removeGID(pkt.GID);
 		}
 
 		// Show escape menu

--- a/src/Renderer/Entity/Entity.js
+++ b/src/Renderer/Entity/Entity.js
@@ -415,8 +415,8 @@ define(function (require) {
 
 		this.falcon = null;
 		this.wug = null;
-		// Aviod conflict if entity re-appears. Official sets it to -1
-		this.GID += Math.random();
+		// Avoid conflict if entity re-appears. Official sets it to -1
+		this.GID = -1;
 	};
 
 	/**

--- a/src/Renderer/EntityManager.js
+++ b/src/Renderer/EntityManager.js
@@ -198,6 +198,16 @@ define(function (require) {
 	}
 
 	/**
+	 * Remove a GID from the lookup map without removing from render list.
+	 * Used when entity vanishes (OUTOFSIGHT) so the fade-out animation
+	 * continues but the GID slot is freed for re-use if entity re-appears.
+	 * @param {number} gid
+	 */
+	function removeGID(gid) {
+		_gidMap.delete(gid);
+	}
+
+	/**
 	 * Remove an entity
 	 * @param {number} gid
 	 */
@@ -562,6 +572,7 @@ define(function (require) {
 		free: free,
 		add: addEntity,
 		remove: removeEntity,
+		removeGID: removeGID,
 		get: getEntity,
 		getByCID: getEntityByCID,
 		forEach: forEach,


### PR DESCRIPTION
Fixes a bug where `_gidMap` retained a ghost reference after `entity.clean()` corrupted the GID with `Math.random()`. Upon returning, the lookup found the ghost entity (outside the `_list` of rendering), updated its data, but never re-added it for rendering.

Adds `removeGID()` to the EntityManager to clean up `_gidMap` in `vanish`.
Calls `removeGID()` in `onEntityVanish()` before the GID is corrupted. 
Changes `GID += Math.random()` to `GID = -1` (official behavior).