### PR TITLE
Revert "Allow LUA interpreter wasm to be loaded from a custom URL."

### DIFF
--- a/applications/api/api.js
+++ b/applications/api/api.js
@@ -316,16 +316,7 @@
 		 * the total will be the double in ms because its used on fade in then on fade out
 		 * eg: if you use 500ms the transition will take 1000ms in total
 		 */
-		transitionDuration: 500,
-
-		/**
-		 * @type {string} Define custom source location of liblua5.1.wasm.
-		 * used for allowing servers to host their own copy of the lua wasm, and avoid
-		 * requiring an internet connection for lua support. (Also for those that care
-		 * about telemetry being handed out about their users as a hard requirement.
-		 * GDPR / etc. Or those that worry about supply chain attacks.)
-		 */
-		luaWasmUri: ''
+		transitionDuration: 500
 	};
 
 	/**

--- a/applications/pwa/Config.js
+++ b/applications/pwa/Config.js
@@ -55,7 +55,6 @@ window.ROConfigBase = {
 	grfList: null,
 	hashFiles: [],
 	loadLua: false,
-	luaWasmUri: '',
 	onReady: null,
 	plugins: {},
 	registrationweb: '',

--- a/doc/README.md
+++ b/doc/README.md
@@ -439,7 +439,6 @@ var ROConfig = {
 	enableCheckAttendance: false, // Enable Check Attendance? (Requires PACKETVER 20180307 above)
 	enableHomunAutoFeed: false, // Enable Homunculus Auto Feed for older PACKETVER than 20170920
 	loadLua: false, // Enable this option to load LUA tables (currently only item table) from client/System/...
-	luaWasmUri: '', // Set this option to change where the LUA interpreter's WASM module will be fetched from at runtime. (By default it uses the library's built in URL, on unpkg.com)
 	customItemInfo: ['kRO.lua', 'jRO.lua', 'lua files514/iteminfo.lua'], // Customized iteminfo array-list, it loads using firt to last priority
 
 	//clientHash:    '113e195e6c051bb1cfb12a644bb084c5', // Set fixed client hash value here (less secure, for development only)

--- a/src/DB/DBManager.js
+++ b/src/DB/DBManager.js
@@ -3718,17 +3718,11 @@ class DB {
 }
 
 async function startLua() {
-	const options = {};
-	const wasm_uri = Configs.get('luaWasmUri', '');
-	if (wasm_uri != '') {
-		console.log('Loading lua interpreter wasm from ', wasm_uri);
-		Object.assign(options, { customWasmUri: wasm_uri });
-	}
-	lua = await CLua.Lua.create(options);
-	HO_AI = await CLua.Lua.create(options);
-	MER_AI = await CLua.Lua.create(options);
-	default_HO_AI = await CLua.Lua.create(options);
-	default_MER_AI = await CLua.Lua.create(options);
+	lua = await CLua.Lua.create();
+	HO_AI = await CLua.Lua.create();
+	MER_AI = await CLua.Lua.create();
+	default_HO_AI = await CLua.Lua.create();
+	default_MER_AI = await CLua.Lua.create();
 }
 
 function loadFontFromClient(fontPath) {


### PR DESCRIPTION
Reverts MrAntares/roBrowserLegacy#1098

This reverts the luaWasmUri configuration option.

Our wasmoon build was modified to remove all remote fetching and URL-based
resolution in order to avoid Vite "externalized for browser compatibility"
warnings and guarantee the WASM is always bundled and loaded locally.

Because the WASM is no longer fetched from a remote source, allowing a custom
URI is unnecessary and misleading. The interpreter always uses the local
bundled liblua5.1.wasm.

This also keeps behavior deterministic and avoids reintroducing external
network access.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mrantares/robrowserlegacy/pull/1099" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
