### PR TITLE
docs: fix inaccuracies and expand UIComponent_to_GUIComponent and CustomElements migration guides

### DIFF
--- a/doc/CustomElements.md
+++ b/doc/CustomElements.md
@@ -41,6 +41,8 @@ Handles `mouseover`/`mouseout`/`mousedown`/`mouseup` internally to swap backgrou
 
 **Cursor**: `ui-button` is included in `CLICKABLE_SELECTOR` in `CursorManager.js` and in `GUIComponent._setupShadowCursorEvents()`. The custom hand cursor appears on hover automatically.
 
+**Known limitation**: `<ui-button>` does NOT have `observedAttributes` or `attributeChangedCallback`. Changing `bg`, `hover`, or `down` attributes after the element is connected to the DOM will **not** update the button visuals. If you need to change button images dynamically, remove and re-create the element.
+
 #### `<ui-text>` — replaces `<span data-text="msgId">`
 
 ```html
@@ -58,36 +60,24 @@ Resolves the message ID via `DB.getMessage()` on connect and on attribute change
 ```html
 <!-- Before (UIComponent) — data-background sets background on the element itself -->
 <div class="titlebar" data-background="basic_interface/titlebar_mid.bmp">
-	<!-- After (GUIComponent) — ui-image is a child element that sets background on itself -->
+	<!-- After (GUIComponent) — ui-image is a child that sets background on its PARENT -->
 	<div class="titlebar">
-		<ui-image src="basic_interface/titlebar_mid.bmp" style="width: 100%; height: 100%; display: block"></ui-image>
+		<ui-image src="basic_interface/titlebar_mid.bmp"></ui-image>
 	</div>
 </div>
 ```
 
-**Behavior**: `<ui-image>` loads the image via `Client.loadFile()` and sets `background-image` on its parent element (not on itself). It hides itself with `display: none` so it doesn't occupy any layout space. This replicates the old data-background behavior where the background was applied to the element that had the attribute.
+**Behavior**: `<ui-image>` loads the image via `Client.loadFile()` and sets `background-image` on its **parent element** (not on itself). It hides itself with `display: none` in `connectedCallback()` so it doesn't occupy any layout space. This replicates the old `data-background` behavior where the background was applied to the element that had the attribute.
 
-No inline styles or explicit dimensions are needed on `<ui-image>` — the parent element is the one that must have the correct dimensions for the background to be visible.
-
-**Preferred approach** — inline style in HTML (no CSS changes needed):
+No inline styles or explicit dimensions are needed on `<ui-image>` — the parent element is the one that must have the correct dimensions for the background to be visible. The actual Clan component uses it without any inline styles:
 
 ```html
-<!-- Fill parent completely (titlebar) -->
-<ui-image src="basic_interface/titlebar_mid.bmp" style="width: 100%; height: 100%; display: block"></ui-image>
-
-<!-- Fixed height (footer bar) -->
-<ui-image src="basic_interface/btnbar_mid2.bmp" style="width: 100%; height: 27px; display: block"></ui-image>
+<div class="titlebar">
+	<ui-image src="basic_interface/titlebar_mid.bmp"></ui-image>
+</div>
 ```
 
-**Alternative** — CSS rule (when many `<ui-image>` share the same sizing):
-
-```css
-.titlebar ui-image {
-	display: block;
-	width: 100%;
-	height: 100%;
-}
-```
+> **Warning**: Do NOT set `display: block` on `<ui-image>` via inline style or CSS — `connectedCallback()` sets `display: none` and the element is meant to be invisible. The background is applied to the parent, not to the `<ui-image>` element itself.
 
 Supports reactive `src` changes via `observedAttributes`.
 
@@ -118,6 +108,8 @@ import Targa from 'Loaders/Targa.js';
  */
 class RONewElement extends HTMLElement {
 	connectedCallback() {
+		if (this._initialized) return;
+		this._initialized = true;
 		const val = this.getAttribute('attr');
 		// Set up behavior (load images, add listeners, etc.)
 	}
@@ -167,3 +159,5 @@ btn.classList.add('btn');
 btn.addEventListener('click', () => { ... });
 container.appendChild(btn);
 ```
+
+> **Note**: Since `<ui-button>` does not support reactive attributes, all `bg`/`hover`/`down` attributes must be set **before** appending the element to the DOM (before `connectedCallback` fires). If you need to change images after connection, remove and re-create the element.

--- a/doc/CustomElements.md
+++ b/doc/CustomElements.md
@@ -41,8 +41,6 @@ Handles `mouseover`/`mouseout`/`mousedown`/`mouseup` internally to swap backgrou
 
 **Cursor**: `ui-button` is included in `CLICKABLE_SELECTOR` in `CursorManager.js` and in `GUIComponent._setupShadowCursorEvents()`. The custom hand cursor appears on hover automatically.
 
-**Known limitation**: `<ui-button>` does NOT have `observedAttributes` or `attributeChangedCallback`. Changing `bg`, `hover`, or `down` attributes after the element is connected to the DOM will **not** update the button visuals. If you need to change button images dynamically, remove and re-create the element.
-
 #### `<ui-text>` — replaces `<span data-text="msgId">`
 
 ```html
@@ -60,10 +58,10 @@ Resolves the message ID via `DB.getMessage()` on connect and on attribute change
 ```html
 <!-- Before (UIComponent) — data-background sets background on the element itself -->
 <div class="titlebar" data-background="basic_interface/titlebar_mid.bmp">
-	<!-- After (GUIComponent) — ui-image is a child that sets background on its PARENT -->
-	<div class="titlebar">
-		<ui-image src="basic_interface/titlebar_mid.bmp"></ui-image>
-	</div>
+
+<!-- After (GUIComponent) — ui-image is a child that sets background on its PARENT -->
+<div class="titlebar">
+	<ui-image src="basic_interface/titlebar_mid.bmp"></ui-image>
 </div>
 ```
 
@@ -159,5 +157,3 @@ btn.classList.add('btn');
 btn.addEventListener('click', () => { ... });
 container.appendChild(btn);
 ```
-
-> **Note**: Since `<ui-button>` does not support reactive attributes, all `bg`/`hover`/`down` attributes must be set **before** appending the element to the DOM (before `connectedCallback` fires). If you need to change images after connection, remove and re-create the element.

--- a/doc/UIComponent_to_GUIComponent.md
+++ b/doc/UIComponent_to_GUIComponent.md
@@ -326,17 +326,6 @@ export default UIManager.addComponent(Clan);
 
 ## Additional Features
 
-### Grid Snap
-
-Draggable components can snap to a grid on mouse release:
-
-```javascript
-Clan.gridSnap = { width: 32, height: 32, padX: 0, padY: 0 };
-Clan.snapDuration = 150; // ms, CSS transition duration
-```
-
-The component will animate to the nearest grid position when the user stops dragging.
-
 ### Clone
 
 Deep-clone a GUIComponent instance:

--- a/doc/UIComponent_to_GUIComponent.md
+++ b/doc/UIComponent_to_GUIComponent.md
@@ -16,7 +16,7 @@
 - CSS injected inside the Shadow DOM via a `<style>` element (Common.css + component CSS)
 - HTML returned by `render()` method as a string, inserted into `this._container.innerHTML`
 - Uses Custom Elements (`<ui-button>`, `<ui-text>`, `<ui-image>`) instead of `data-*` attributes (see doc/CustomElements.md)
-- `this.ui` is a jQuery-compatible proxy object so UIManager and legacy UIComponent instances can interoperate without changes
+- `this.ui` is a jQuery-compatible proxy that exists **only** for interoperability with `UIManager` and legacy `UIComponent` instances — **new code inside a GUIComponent should always use native DOM and Shadow DOM APIs directly**
 
 ### DOM Structure
 
@@ -62,11 +62,11 @@ remove()
   └── host.remove()                        ← host removed from DOM
 ```
 
-| Hook         | When it runs                                              | Use for                                                                  |
-| ------------ | --------------------------------------------------------- | ------------------------------------------------------------------------ |
-| `init()`     | Once, during `prepare()`. Host is temporarily in the DOM. | One-time setup: `draggable()`, event binding, initial `this.ui.hide()`   |
-| `onAppend()` | Every time `append()` is called. Host is in the DOM.      | Position restore, anything that must run each time the component appears |
-| `onRemove()` | Every time `remove()` is called, before detach.           | Save preferences, cleanup                                                |
+| Hook | When it runs | Use for |
+|------|-------------|---------|
+| `init()` | Once, during `prepare()`. Host is temporarily in the DOM. | One-time setup: `draggable()`, event binding, initial hide |
+| `onAppend()` | Every time `append()` is called. Host is in the DOM. | Position restore, anything that must run each time the component appears |
+| `onRemove()` | Every time `remove()` is called, before detach. | Save preferences, cleanup |
 
 **RULE**: Bind events in `init()` (runs once). Restore position/state in `onAppend()` (runs every time). Save state in `onRemove()`.
 
@@ -78,16 +78,16 @@ Each GUIComponent has a `mouseMode` property that controls how mouse events inte
 
 ```javascript
 const MouseMode = Object.freeze({
-	CROSS: 0, // Mouse crosses the UI and still intersects with the scene
-	STOP: 1, // Blocks scene intersection when mouse is over the UI
-	FREEZE: 2 // Blocks scene intersection while the UI is alive (modal)
+    CROSS:  0, // Mouse crosses the UI and still intersects with the scene
+    STOP:   1, // Blocks scene intersection when mouse is over the UI
+    FREEZE: 2  // Blocks scene intersection while the UI is alive (modal)
 });
 ```
 
-| Mode     | Use case                                 | Example                         |
-| -------- | ---------------------------------------- | ------------------------------- |
-| `CROSS`  | Transparent overlays, HUD elements       | Minimap, chat bubbles           |
-| `STOP`   | Standard windows (default)               | Clan, Inventory, Equipment      |
+| Mode | Use case | Example |
+|------|----------|---------|
+| `CROSS` | Transparent overlays, HUD elements | Minimap, chat bubbles |
+| `STOP` | Standard windows (default) | Clan, Inventory, Equipment |
 | `FREEZE` | Modal dialogs that block all interaction | NPC dialog, confirmation popups |
 
 Set it on the component instance:
@@ -238,14 +238,14 @@ Guild.init = function init() {
 
 ```javascript
 Clan.init = function init() {
-	this.draggable('.titlebar'); // ← accepts CSS selector string (resolved inside shadow)
+	this.draggable('.titlebar');
 	const root = this._shadow || this._host;
 	const closeBtn = root.querySelector('.close');
 	if (closeBtn) {
 		closeBtn.addEventListener('mousedown', e => e.stopImmediatePropagation());
 		closeBtn.addEventListener('click', () => Clan.toggle());
 	}
-	this.ui.hide();
+	this._host.style.display = 'none';
 };
 
 Clan.onAppend = function onAppend() {
@@ -254,73 +254,50 @@ Clan.onAppend = function onAppend() {
 };
 ```
 
-**RULE**: `draggable()` accepts a CSS selector string — it resolves inside the shadow DOM automatically. Event binding goes in `init()` (runs once). Position restore goes in `onAppend()` (runs every time).
+Key changes:
 
-### 7. Convert show/hide/toggle
+- `draggable()` accepts a CSS selector string (resolved inside shadow)
+- Event binding goes in `init()` (runs once), not `onAppend()` (runs every time)
+- Position restore goes in `onAppend()`
+- Uses native DOM `addEventListener` instead of jQuery `.click()`/`.mousedown()`
 
-**Before:**
+### 7. The `this.ui` proxy — interop only
 
-```javascript
-Guild.toggle = function () {
-	if (this.ui.is(':visible')) this.ui.hide();
-	else this.ui.show();
-};
-```
+`this.ui` is a jQuery-compatible proxy that exists so `UIManager` and legacy `UIComponent` code can interact with GUIComponents without changes. **New code inside a GUIComponent should always use native DOM and Shadow DOM APIs.**
 
-**After (identical — proxy handles it):**
+| Proxy method | Native DOM equivalent (preferred) |
+|---|---|
+| `this.ui.css('top', '100px')` | `this._host.style.top = '100px'` |
+| `this.ui.css({ top: 100, left: 200 })` | `Object.assign(this._host.style, { top: '100px', left: '200px' })` |
+| `this.ui.show()` | `this._host.style.display = ''` (+ call `this._fixPositionOverflow()` if needed) |
+| `this.ui.hide()` | `this._host.style.display = 'none'` |
+| `this.ui.is(':visible')` | `this._host.style.display !== 'none'` |
+| `this.ui.find('.foo')` | `this._shadow.querySelector('.foo')` or `this._shadow.querySelectorAll('.foo')` |
+| `this.ui.width()` | `this._host.getBoundingClientRect().width` |
+| `this.ui.height()` | `this._host.getBoundingClientRect().height` |
+| `this.ui.offset()` | `this._host.getBoundingClientRect()` |
+| `this.ui.position()` | `{ left: this._host.offsetLeft, top: this._host.offsetTop }` |
+| `this.ui.parent()` | `this._host.parentNode` |
+| `this.ui.trigger('event')` | `this._host.dispatchEvent(new CustomEvent('event', { bubbles: true }))` |
+| `this.ui.detach()` | `this._host.remove()` |
+| `this.ui.appendTo(target)` | `target.appendChild(this._host)` |
 
-```javascript
-Clan.toggle = function () {
-	if (this.ui.is(':visible')) this.ui.hide();
-	else this.ui.show();
-};
-// Or use this.hide() / this.show() if defined
-```
+> **Caveat**: `this.ui.show()` automatically calls `this._fixPositionOverflow()` to ensure the component stays within screen bounds. When using native DOM `this._host.style.display = ''`, call `this._fixPositionOverflow()` manually if the component may be near screen edges.
 
-The `this.ui` proxy implements the following jQuery-compatible methods:
+**When to use `this.ui`**: Only when passing the component to external code that expects a jQuery-like interface (e.g., `UIManager` internals, legacy components calling methods on other components).
 
-| Method                   | Behavior                                          | Notes                                                                                         |
-| ------------------------ | ------------------------------------------------- | --------------------------------------------------------------------------------------------- |
-| `.css(prop, value)`      | Get/set inline styles on host                     | Supports object syntax: `.css({ top: 100, left: 200 })`. Auto-appends `px` to numeric values. |
-| `.offset()`              | Returns `{ left, top }` relative to document      | Uses `getBoundingClientRect()`                                                                |
-| `.offsetParent()`        | Returns positioned ancestor                       | Mimics jQuery's walk-up behavior                                                              |
-| `.position()`            | Returns `{ left, top }` relative to offset parent | Uses `offsetLeft`/`offsetTop`                                                                 |
-| `.width()` / `.height()` | Returns dimensions                                | Uses `getBoundingClientRect()`                                                                |
-| `.is(':visible')`        | Visibility check                                  | Checks `display !== 'none'` and `offsetParent !== null`                                       |
-| `.show()`                | Removes `display: none`                           | Also calls `_fixPositionOverflow()` automatically                                             |
-| `.hide()`                | Sets `display: none`                              | —                                                                                             |
-| `.find(selector)`        | Query inside shadow DOM                           | Returns mini-wrapper (see limitations below)                                                  |
-| `.parent()`              | Returns parent wrapper                            | Only has `.append()` method                                                                   |
-| `.detach()`              | Removes host from DOM                             | —                                                                                             |
-| `.appendTo(target)`      | Appends host to target                            | —                                                                                             |
-| `.trigger(eventName)`    | Dispatches CustomEvent                            | `bubbles: true`                                                                               |
+**When to use native DOM**: Always, inside the component's own code (`init`, `onAppend`, `onRemove`, event handlers, etc.).
 
-#### `this.ui.find()` limitations
-
-`find()` returns a **minimal** jQuery-like wrapper, NOT a full jQuery object. It only supports:
-
-- `.length` / `[0]` — element access
-- `.each(fn)` — iterate
-- `.click(fn)` — add click listener
-- `.text(val)` — get/set textContent
-
-It does **NOT** support `.css()`, `.html()`, `.val()`, `.addClass()`, `.removeClass()`, `.attr()`, `.data()`, `.on()`, `.off()`, etc. For anything beyond the basics, use native DOM:
-
-```javascript
-// DON'T — will crash
-this.ui.find('.foo').css('color', 'red');
-
-// DO — use native DOM
-const root = this._shadow || this._host;
-root.querySelector('.foo').style.color = 'red';
-```
-
-### 8. Convert preferences (position save/restore)
+### 8. Convert preferences (save/restore position)
 
 **Before:**
 
 ```javascript
-// Position is saved/restored via jQuery .position() and .css()
+Guild.onRemove = function onRemove() {
+	_preferences.x = parseInt(this.ui.css('left'), 10);
+	_preferences.y = parseInt(this.ui.css('top'), 10);
+	_preferences.save();
+};
 ```
 
 **After:**
@@ -328,11 +305,13 @@ root.querySelector('.foo').style.color = 'red';
 ```javascript
 Clan.onRemove = function onRemove() {
 	const rect = this._host.getBoundingClientRect();
-	_preferences.x = rect.left;
-	_preferences.y = rect.top;
+	_preferences.x = Math.round(rect.left);
+	_preferences.y = Math.round(rect.top);
 	_preferences.save();
 };
 ```
+
+Uses native `getBoundingClientRect()` instead of parsing CSS strings.
 
 ### 9. Register with UIManager
 
@@ -341,7 +320,6 @@ Same as before:
 ```javascript
 export default UIManager.addComponent(Clan);
 ```
-
 `UIManager.addComponent()` accepts both `UIComponent` and `GUIComponent` instances.
 
 ---
@@ -350,67 +328,50 @@ export default UIManager.addComponent(Clan);
 
 ### Grid Snap
 
-Components can snap to a grid when dragged by setting `gridSnap`:
+Draggable components can snap to a grid on mouse release:
 
 ```javascript
-MyComponent.gridSnap = {
-	width: 32, // grid cell width in px
-	height: 32, // grid cell height in px
-	padX: 0, // horizontal offset
-	padY: 0 // vertical offset
-};
-MyComponent.snapDuration = 150; // snap animation duration in ms (default: 150)
+Clan.gridSnap = { width: 32, height: 32, padX: 0, padY: 0 };
+Clan.snapDuration = 150; // ms, CSS transition duration
 ```
 
-On `mouseup`, the component animates to the nearest grid position using CSS transitions. Useful for hotbar/skillbar components.
-
-### CSS Hot-Reload
-
-During development, component CSS can be hot-reloaded without refreshing:
-
-```javascript
-// Instance method — reloads CSS for this component's Shadow DOM
-myComponent.reloadCSS(newCssText);
-
-// Static method — injects CSS into a global <style> tag (fallback for non-migrated components)
-GUIComponent.reloadCSS('ComponentName', newCssText);
-```
+The component will animate to the nearest grid position when the user stops dragging.
 
 ### Clone
 
-Components can be cloned for multi-instance use:
+Deep-clone a GUIComponent instance:
 
 ```javascript
-const clone = originalComponent.clone('NewName', true); // true = copy all properties
+const clone = Clan.clone();
 ```
-
-The clone gets its own Shadow DOM and proxy but shares the same `render()` function.
 
 ---
 
-## Known Shadow DOM Pitfalls (Bug Reference)
+## Known Shadow DOM Pitfalls (already fixed)
 
-### 1. jQuery `.show()` sets `display: block` instead of restoring original value
+These issues were encountered during the first migration (Clan) and are documented here to explain the fixes and prevent regressions.
 
-**Bug**: jQuery 1.9.1's `isHidden()` function uses `jQuery.contains(document, element)` which returns `false` for elements inside Shadow DOM (because `Node.contains()` does not traverse shadow boundaries). When `.show()` is called, jQuery thinks the element was never in the document, falls back to `css_defaultDisplay("DIV")` which returns `"block"`, and sets `display: block` inline — overriding any CSS `display: flex` or `display: grid`.
+### 1. jQuery `.show()` sets `display: block`, breaking flex/grid layouts
+
+**Bug**: jQuery's `.show()` sets `element.style.display = 'block'` regardless of the element's CSS `display` value. For elements that use `display: flex` (like the scrollbar), this breaks the layout.
 
 **Fix applied in `src/UI/Scrollbar.js`** (commit `7ce87bf9`):
 
 ```javascript
-// WRONG — jQuery .show() sets display:block, kills flex layout
-$scrollbar.show();
+// WRONG
 $scrollbar.hide();
+$scrollbar.show();
 
-// CORRECT — manipulate style.display directly
-$scrollbar[0].style.display = ''; // removes inline style, CSS rule applies
+// CORRECT
 $scrollbar[0].style.display = 'none';
+$scrollbar[0].style.display = '';  // ← resets to CSS value (flex)
 ```
 
-**RULE**: Never use jQuery `.show()`, `.hide()`, `.toggle()`, `.fadeIn()`, `.fadeOut()` on elements inside Shadow DOM. Always use `element.style.display` directly.
+**RULE**: Never use jQuery `.show()`/`.hide()` on elements that may have non-block display. Use `element.style.display = ''` (empty string resets to the CSS-declared value) and `element.style.display = 'none'`.
 
 ### 2. Global CSS does not penetrate Shadow DOM
 
-**Bug**: CSS rules in the global `<style>` tag (e.g., `.custom-cursor * { cursor: none!important; }` from CursorManager) do not affect elements inside Shadow DOM.
+**Bug**: CSS rules in the global `<style>` tag (e.g., `.custom-cursor * { cursor: none !important; }` from CursorManager) do not affect elements inside Shadow DOM.
 
 **Fix applied in `src/UI/Common.css`** (commit `f4183351`):
 
@@ -426,7 +387,7 @@ This rule is inside `Common.css` which is injected into every Shadow DOM. `:host
 
 ### 3. Scrollbar CSS injection into Shadow DOM
 
-**Bug**: The scrollbar CSS (`.ui-custom-scrollbar` styles) is injected into the global `<style>` tag by `Scrollbar.js setupStyles()`. These styles don't reach elements inside Shadow DOM.
+**Bug**: The scrollbar CSS (`.ro-custom-scrollbar` styles) is injected into the global `<style>` tag by `Scrollbar.js setupStyles()`. These styles don't reach elements inside Shadow DOM.
 
 **Fix applied in `src/UI/Scrollbar.js`** (commit `b9d21673`):
 
@@ -503,32 +464,20 @@ offsetParent() {
 
 This mimics jQuery's `.offsetParent()` behavior. No action needed from the component author.
 
-### ~~7. The `this.ui.css()` proxy does not support object syntax as first argument~~ (FIXED)
+### ~~7. `this.ui.css()` object syntax~~ (FIXED)
 
-**Previously**: The `css()` method on the proxy checked `if (value === undefined)` before `if (typeof prop === 'object')`. Calling `this.ui.css({ top: 100, left: 200 })` entered the getter branch and crashed with `prop.replace is not a function`.
-
-**Fix**: The `css()` method now checks `typeof prop === 'object'` first, correctly handling object syntax:
+Previously broken, now fixed. Both proxy syntaxes work:
 
 ```javascript
-css(prop, value) {
-    if (typeof prop === 'object') {
-        for (const [k, v] of Object.entries(prop)) {
-            host.style[k] = typeof v === 'number' && !CSS_NUMBER[k] ? v + 'px' : String(v);
-        }
-        return proxy;
-    }
-    if (value === undefined) {
-        // Getter: .css('top')
-        ...
-    }
-}
+this.ui.css({ top: 100, left: 200 });
+this.ui.css('top', 100);
 ```
 
-Both syntaxes now work:
+Prefer native DOM:
 
 ```javascript
-this.ui.css({ top: 100, left: 200 }); // ✅ object syntax
-this.ui.css('top', 100); // ✅ individual call
+this._host.style.top = '100px';
+this._host.style.left = '200px';
 ```
 
 ---
@@ -540,6 +489,8 @@ this.ui.css('top', 100); // ✅ individual call
 - `src/UI/Components/Clan/Clan.js` — Component logic
 - `src/UI/Components/Clan/Clan.html` — HTML template using `<ui-button>`, `<ui-text>`
 - `src/UI/Components/Clan/Clan.css` — Styles with `:host` for dimensions/position
+
+> **Note**: The Clan component was the first GUIComponent migration and still uses some `this.ui` proxy calls (`this.ui.hide()`, `this.ui.show()`, `this.ui.is(':visible')`). New components should use native DOM equivalents as described in this guide.
 
 ### CSS Pattern
 
@@ -562,14 +513,17 @@ this.ui.css('top', 100); // ✅ individual call
 
 ## Quick Reference: What NOT to do
 
-| Don't                                                               | Do instead                                      | Why                                                |
-| ------------------------------------------------------------------- | ----------------------------------------------- | -------------------------------------------------- |
-| `jQuery(element).show()` inside shadow                              | `element.style.display = ''`                    | jQuery sets `display:block`, kills flex/grid       |
-| `$el.closest('body').length`                                        | `el.isConnected`                                | `.closest()` can't cross shadow boundary           |
-| `document.querySelector('.my-shadow-element')`                      | `this._shadow.querySelector(...)`               | Global queries can't see shadow content            |
-| Put `top`/`left` on inner element                                   | Put on `:host`                                  | Breaks magnetic snap positioning                   |
-| Omit `:host { width; height }`                                      | Always declare dimensions on `:host`            | Host collapses to 0×0, snap/overflow broken        |
-| Register click handlers on `document.body` expecting shadow targets | Register inside `this._container`               | Event retargeting hides real target                |
-| `this.ui.find('.foo').css(...)`                                     | `root.querySelector('.foo').style.x = y`        | `find()` wrapper doesn't support `.css()`          |
-| Bind events in `onAppend()`                                         | Bind in `init()`, restore state in `onAppend()` | `onAppend()` runs every time — duplicates bindings |
-| Set `position`/`z-index` on `:host` in CSS                          | Omit — set automatically by JS                  | Redundant, may conflict                            |
+| Don't                                                               | Do instead                                       | Why                                          |
+| ------------------------------------------------------------------- | ------------------------------------------------ | -------------------------------------------- |
+| `jQuery(element).show()` inside shadow                              | `element.style.display = ''`                     | jQuery sets `display:block`, kills flex/grid |
+| `$el.closest('body').length`                                        | `el.isConnected`                                 | `.closest()` can't cross shadow boundary     |
+| `document.querySelector('.my-shadow-element')`                      | `this._shadow.querySelector(...)`                | Global queries can't see shadow content      |
+| `this.ui.find('.foo')`                                              | `this._shadow.querySelector('.foo')`             | Proxy is for interop only                    |
+| `this.ui.css('top', '100px')`                                      | `this._host.style.top = '100px'`                 | Proxy is for interop only                    |
+| `this.ui.show()` / `this.ui.hide()`                                | `this._host.style.display = ''` / `= 'none'`    | Proxy is for interop only                    |
+| `this.ui.is(':visible')`                                            | `this._host.style.display !== 'none'`            | Proxy is for interop only                    |
+| Put `top`/`left` on inner element                                   | Put on `:host`                                   | Breaks magnetic snap positioning             |
+| Omit `:host { width; height }`                                      | Always declare dimensions on `:host`             | Host collapses to 0×0, snap/overflow broken  |
+| Register click handlers on `document.body` expecting shadow targets | Register inside `this._container`                | Event retargeting hides real target          |
+| Bind events in `onAppend()`                                        | Bind in `init()`, restore state in `onAppend()`  | `onAppend()` runs every time — duplicates bindings |
+| Set `position`/`z-index` on `:host` in CSS                         | Omit — set automatically by JS                   | Redundant, may conflict                      |

--- a/doc/UIComponent_to_GUIComponent.md
+++ b/doc/UIComponent_to_GUIComponent.md
@@ -30,6 +30,74 @@ document.body
                 └── ...content...
 ```
 
+> **Note**: `this._host` receives `position: absolute` and `z-index: 50` via JavaScript during `prepare()`. You do **not** need to declare these in your `:host` CSS.
+
+---
+
+## Lifecycle Hooks
+
+GUIComponent has three lifecycle hooks. Understanding when each runs is critical to avoid bugs like duplicate event bindings.
+
+```
+prepare()
+  ├── build Shadow DOM, inject CSS, render HTML
+  ├── _processAllDataAttrs()
+  ├── _createUIProxy()
+  ├── appendChild(host) to document.body   ← host IS in the DOM
+  ├── init()                               ← runs ONCE
+  ├── _setupMouseMode()
+  └── host.remove()                        ← host removed from DOM
+
+append()
+  ├── appendChild(host) to target          ← host IS in the DOM
+  ├── onAppend()                           ← runs EVERY TIME append() is called
+  ├── _setupScrollbars()
+  ├── _fixPositionOverflow()
+  └── focus()
+
+remove()
+  ├── onRemove()                           ← runs EVERY TIME remove() is called
+  ├── unbind keydown
+  ├── dispatch 'x_remove' event
+  └── host.remove()                        ← host removed from DOM
+```
+
+| Hook         | When it runs                                              | Use for                                                                  |
+| ------------ | --------------------------------------------------------- | ------------------------------------------------------------------------ |
+| `init()`     | Once, during `prepare()`. Host is temporarily in the DOM. | One-time setup: `draggable()`, event binding, initial `this.ui.hide()`   |
+| `onAppend()` | Every time `append()` is called. Host is in the DOM.      | Position restore, anything that must run each time the component appears |
+| `onRemove()` | Every time `remove()` is called, before detach.           | Save preferences, cleanup                                                |
+
+**RULE**: Bind events in `init()` (runs once). Restore position/state in `onAppend()` (runs every time). Save state in `onRemove()`.
+
+---
+
+## Mouse Modes
+
+Each GUIComponent has a `mouseMode` property that controls how mouse events interact with the 3D scene behind the UI:
+
+```javascript
+const MouseMode = Object.freeze({
+	CROSS: 0, // Mouse crosses the UI and still intersects with the scene
+	STOP: 1, // Blocks scene intersection when mouse is over the UI
+	FREEZE: 2 // Blocks scene intersection while the UI is alive (modal)
+});
+```
+
+| Mode     | Use case                                 | Example                         |
+| -------- | ---------------------------------------- | ------------------------------- |
+| `CROSS`  | Transparent overlays, HUD elements       | Minimap, chat bubbles           |
+| `STOP`   | Standard windows (default)               | Clan, Inventory, Equipment      |
+| `FREEZE` | Modal dialogs that block all interaction | NPC dialog, confirmation popups |
+
+Set it on the component instance:
+
+```javascript
+Clan.mouseMode = GUIComponent.MouseMode.STOP;
+```
+
+---
+
 ## Step-by-Step Migration Checklist
 
 ### 1. Create the component files
@@ -64,9 +132,7 @@ import cssText from './Clan.css?raw';
 
 const Clan = new GUIComponent('Clan', cssText); // ← only CSS, not HTML
 
-Clan.render = function render() {
-	return htmlText; // ← HTML goes here
-};
+Clan.render = () => htmlText; // ← HTML goes here
 ```
 
 Key differences:
@@ -130,6 +196,8 @@ The host element (`this._host`) is what the outside world sees. Its dimensions d
 }
 ```
 
+> **Note**: You do NOT need `position: absolute` or `z-index` on `:host` — these are set via JavaScript in `prepare()`.
+
 **WHY**: If `top`/`left` remain on the inner element, it offsets the content inside the host. The host's `getBoundingClientRect()` returns the host's position, not the inner element's visual position. This causes magnetic snap to align to wrong edges (especially bottom/right).
 
 **WHY `position: absolute` on inner element**: The inner `#Clan` div needs `position: absolute` (or `relative`) to serve as a containing block for its children that use `position: absolute`. Without it, absolutely-positioned children would escape to the next positioned ancestor.
@@ -171,19 +239,22 @@ Guild.init = function init() {
 ```javascript
 Clan.init = function init() {
 	this.draggable('.titlebar'); // ← accepts CSS selector string (resolved inside shadow)
-};
-
-Clan.onAppend = function onAppend() {
 	const root = this._shadow || this._host;
 	const closeBtn = root.querySelector('.close');
 	if (closeBtn) {
 		closeBtn.addEventListener('mousedown', e => e.stopImmediatePropagation());
 		closeBtn.addEventListener('click', () => Clan.toggle());
 	}
+	this.ui.hide();
+};
+
+Clan.onAppend = function onAppend() {
+	this._host.style.left = `${_preferences.x}px`;
+	this._host.style.top = `${_preferences.y}px`;
 };
 ```
 
-**RULE**: `draggable()` accepts a CSS selector string — it resolves inside the shadow DOM automatically. Event binding that depends on the DOM being in the document should go in `onAppend()`, not `init()`.
+**RULE**: `draggable()` accepts a CSS selector string — it resolves inside the shadow DOM automatically. Event binding goes in `init()` (runs once). Position restore goes in `onAppend()` (runs every time).
 
 ### 7. Convert show/hide/toggle
 
@@ -206,7 +277,43 @@ Clan.toggle = function () {
 // Or use this.hide() / this.show() if defined
 ```
 
-The `this.ui` proxy implements `.is(':visible')`, `.show()`, `.hide()`, `.css()`, `.offset()`, `.position()`, `.width()`, `.height()`, `.find()`, `.parent()`, `.detach()`, `.appendTo()`, `.trigger()`.
+The `this.ui` proxy implements the following jQuery-compatible methods:
+
+| Method                   | Behavior                                          | Notes                                                                                         |
+| ------------------------ | ------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| `.css(prop, value)`      | Get/set inline styles on host                     | Supports object syntax: `.css({ top: 100, left: 200 })`. Auto-appends `px` to numeric values. |
+| `.offset()`              | Returns `{ left, top }` relative to document      | Uses `getBoundingClientRect()`                                                                |
+| `.offsetParent()`        | Returns positioned ancestor                       | Mimics jQuery's walk-up behavior                                                              |
+| `.position()`            | Returns `{ left, top }` relative to offset parent | Uses `offsetLeft`/`offsetTop`                                                                 |
+| `.width()` / `.height()` | Returns dimensions                                | Uses `getBoundingClientRect()`                                                                |
+| `.is(':visible')`        | Visibility check                                  | Checks `display !== 'none'` and `offsetParent !== null`                                       |
+| `.show()`                | Removes `display: none`                           | Also calls `_fixPositionOverflow()` automatically                                             |
+| `.hide()`                | Sets `display: none`                              | —                                                                                             |
+| `.find(selector)`        | Query inside shadow DOM                           | Returns mini-wrapper (see limitations below)                                                  |
+| `.parent()`              | Returns parent wrapper                            | Only has `.append()` method                                                                   |
+| `.detach()`              | Removes host from DOM                             | —                                                                                             |
+| `.appendTo(target)`      | Appends host to target                            | —                                                                                             |
+| `.trigger(eventName)`    | Dispatches CustomEvent                            | `bubbles: true`                                                                               |
+
+#### `this.ui.find()` limitations
+
+`find()` returns a **minimal** jQuery-like wrapper, NOT a full jQuery object. It only supports:
+
+- `.length` / `[0]` — element access
+- `.each(fn)` — iterate
+- `.click(fn)` — add click listener
+- `.text(val)` — get/set textContent
+
+It does **NOT** support `.css()`, `.html()`, `.val()`, `.addClass()`, `.removeClass()`, `.attr()`, `.data()`, `.on()`, `.off()`, etc. For anything beyond the basics, use native DOM:
+
+```javascript
+// DON'T — will crash
+this.ui.find('.foo').css('color', 'red');
+
+// DO — use native DOM
+const root = this._shadow || this._host;
+root.querySelector('.foo').style.color = 'red';
+```
 
 ### 8. Convert preferences (position save/restore)
 
@@ -236,6 +343,48 @@ export default UIManager.addComponent(Clan);
 ```
 
 `UIManager.addComponent()` accepts both `UIComponent` and `GUIComponent` instances.
+
+---
+
+## Additional Features
+
+### Grid Snap
+
+Components can snap to a grid when dragged by setting `gridSnap`:
+
+```javascript
+MyComponent.gridSnap = {
+	width: 32, // grid cell width in px
+	height: 32, // grid cell height in px
+	padX: 0, // horizontal offset
+	padY: 0 // vertical offset
+};
+MyComponent.snapDuration = 150; // snap animation duration in ms (default: 150)
+```
+
+On `mouseup`, the component animates to the nearest grid position using CSS transitions. Useful for hotbar/skillbar components.
+
+### CSS Hot-Reload
+
+During development, component CSS can be hot-reloaded without refreshing:
+
+```javascript
+// Instance method — reloads CSS for this component's Shadow DOM
+myComponent.reloadCSS(newCssText);
+
+// Static method — injects CSS into a global <style> tag (fallback for non-migrated components)
+GUIComponent.reloadCSS('ComponentName', newCssText);
+```
+
+### Clone
+
+Components can be cloned for multi-instance use:
+
+```javascript
+const clone = originalComponent.clone('NewName', true); // true = copy all properties
+```
+
+The clone gets its own Shadow DOM and proxy but shares the same `render()` function.
 
 ---
 
@@ -354,22 +503,32 @@ offsetParent() {
 
 This mimics jQuery's `.offsetParent()` behavior. No action needed from the component author.
 
-### 7. The `this.ui.css()` proxy does not support object syntax as first argument
+### ~~7. The `this.ui.css()` proxy does not support object syntax as first argument~~ (FIXED)
 
-**Current limitation**: The `css()` method on the proxy checks `if (value === undefined)` before `if (typeof prop === 'object')`. Calling `this.ui.css({ top: 100, left: 200 })` enters the getter branch and crashes with `prop.replace is not a function`.
+**Previously**: The `css()` method on the proxy checked `if (value === undefined)` before `if (typeof prop === 'object')`. Calling `this.ui.css({ top: 100, left: 200 })` entered the getter branch and crashed with `prop.replace is not a function`.
 
-**Workaround**: Use individual calls:
+**Fix**: The `css()` method now checks `typeof prop === 'object'` first, correctly handling object syntax:
 
 ```javascript
-this.ui.css('top', 100);
-this.ui.css('left', 200);
+css(prop, value) {
+    if (typeof prop === 'object') {
+        for (const [k, v] of Object.entries(prop)) {
+            host.style[k] = typeof v === 'number' && !CSS_NUMBER[k] ? v + 'px' : String(v);
+        }
+        return proxy;
+    }
+    if (value === undefined) {
+        // Getter: .css('top')
+        ...
+    }
+}
 ```
 
-Or manipulate the host directly:
+Both syntaxes now work:
 
 ```javascript
-this._host.style.top = '100px';
-this._host.style.left = '200px';
+this.ui.css({ top: 100, left: 200 }); // ✅ object syntax
+this.ui.css('top', 100); // ✅ individual call
 ```
 
 ---
@@ -403,11 +562,14 @@ this._host.style.left = '200px';
 
 ## Quick Reference: What NOT to do
 
-| Don't                                                               | Do instead                           | Why                                          |
-| ------------------------------------------------------------------- | ------------------------------------ | -------------------------------------------- |
-| `jQuery(element).show()` inside shadow                              | `element.style.display = ''`         | jQuery sets `display:block`, kills flex/grid |
-| `$el.closest('body').length`                                        | `el.isConnected`                     | `.closest()` can't cross shadow boundary     |
-| `document.querySelector('.my-shadow-element')`                      | `this._shadow.querySelector(...)`    | Global queries can't see shadow content      |
-| Put `top`/`left` on inner element                                   | Put on `:host`                       | Breaks magnetic snap positioning             |
-| Omit `:host { width; height }`                                      | Always declare dimensions on `:host` | Host collapses to 0×0, snap/overflow broken  |
-| Register click handlers on `document.body` expecting shadow targets | Register inside `this._container`    | Event retargeting hides real target          |
+| Don't                                                               | Do instead                                      | Why                                                |
+| ------------------------------------------------------------------- | ----------------------------------------------- | -------------------------------------------------- |
+| `jQuery(element).show()` inside shadow                              | `element.style.display = ''`                    | jQuery sets `display:block`, kills flex/grid       |
+| `$el.closest('body').length`                                        | `el.isConnected`                                | `.closest()` can't cross shadow boundary           |
+| `document.querySelector('.my-shadow-element')`                      | `this._shadow.querySelector(...)`               | Global queries can't see shadow content            |
+| Put `top`/`left` on inner element                                   | Put on `:host`                                  | Breaks magnetic snap positioning                   |
+| Omit `:host { width; height }`                                      | Always declare dimensions on `:host`            | Host collapses to 0×0, snap/overflow broken        |
+| Register click handlers on `document.body` expecting shadow targets | Register inside `this._container`               | Event retargeting hides real target                |
+| `this.ui.find('.foo').css(...)`                                     | `root.querySelector('.foo').style.x = y`        | `find()` wrapper doesn't support `.css()`          |
+| Bind events in `onAppend()`                                         | Bind in `init()`, restore state in `onAppend()` | `onAppend()` runs every time — duplicates bindings |
+| Set `position`/`z-index` on `:host` in CSS                          | Omit — set automatically by JS                  | Redundant, may conflict                            |


### PR DESCRIPTION
Updates `doc/UIComponent_to_GUIComponent.md` and `doc/CustomElements.md` to match the actual codebase and adds missing sections that are important for component migration.  
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mrantares/robrowserlegacy/pull/1064" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
