### PR TITLE
chore: fix left over from cart renderer

### DIFF
--- a/src/Engine/MapEngine/Skill.js
+++ b/src/Engine/MapEngine/Skill.js
@@ -594,7 +594,7 @@ function onIncreaseSkill(SKID) {
 Guild.onIncreaseSkill =
 	SkillListMH.homunculus.onIncreaseSkill =
 	SkillListMH.mercenary.onIncreaseSkill =
-		onIncreaseSkill;
+	onIncreaseSkill;
 
 /**
  * Cast a skill on someone
@@ -705,7 +705,7 @@ Guild.onUseSkill =
 	SkillListMH.homunculus.onUseSkill =
 	SkillListMH.mercenary.onUseSkill =
 	SkillTargetSelection.onUseSkillToId =
-		onUseSkill;
+	onUseSkill;
 
 /**
  * Cast a skill on the ground
@@ -924,6 +924,5 @@ export default function SkillEngine() {
 	Network.hookPacket(PACKET.ZC.MSG_SKILL, onMessageSkill);
 	Network.hookPacket(PACKET.ZC.MONSTER_INFO, onSense);
 	Network.hookPacket(PACKET.ZC.DEVOTIONLIST, onDevotionList);
-	Network.registerPacket(0x97f, PACKET.ZC.SELECTCART);
 	Network.hookPacket(PACKET.ZC.SELECTCART, pkt => CartDecoration.onSelectCart(pkt));
 }

--- a/src/Network/PacketLength.js
+++ b/src/Network/PacketLength.js
@@ -62,8 +62,6 @@ const packetModules = {
 };
 
 let packets_len = new Array();
-packets_len[0x097f] = -1;
-packets_len[0x0980] = 7;
 
 /**
  * Get a Packet Length

--- a/src/UI/Components/CartDecoration/CartDecoration.js
+++ b/src/UI/Components/CartDecoration/CartDecoration.js
@@ -117,6 +117,7 @@ CartDecoration.onSelectCart = function onSelectCart(pkt) {
 	}
 
 	CartDecoration.ui.show();
+	Renderer.stop(render);
 	Renderer.render(render);
 };
 


### PR DESCRIPTION
Remove wrong SELECTCART packet register and remove the packet length entries (0x097f and 0x0980) from PacketLength. Also call Renderer.stop(render) before Renderer.render(render) in CartDecoration to avoid overlapping render loops. Minor formatting cleanup of skill handler assignments.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mrantares/robrowserlegacy/pull/1080" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
