### PR TITLE
add second part of wizzard soul drain effect

### DIFF
--- a/src/DB/Effects/EffectTable.js
+++ b/src/DB/Effects/EffectTable.js
@@ -4487,6 +4487,54 @@ export default {
 			arc: 3.0,
 			retreat: 3.0,
 			drainPattern: true
+		},
+		{
+			type: 'FUNC',
+			attachedEntity: true,
+			func: function EffectBodyColor(Params) {
+				const entity = Params.Init.ownerEntity;
+				entity.animations.add(function (tick) {
+					// Wait for drain particles from Part 1 (Soul Drain travel)
+					if (tick < 500) {
+						return false;
+					}
+
+					const time = tick - 500;
+
+					// Part 2: Blue tint progression (200ms duration from official source)
+					if (time < 200) {
+						// Formula from official source: m_master->SetArgb(-1, 255-(m_stateCnt+50), 255-(m_stateCnt+50), 255)
+						const val = (255 - (time + 50)) / 255;
+						entity._flashColor[0] = val;
+						entity._flashColor[1] = val;
+						entity._flashColor[2] = 1.0;
+						entity._flashColor[3] = 1.0;
+						entity.recalculateBlendingColor();
+						return false;
+					}
+
+					// Part 3: Smooth fade back to normal (200ms) for premium feel
+					if (time < 400) {
+						const progress = (time - 200) / 200;
+						const startVal = 5 / 255; // 255 - (200 + 50)
+						const val = startVal + (1.0 - startVal) * progress;
+						entity._flashColor[0] = val;
+						entity._flashColor[1] = val;
+						entity._flashColor[2] = 1.0;
+						entity._flashColor[3] = 1.0;
+						entity.recalculateBlendingColor();
+						return false;
+					}
+
+					// Final reset
+					entity._flashColor[0] = 1.0;
+					entity._flashColor[1] = 1.0;
+					entity._flashColor[2] = 1.0;
+					entity._flashColor[3] = 1.0;
+					entity.recalculateBlendingColor();
+					return true;
+				});
+			}
 		}
 	],
 
@@ -7758,7 +7806,7 @@ export default {
 
 	378: [
 		{
-			//EF_ENERGYDRAIN2          Soul Drain (1st Part)
+			//EF_ENERGYDRAIN2          Energy Drain (1st Part)
 			type: '3D',
 			duration: 600,
 			duplicate: 5,
@@ -7799,7 +7847,7 @@ export default {
 
 					const time = tick - 500;
 
-					// Enable halo (Double Body)
+					// Enable halo (BL_DOUBLE_BODY actor)
 					entity._enableHalo = true;
 
 					// Part 2: Blue tint progression (200ms duration from official source)

--- a/src/Renderer/Entity/EntityRender.js
+++ b/src/Renderer/Entity/EntityRender.js
@@ -475,10 +475,21 @@ const renderEntity = (function renderEntityClosure() {
 	};
 })();
 
+/**
+ * Render second body (BL_DOUBLE_BODY + EF_MAKEBLUR)
+ * @param {Entity} entity
+ * @param {Array} layers
+ * @param {string} spr
+ * @param {string} pal
+ * @param {object} files
+ * @param {string} type
+ * @param {number[]} _position
+ * @param {object} options
+ */
 function renderSecondBody(entity, layers, spr, pal, files, type, _position, options = {}) {
 	// options:
-	// - options.enableHalo: boolean  -> halo type Assumptio
-	// - options.enableTrail: boolean -> trail behind the character
+	// - options.enableHalo: boolean  -> halo type Assumptio (BL_DOUBLE_BODY)
+	// - options.enableTrail: boolean -> trail behind the character (EF_MAKEBLUR)
 	// - options.trailLength: number  -> number of ghosts to keep
 	// - options.blurType: number     -> 1 (standard) EF_MAKEBLUR , 3 (spaced) - EF_MAKEBLUR3, 4 (once), 5 (attack only) - EF_MAKEBLUR5
 	const { enableHalo = false, enableTrail = false, trailLength = 5, blurType = 1 } = options;


### PR DESCRIPTION
same effect than second part of energy drain but no halo and no separate id
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mrantares/robrowserlegacy/pull/1089" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
