### PR TITLE
fix: cleaned manipulation on Roulette/Roulette.css

### DIFF
--- a/src/UI/Components/Roulette/Roulette.css
+++ b/src/UI/Components/Roulette/Roulette.css
@@ -171,7 +171,6 @@
 	background-repeat: no-repeat;
 	background-position: center;
 	color: #fff;
-	cursor: pointer;
 	border-radius: 5px;
 	transition: background-color 0.3s;
 }
@@ -186,7 +185,6 @@
 
 #Roulette .buttons-container button:disabled {
 	opacity: 0.5;
-	cursor: not-allowed;
 }
 
 #Roulette .result-display {
@@ -244,7 +242,6 @@
 	background-size: contain !important;
 	background-repeat: no-repeat !important;
 	background-position: center !important;
-	cursor: pointer !important;
 	display: block !important;
 	min-width: 43px !important;
 	min-height: 43px !important;


### PR DESCRIPTION
this fixes default cursor overrides custom cursor on roulete interactions
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mrantares/robrowserlegacy/pull/1071" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
