### PR TITLE
optimize: drag loop use rAF, hoist helpers, skip idle frames, and drop jQuery from mouse tracking

### DIFF
--- a/src/Controls/MouseEventHandler.js
+++ b/src/Controls/MouseEventHandler.js
@@ -8,8 +8,6 @@
  * @author Vincent Thibault
  */
 
-import jQuery from 'Utils/jquery.js';
-
 /**
  * Mouse object
  */
@@ -51,12 +49,16 @@ class Mouse {
 }
 
 /**
- * Track mouse move event
+ * Track mouse move event (native, passive)
  */
-jQuery(window).mousemove(event => {
-	Mouse.screen.x = event.pageX;
-	Mouse.screen.y = event.pageY;
-});
+window.addEventListener(
+	'mousemove',
+	event => {
+		Mouse.screen.x = event.pageX;
+		Mouse.screen.y = event.pageY;
+	},
+	{ passive: true }
+);
 
 /**
  * Export

--- a/src/UI/Components/CashShopIcon/CashShopIcon.js
+++ b/src/UI/Components/CashShopIcon/CashShopIcon.js
@@ -53,6 +53,8 @@ function stopPropagation(event) {
 	return false;
 }
 
+CashShopIcon.needFocus = false;
+
 /**
  * Create component and export it
  */

--- a/src/UI/Components/PCGoldTimer/PCGoldTimer.js
+++ b/src/UI/Components/PCGoldTimer/PCGoldTimer.js
@@ -141,6 +141,8 @@ PCGoldTimer.formatTime = function formatTime(millisecondsMissing) {
 	return minutes.toString().padStart(2, '0') + ':' + seconds.toString().padStart(2, '0');
 };
 
+PCGoldTimer.needFocus = false;
+
 /**
  * Create component and export it
  */

--- a/src/UI/GUIComponent.js
+++ b/src/UI/GUIComponent.js
@@ -466,6 +466,7 @@ class GUIComponent {
 	draggable(handle) {
 		const host = this._host;
 		const component = this;
+		const SNAP_DISTANCE = 10;
 
 		if (!host) return this;
 
@@ -504,7 +505,15 @@ class GUIComponent {
 				const components = component.manager.components;
 				for (const name in components) {
 					const other = components[name];
-					if (!other || other === component || !other.__active) continue;
+					if (
+						!other ||
+						other === component ||
+						!other.__active ||
+						!other.needFocus ||
+						!other.ui ||
+						!other.ui.is(':visible')
+					)
+						continue;
 
 					const el = other._host || (other.ui && other.ui[0]);
 					if (!el) continue;
@@ -528,6 +537,8 @@ class GUIComponent {
 
 			let drag;
 			let currentOpacity = 1.0;
+			let lastMx = Mouse.screen.x;
+			let lastMy = Mouse.screen.y;
 
 			// Stop drag on mouseup / touchend
 			const onEnd = ev => {
@@ -555,7 +566,6 @@ class GUIComponent {
 						const snappedX = gxi * gw + padX;
 						const snappedY = gyi * gh + padY;
 
-						// Animate snap using CSS transition
 						host.style.transition = `left ${component.snapDuration || 150}ms, top ${component.snapDuration || 150}ms, opacity 150ms`;
 						host.style.left = snappedX + 'px';
 						host.style.top = snappedY + 'px';
@@ -568,7 +578,6 @@ class GUIComponent {
 						};
 						host.addEventListener('transitionend', onTransEnd);
 					} else {
-						// Restore opacity with transition
 						host.style.transition = 'opacity 150ms';
 						host.style.opacity = '1';
 						const onTransEnd = () => {
@@ -585,12 +594,21 @@ class GUIComponent {
 			window.addEventListener('touchend', onEnd);
 
 			// Drag loop
-
 			const dragging = () => {
-				let x_ = Mouse.screen.x + x;
-				let y_ = Mouse.screen.y + y;
+				const mx = Mouse.screen.x;
+				const my = Mouse.screen.y;
+
+				// Skip frame if mouse hasn't moved
+				if (mx === lastMx && my === lastMy) {
+					drag = requestAnimationFrame(dragging);
+					return;
+				}
+				lastMx = mx;
+				lastMy = my;
+
+				let x_ = mx + x;
+				let y_ = my + y;
 				currentOpacity = Math.max(currentOpacity - 0.02, 0.7);
-				const snapDistance = 10;
 
 				// Reset magnet
 				if (component.magnet) {
@@ -602,19 +620,19 @@ class GUIComponent {
 				}
 
 				// Border magnet
-				if (Math.abs(x_) < snapDistance) {
+				if (Math.abs(x_) < SNAP_DISTANCE) {
 					x_ = 0;
 					if (component.magnet) component.magnet.LEFT = true;
 				}
-				if (Math.abs(y_) < snapDistance) {
+				if (Math.abs(y_) < SNAP_DISTANCE) {
 					y_ = 0;
 					if (component.magnet) component.magnet.TOP = true;
 				}
-				if (Math.abs(x_ + width - Mouse.screen.width) < snapDistance) {
+				if (Math.abs(x_ + width - Mouse.screen.width) < SNAP_DISTANCE) {
 					x_ = Mouse.screen.width - width;
 					if (component.magnet) component.magnet.RIGHT = true;
 				}
-				if (Math.abs(y_ + height - Mouse.screen.height) < snapDistance) {
+				if (Math.abs(y_ + height - Mouse.screen.height) < SNAP_DISTANCE) {
 					y_ = Mouse.screen.height - height;
 					if (component.magnet) component.magnet.BOTTOM = true;
 				}
@@ -625,8 +643,8 @@ class GUIComponent {
 					const lockY = component.magnet && (component.magnet.TOP || component.magnet.BOTTOM);
 					let snapX = null,
 						snapY = null;
-					let snapXD = snapDistance + 1,
-						snapYD = snapDistance + 1;
+					let snapXD = SNAP_DISTANCE + 1,
+						snapYD = SNAP_DISTANCE + 1;
 
 					const checkX = val => {
 						const d = Math.abs(val - x_);
@@ -642,7 +660,7 @@ class GUIComponent {
 							snapY = val;
 						}
 					};
-					const isNear = (sA, eA, sB, eB) => !(eA + snapDistance < sB || eB + snapDistance < sA);
+					const isNear = (sA, eA, sB, eB) => !(eA + SNAP_DISTANCE < sB || eB + SNAP_DISTANCE < sA);
 
 					for (let i = 0; i < _snapCache.length; i++) {
 						const box = _snapCache[i];

--- a/src/UI/UIComponent.js
+++ b/src/UI/UIComponent.js
@@ -585,7 +585,6 @@ UIComponent.prototype.draggable = function draggable(element) {
 			}
 		}
 
-		// checkX/checkY/isNear fora do loop (evita recriar ~60x/s)
 		let snapX, snapY, snapXD, snapYD, currentX, currentY;
 
 		function checkX(val) {

--- a/src/UI/UIComponent.js
+++ b/src/UI/UIComponent.js
@@ -13,7 +13,6 @@ import jQuery from 'Utils/jquery.js';
 import Cursor from './CursorManager.js';
 import DB from 'DB/DBManager.js';
 import Client from 'Core/Client.js';
-import Events from 'Core/Events.js';
 import Mouse from 'Controls/MouseEventHandler.js';
 import UIPreferences from 'Preferences/UI.js';
 import Session from 'Engine/SessionStorage.js';
@@ -510,6 +509,7 @@ UIComponent.prototype.draggable = function draggable(element) {
 	});
 
 	const component = this;
+	const SNAP_DISTANCE = 10;
 
 	// Global variable
 	if (!element) {
@@ -543,6 +543,10 @@ UIComponent.prototype.draggable = function draggable(element) {
 		const width = container.width();
 		const height = container.height();
 
+		let lastMx = Mouse.screen.x;
+		let lastMy = Mouse.screen.y;
+		let currentOpacity = parseFloat(container.css('opacity') || 1);
+
 		_snapCache = [];
 		if (UIPreferences.windowmagnet && component.manager) {
 			const containerParent = container.offsetParent();
@@ -551,7 +555,15 @@ UIComponent.prototype.draggable = function draggable(element) {
 			for (const name in components) {
 				const other = components[name];
 
-				if (!other || other === component || !other.__active || !other.ui || !other.ui.length) {
+				if (
+					!other ||
+					other === component ||
+					!other.__active ||
+					!other.needFocus ||
+					!other.ui ||
+					!other.ui.length ||
+					!other.ui.is(':visible')
+				) {
 					continue;
 				}
 
@@ -573,11 +585,32 @@ UIComponent.prototype.draggable = function draggable(element) {
 			}
 		}
 
+		// checkX/checkY/isNear fora do loop (evita recriar ~60x/s)
+		let snapX, snapY, snapXD, snapYD, currentX, currentY;
+
+		function checkX(val) {
+			const d = Math.abs(val - currentX);
+			if (d < snapXD) {
+				snapXD = d;
+				snapX = val;
+			}
+		}
+		function checkY(val) {
+			const d = Math.abs(val - currentY);
+			if (d < snapYD) {
+				snapYD = d;
+				snapY = val;
+			}
+		}
+		function isNear(startA, endA, startB, endB) {
+			return !(endA + SNAP_DISTANCE < startB || endB + SNAP_DISTANCE < startA);
+		}
+
 		// Start the loop
 		container.stop();
-		drag = Events.setTimeout(dragging, 15);
+		drag = requestAnimationFrame(dragging);
 
-		// Stop the drag (need to focus on window to avoid possible errors...)
+		// Stop the drag
 		jQuery(window).on('mouseup.dragdrop touchend.dragdrop', function (ev) {
 			if (ev.type === 'touchend' || ev.which === 1 || ev.isTrigger) {
 				if (component.gridSnap) {
@@ -618,7 +651,7 @@ UIComponent.prototype.draggable = function draggable(element) {
 					});
 				}
 
-				Events.clearTimeout(drag);
+				cancelAnimationFrame(drag);
 				jQuery(window).off('mouseup.dragdrop touchend.dragdrop');
 				_snapCache = [];
 			}
@@ -626,70 +659,52 @@ UIComponent.prototype.draggable = function draggable(element) {
 
 		// Process dragging
 		function dragging() {
-			let x_ = Mouse.screen.x + x;
-			let y_ = Mouse.screen.y + y;
-			const opacity = parseFloat(container.css('opacity') || 1) - 0.02;
-			const snapDistance = 10;
+			const mx = Mouse.screen.x;
+			const my = Mouse.screen.y;
+
+			// Skip frame if mouse hasn't moved
+			if (mx === lastMx && my === lastMy) {
+				drag = requestAnimationFrame(dragging);
+				return;
+			}
+			lastMx = mx;
+			lastMy = my;
+
+			let x_ = mx + x;
+			let y_ = my + y;
+			currentOpacity = Math.max(currentOpacity - 0.02, 0.7);
 
 			if (component.magnet) {
 				component.magnet.TOP = component.magnet.BOTTOM = component.magnet.LEFT = component.magnet.RIGHT = false;
 			}
 
 			// Magnet on border
-			if (Math.abs(x_) < snapDistance) {
+			if (Math.abs(x_) < SNAP_DISTANCE) {
 				x_ = 0;
-				if (component.magnet) {
-					component.magnet.LEFT = true;
-				}
+				if (component.magnet) component.magnet.LEFT = true;
 			}
-			if (Math.abs(y_) < snapDistance) {
+			if (Math.abs(y_) < SNAP_DISTANCE) {
 				y_ = 0;
-				if (component.magnet) {
-					component.magnet.TOP = true;
-				}
+				if (component.magnet) component.magnet.TOP = true;
 			}
-
-			if (Math.abs(x_ + width - Mouse.screen.width) < snapDistance) {
+			if (Math.abs(x_ + width - Mouse.screen.width) < SNAP_DISTANCE) {
 				x_ = Mouse.screen.width - width;
-				if (component.magnet) {
-					component.magnet.RIGHT = true;
-				}
+				if (component.magnet) component.magnet.RIGHT = true;
 			}
-
-			if (Math.abs(y_ + height - Mouse.screen.height) < snapDistance) {
+			if (Math.abs(y_ + height - Mouse.screen.height) < SNAP_DISTANCE) {
 				y_ = Mouse.screen.height - height;
-				if (component.magnet) {
-					component.magnet.BOTTOM = true;
-				}
+				if (component.magnet) component.magnet.BOTTOM = true;
 			}
 
 			if (UIPreferences.windowmagnet && component.manager) {
 				const lockX = component.magnet && (component.magnet.LEFT || component.magnet.RIGHT);
 				const lockY = component.magnet && (component.magnet.TOP || component.magnet.BOTTOM);
-				let snapX = null;
-				let snapY = null;
-				let snapXD = snapDistance + 1;
-				let snapYD = snapDistance + 1;
-
-				function checkX(val) {
-					const d = Math.abs(val - x_);
-					if (d < snapXD) {
-						snapXD = d;
-						snapX = val;
-					}
-				}
-
-				function checkY(val) {
-					const d = Math.abs(val - y_);
-					if (d < snapYD) {
-						snapYD = d;
-						snapY = val;
-					}
-				}
-
-				function isNear(startA, endA, startB, endB) {
-					return !(endA + snapDistance < startB || endB + snapDistance < startA);
-				}
+				snapX = null;
+				snapY = null;
+				snapXD = SNAP_DISTANCE + 1;
+				snapYD = SNAP_DISTANCE + 1;
+				currentX = x_;
+				currentY = y_;
 
 				const len = _snapCache.length;
 				for (let i = 0; i < len; i++) {
@@ -710,17 +725,13 @@ UIComponent.prototype.draggable = function draggable(element) {
 					}
 				}
 
-				if (!lockX && snapX !== null) {
-					x_ = snapX;
-				}
-				if (!lockY && snapY !== null) {
-					y_ = snapY;
-				}
+				if (!lockX && snapX !== null) x_ = snapX;
+				if (!lockY && snapY !== null) y_ = snapY;
 			}
 
 			container.offset({ top: y_, left: x_ });
-			container.css('opacity', Math.max(opacity, 0.7));
-			drag = Events.setTimeout(dragging, 15);
+			container.css('opacity', Math.max(currentOpacity, 0.7));
+			drag = requestAnimationFrame(dragging);
 		}
 	});
 


### PR DESCRIPTION
Micro-optimizations targeting the window-dragging hot path in both `GUIComponent` and `UIComponent`, plus a lightweight change to `MouseEventHandler`.

### Changes
**`src/Controls/MouseEventHandler.js`**
- Replace `jQuery(window).mousemove(…)` with a native `window.addEventListener('mousemove', …, { passive: true })`, removing the jQuery import entirely. The `passive` flag tells the browser the handler will never call `preventDefault()`, allowing scroll/compositor optimizations.

**`src/UI/GUIComponent.js`**
- Hoist `SNAP_DISTANCE` as a constant outside the drag loop to avoid re-creating it every frame.
- Track `lastMx` / `lastMy` and **skip the frame** when the mouse position hasn't changed, avoiding unnecessary DOM writes (~60 fps → only when needed).
- Add early-continue guards (`!other.needFocus`, `!other.ui`, `!other.ui.is(':visible')`) when building the snap cache so invisible or non-focusable windows are excluded upfront.

**`src/UI/UIComponent.js`**
- Replace `Events.setTimeout(dragging, 15)` / `Events.clearTimeout(drag)` with native `requestAnimationFrame` / `cancelAnimationFrame`, aligning the drag loop with the browser's paint cycle instead of a fixed 15 ms timer.
- Remove the now-unused `Events` import.
- Hoist `checkX`, `checkY`, and `isNear` helper functions **outside** the `dragging()` closure so they are created once per drag session instead of being re-allocated ~60 times/second.
- Track `currentOpacity` in a variable instead of reading it from the DOM (`container.css('opacity')`) every frame.
- Same idle-frame skip (`lastMx` / `lastMy`) and snap-cache filtering improvements as in `GUIComponent`.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mrantares/robrowserlegacy/pull/1076" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
