### PR TITLE
ci: add nightly Docker image builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,192 @@
+name: 'Build Docker Image'
+
+# Builds and publishes Docker images nightly and on manual trigger.
+# Since roBrowserLegacy does not publish semver releases, images are tagged
+# by build date so users can pin to a specific build or track latest.
+#
+# Tags produced per build:
+#   ghcr.io/<owner>/roBrowserLegacy:YYYY-MM-DD-slim   - slim (~400MB, mount GRFs at runtime)
+#   ghcr.io/<owner>/roBrowserLegacy:latest-slim        - slim, always points to most recent build
+#
+# Full image (GRFs baked in, ~5GB) is also built if S3 secrets are configured:
+#   ghcr.io/<owner>/roBrowserLegacy:YYYY-MM-DD         - full
+#   ghcr.io/<owner>/roBrowserLegacy:latest             - full, always points to most recent build
+#
+# Required secrets for full image (optional - slim is always built):
+#   GRF_BASE_URL         - base HTTPS URL for GRF asset tarballs
+#   S3_ACCESS_KEY_ID     - S3/MinIO access key ID
+#   S3_SECRET_ACCESS_KEY - S3/MinIO secret access key
+#
+# See DOCKER.md for full documentation including GRF tarball preparation.
+
+concurrency:
+    group: ${{ github.repository }}-docker
+    cancel-in-progress: false
+
+on:
+    schedule:
+        - cron: '0 4 * * *'   # 04:00 UTC daily
+    workflow_dispatch:         # allow manual trigger
+
+permissions:
+    contents: read
+    packages: write
+
+jobs:
+    # ── Slim image ─────────────────────────────────────────────────────────────
+    # Always built. No GRFs - fast build (~5min), small image (~400MB).
+    # GRFs and Config.local.js must be mounted at runtime.
+    slim:
+        name: 'Build slim image'
+        runs-on: ubuntu-latest
+        outputs:
+            build_date: ${{ steps.date.outputs.build_date }}
+            created: ${{ steps.date.outputs.created }}
+        steps:
+            - name: 'Checkout repository'
+              uses: actions/checkout@v5
+
+            - name: 'Generate build date'
+              id: date
+              run: |
+                  echo "build_date=$(date -u +"%Y-%m-%d")" >> "$GITHUB_OUTPUT"
+                  echo "created=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> "$GITHUB_OUTPUT"
+
+            - name: 'Free up disk space'
+              run: sudo rm -rf /usr/local/lib/android /opt/ghc /usr/share/dotnet || true
+
+            - name: 'Set up QEMU (ARM64 emulation)'
+              uses: docker/setup-qemu-action@v3
+              with:
+                  platforms: arm64
+
+            - name: 'Set up Docker Buildx'
+              uses: docker/setup-buildx-action@v3
+
+            - name: 'Log in to GitHub Container Registry'
+              uses: docker/login-action@v3
+              with:
+                  registry: ghcr.io
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: 'Build and push slim image'
+              uses: docker/build-push-action@v6
+              with:
+                  context: .
+                  file: Dockerfile.remoteclient
+                  target: slim
+                  platforms: linux/amd64,linux/arm64
+                  push: true
+                  provenance: false
+                  build-args: BUILD_VERSION=${{ steps.date.outputs.build_date }}
+                  tags: |
+                      ghcr.io/${{ github.repository }}:${{ steps.date.outputs.build_date }}-slim
+                      ghcr.io/${{ github.repository }}:latest-slim
+                  cache-from: type=gha,scope=docker-slim
+                  cache-to: type=gha,mode=max,scope=docker-slim,ignore-error=true
+                  labels: |
+                      org.opencontainers.image.source=https://github.com/${{ github.repository }}
+                      org.opencontainers.image.revision=${{ github.sha }}
+                      org.opencontainers.image.created=${{ steps.date.outputs.created }}
+                      ro.image.variant=slim
+                      ro.build.date=${{ steps.date.outputs.build_date }}
+
+            - name: 'Summary'
+              run: |
+                  echo "## Slim Image" >> $GITHUB_STEP_SUMMARY
+                  echo "| | |" >> $GITHUB_STEP_SUMMARY
+                  echo "|---|---|" >> $GITHUB_STEP_SUMMARY
+                  echo "| **tag** | \`ghcr.io/${{ github.repository }}:${{ steps.date.outputs.build_date }}-slim\` |" >> $GITHUB_STEP_SUMMARY
+                  echo "| **platforms** | linux/amd64, linux/arm64 |" >> $GITHUB_STEP_SUMMARY
+                  echo "| **GRF assets** | mount at runtime |" >> $GITHUB_STEP_SUMMARY
+                  echo "| **commit** | \`${{ github.sha }}\` |" >> $GITHUB_STEP_SUMMARY
+
+    # ── Full image ─────────────────────────────────────────────────────────────
+    # Only built when GRF_BASE_URL secret is configured.
+    # GRFs are copyrighted by Gravity Co., Ltd. - only publish to private registries.
+    # See DOCKER.md for GRF tarball preparation instructions.
+    full:
+        name: 'Build full image'
+        runs-on: ubuntu-latest
+        needs: slim
+        steps:
+            - name: 'Check GRF secrets are configured'
+              id: check
+              env:
+                  GRF_BASE_URL: ${{ secrets.GRF_BASE_URL }}
+              run: |
+                  if [ -z "${GRF_BASE_URL}" ]; then
+                    echo "GRF_BASE_URL secret not set - skipping full image build."
+                    echo "skip=true" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "skip=false" >> "$GITHUB_OUTPUT"
+                  fi
+
+            - name: 'Checkout repository'
+              if: steps.check.outputs.skip == 'false'
+              uses: actions/checkout@v5
+
+            - name: 'Free up disk space'
+              if: steps.check.outputs.skip == 'false'
+              run: |
+                  sudo rm -rf /usr/local/lib/android /opt/ghc /usr/share/dotnet || true
+                  df -h
+
+            - name: 'Set up QEMU (ARM64 emulation)'
+              if: steps.check.outputs.skip == 'false'
+              uses: docker/setup-qemu-action@v3
+              with:
+                  platforms: arm64
+
+            - name: 'Set up Docker Buildx'
+              if: steps.check.outputs.skip == 'false'
+              uses: docker/setup-buildx-action@v3
+
+            - name: 'Log in to GitHub Container Registry'
+              if: steps.check.outputs.skip == 'false'
+              uses: docker/login-action@v3
+              with:
+                  registry: ghcr.io
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: 'Build and push full image'
+              if: steps.check.outputs.skip == 'false'
+              uses: docker/build-push-action@v6
+              with:
+                  context: .
+                  file: Dockerfile.remoteclient
+                  target: full
+                  platforms: linux/amd64,linux/arm64
+                  push: true
+                  provenance: false
+                  build-args: BUILD_VERSION=${{ needs.slim.outputs.build_date }}
+                  secrets: |
+                      s3_access_key_id=${{ secrets.S3_ACCESS_KEY_ID }}
+                      s3_secret_access_key=${{ secrets.S3_SECRET_ACCESS_KEY }}
+                      grf_base_url=${{ secrets.GRF_BASE_URL }}
+                  tags: |
+                      ghcr.io/${{ github.repository }}:${{ needs.slim.outputs.build_date }}
+                      ghcr.io/${{ github.repository }}:latest
+                  cache-from: |
+                      type=gha,scope=docker-slim
+                      type=gha,scope=docker-full
+                  cache-to: type=gha,mode=max,scope=docker-full,ignore-error=true
+                  labels: |
+                      org.opencontainers.image.source=https://github.com/${{ github.repository }}
+                      org.opencontainers.image.revision=${{ github.sha }}
+                      org.opencontainers.image.created=${{ needs.slim.outputs.created }}
+                      ro.image.variant=full
+                      ro.build.date=${{ needs.slim.outputs.build_date }}
+
+            - name: 'Summary'
+              if: steps.check.outputs.skip == 'false'
+              run: |
+                  echo "## Full Image" >> $GITHUB_STEP_SUMMARY
+                  echo "| | |" >> $GITHUB_STEP_SUMMARY
+                  echo "|---|---|" >> $GITHUB_STEP_SUMMARY
+                  echo "| **tag** | \`ghcr.io/${{ github.repository }}:${{ needs.slim.outputs.build_date }}\` |" >> $GITHUB_STEP_SUMMARY
+                  echo "| **platforms** | linux/amd64, linux/arm64 |" >> $GITHUB_STEP_SUMMARY
+                  echo "| **GRF assets** | baked in (private registry only) |" >> $GITHUB_STEP_SUMMARY
+                  echo "| **commit** | \`${{ github.sha }}\` |" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## What this does

Adds a GitHub Actions workflow that builds and publishes Docker images nightly at 04:00 UTC and on manual trigger.

Since roBrowserLegacy does not publish versioned releases, images are tagged by build date rather than semver:

- `ghcr.io/<owner>/roBrowserLegacy:2026-03-24-slim` - slim, date-pinned
- `ghcr.io/<owner>/roBrowserLegacy:latest-slim` - slim, rolling latest

The slim image (~400MB) is always built. The full image (~5GB, GRFs baked in) is only built when `GRF_BASE_URL`, `S3_ACCESS_KEY_ID`, and `S3_SECRET_ACCESS_KEY` secrets are configured - skips gracefully otherwise. Both variants support linux/amd64 and linux/arm64.

This depends on `Dockerfile.remoteclient` and `DOCKER.md` merged in #956.

## Why date tags instead of semver

The game engine evolves continuously without tagged releases, so semver tags would require manual intervention on every build. Date tags are sortable, unambiguous, and let users pin to a known-good build or just track latest.

## GRF copyright note

The slim image contains no game assets - users supply their own legitimately obtained client files at runtime. The full image (GRFs baked in) is only relevant for private self-hosted registries and will not be built unless the operator explicitly configures their own GRF asset hosting. This is documented in DOCKER.md.