### PR TITLE
add 2nd part of energy drain skill effect

### DIFF
--- a/src/DB/Effects/EffectTable.js
+++ b/src/DB/Effects/EffectTable.js
@@ -7784,7 +7784,61 @@ export default {
 			drainPattern: true
 		}
 	],
-	//379: [{}],	//EF_TRANSBLUEBODY	   Soul Drain (2nd Part)
+	379: [
+		{
+			//EF_TRANSBLUEBODY	   Energy Drain (2nd Part)
+			type: 'FUNC',
+			attachedEntity: true,
+			func: function EffectBodyColor(Params) {
+				const entity = Params.Init.ownerEntity;
+				entity.animations.add(function (tick) {
+					// Wait for drain particles from Part 1 (Soul Drain travel)
+					if (tick < 500) {
+						return false;
+					}
+
+					const time = tick - 500;
+
+					// Enable halo (Double Body)
+					entity._enableHalo = true;
+
+					// Part 2: Blue tint progression (200ms duration from official source)
+					if (time < 200) {
+						// Formula from official source: m_master->SetArgb(-1, 255-(m_stateCnt+50), 255-(m_stateCnt+50), 255)
+						const val = (255 - (time + 50)) / 255;
+						entity._flashColor[0] = val;
+						entity._flashColor[1] = val;
+						entity._flashColor[2] = 1.0;
+						entity._flashColor[3] = 1.0;
+						entity.recalculateBlendingColor();
+						return false;
+					}
+
+					// Part 3: Smooth fade back to normal (200ms) for premium feel
+					if (time < 400) {
+						const progress = (time - 200) / 200;
+						const startVal = 5 / 255; // 255 - (200 + 50)
+						const val = startVal + (1.0 - startVal) * progress;
+						entity._flashColor[0] = val;
+						entity._flashColor[1] = val;
+						entity._flashColor[2] = 1.0;
+						entity._flashColor[3] = 1.0;
+						entity.recalculateBlendingColor();
+						return false;
+					}
+
+					// Final reset
+					entity._enableHalo = false;
+					entity._flashColor[0] = 1.0;
+					entity._flashColor[1] = 1.0;
+					entity._flashColor[2] = 1.0;
+					entity._flashColor[3] = 1.0;
+					entity.recalculateBlendingColor();
+					return true;
+				});
+			}
+		}
+	],
 
 	380: [
 		{

--- a/src/DB/Skills/SkillEffect.js
+++ b/src/DB/Skills/SkillEffect.js
@@ -395,7 +395,7 @@ SkillEffect[SK.CH_PALMSTRIKE] = { hitEffectId: [376, 'quake'] }; //Raging Palm S
 SkillEffect[SK.CH_TIGERFIST] = { effectIdOnCaster: 263, effectId: [377, 'quake'] }; //Glacier Fist
 SkillEffect[SK.CH_CHAINCRUSH] = { effectId: 512 }; //Chain Crush Combo
 // Professor
-SkillEffect[SK.PF_HPCONVERSION] = { effectId: 383, effectIdOnCaster: 378 /*, successEffectIdOnCaster: 379 */ }; //Indulge
+SkillEffect[SK.PF_HPCONVERSION] = { effectId: 383, effectIdOnCaster: 378, successEffectIdOnCaster: 379 }; //Indulge
 SkillEffect[SK.PF_SOULCHANGE] = { effectId: 384, successEffectId: 385 }; //Soul Exhale
 SkillEffect[SK.PF_SOULBURN] = { effectId: 406 }; //Soul Siphon
 // Asassin Cross

--- a/src/Renderer/Entity/EntityRender.js
+++ b/src/Renderer/Entity/EntityRender.js
@@ -757,7 +757,7 @@ const renderElement = (function renderElementClosure() {
 		const isBERSERK = entity.getOpt3(StatusConst.Status.BERSERK);
 
 		renderSecondBody(entity, layers, spr, pal, files, type, _position, {
-			enableHalo: entity.getOpt3(StatusConst.Status.ASSUMPTIO),
+			enableHalo: entity.getOpt3(StatusConst.Status.ASSUMPTIO) || !!entity._enableHalo,
 			enableTrail:
 				isENERGYCOAT ||
 				isBUNSIN ||


### PR DESCRIPTION
This PR implements the previously commented-out visual effect 379 (EF_TRANSBLUEBODY) — the "2nd part" of the Energy/Soul Drain animation for the PF_HPCONVERSION skill. The effect plays on the caster upon successful cast:

Waits 500ms for Part 1 drain particles to arrive
Enables a halo (double body) on the entity
Applies a blue tint over 200ms (R/G fade down, B stays 1.0)
Smoothly fades back to normal over another 200ms
Resets halo and color
The renderer is extended to support a new _enableHalo flag so the effect can programmatically toggle the halo without requiring the Assumptio status.

https://github.com/user-attachments/assets/c93f7c3e-c2e4-4fd9-99bb-af78db18c2ca


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mrantares/robrowserlegacy/pull/1088" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
