### PR TITLE
chore: add warning to unsuported encryption to GRF tester tools

### DIFF
--- a/src/Loaders/GameFile.js
+++ b/src/Loaders/GameFile.js
@@ -228,7 +228,7 @@ class GRF {
 			(data[0] !== 0x78 || (data[1] !== 0x9c && data[1] !== 0x01 && data[1] !== 0xda && data[1] !== 0x5e))
 		) {
 			console.warn(
-				`GRF: file "${entry.filename}" is using a new encryption method by Gravity which is not supported.`
+				`GRF: file "${entry.filename}" is using a new encryption method which is not supported.`
 			);
 			return;
 		}

--- a/src/Loaders/GameFile.js
+++ b/src/Loaders/GameFile.js
@@ -223,6 +223,16 @@ class GRF {
 			return;
 		}
 
+		if (
+			data[0] !== 0 &&
+			(data[0] !== 0x78 || (data[1] !== 0x9c && data[1] !== 0x01 && data[1] !== 0xda && data[1] !== 0x5e))
+		) {
+			console.warn(
+				`GRF: file "${entry.filename}" is using a new encryption method by Gravity which is not supported.`
+			);
+			return;
+		}
+
 		// Uncompress
 		try {
 			out = new Uint8Array(entry.real_size);


### PR DESCRIPTION
add specific warning to new encryption method
<img width="1340" height="518" alt="image" src="https://github.com/user-attachments/assets/1a745a5e-1786-4010-9465-2acb0450e928" />

instead of generic error
<img width="584" height="393" alt="image" src="https://github.com/user-attachments/assets/4e6f743b-8e87-4ca0-b23f-fd2ac39ef5a4" />

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mrantares/robrowserlegacy/pull/1074" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
