### PR TITLE
add Dangerous Soul Collect(Zen) skill effect

### DIFF
--- a/src/DB/Effects/EffectTable.js
+++ b/src/DB/Effects/EffectTable.js
@@ -8886,9 +8886,9 @@ export default {
 						return false;
 					}
 
-					// Part 3: Smooth fade back to normal
+					// Part 2: Smooth fade back to normal
 					if (time < 800) {
-						const progress = (time - 400) / 400;
+						const progress = (time - 200) / 600;
 						entity._flashColor[0] = 1.0 - 0.5 * progress;
 						entity._flashColor[1] = 1.0 - 0.5 * progress;
 						entity._flashColor[2] = 0.0 + 0.5 * progress;

--- a/src/DB/Effects/EffectTable.js
+++ b/src/DB/Effects/EffectTable.js
@@ -8867,7 +8867,47 @@ export default {
 	],
 
 	//401: [{}],	//EF_NAPALMVALCAN	   Napalm Vulcan Sound
-	//402: [{}],	//EF_PORTAL5	   Dangerous Soul Collect
+	402: [
+		//EF_PORTAL5	   Dangerous Soul Collect
+		{
+			type: 'FUNC',
+			attachedEntity: true,
+			func: function EffectBodyColor(Params) {
+				const entity = Params.Init.ownerEntity;
+				entity.animations.add(function (tick) {
+					const time = tick;
+
+					if (time < 200) {
+						entity._flashColor[0] = 1.0; // Red
+						entity._flashColor[1] = 1.0; // Green
+						entity._flashColor[2] = 0.0; // Blue
+						entity._flashColor[3] = 0.1; // Alpha (10%)
+						entity.recalculateBlendingColor();
+						return false;
+					}
+
+					// Part 3: Smooth fade back to normal
+					if (time < 800) {
+						const progress = (time - 400) / 400;
+						entity._flashColor[0] = 1.0 - 0.5 * progress;
+						entity._flashColor[1] = 1.0 - 0.5 * progress;
+						entity._flashColor[2] = 0.0 + 0.5 * progress;
+						entity._flashColor[3] = 0.1 + 0.9 * progress;
+						entity.recalculateBlendingColor();
+						return false;
+					}
+
+					// Final reset
+					entity._flashColor[0] = 1.0;
+					entity._flashColor[1] = 1.0;
+					entity._flashColor[2] = 1.0;
+					entity._flashColor[3] = 1.0;
+					entity.recalculateBlendingColor();
+					return true;
+				});
+			}
+		}
+	],
 
 	403: [
 		{

--- a/src/DB/Effects/EffectTable.js
+++ b/src/DB/Effects/EffectTable.js
@@ -8889,9 +8889,9 @@ export default {
 					// Part 2: Smooth fade back to normal
 					if (time < 800) {
 						const progress = (time - 200) / 600;
-						entity._flashColor[0] = 1.0 - 0.5 * progress;
-						entity._flashColor[1] = 1.0 - 0.5 * progress;
-						entity._flashColor[2] = 0.0 + 0.5 * progress;
+						entity._flashColor[0] = 1.0;
+						entity._flashColor[1] = 1.0;
+						entity._flashColor[2] = 0.0 + 1.0 * progress;
 						entity._flashColor[3] = 0.1 + 0.9 * progress;
 						entity.recalculateBlendingColor();
 						return false;

--- a/src/DB/Skills/SkillAction.js
+++ b/src/DB/Skills/SkillAction.js
@@ -48,7 +48,7 @@ SkillAction['DEFAULT_DORAM'] = function (entity, tick) {
 //Skill action overrides
 
 //IDLE
-SkillAction[SK.ST_CHASEWALK] = function (entity, tick) {
+SkillAction[SK.ST_CHASEWALK] = SkillAction[SK.CH_SOULCOLLECT] = function (entity, tick) {
 	return {
 		action: entity.ACTION.IDLE,
 		frame: 0,
@@ -74,7 +74,6 @@ SkillAction[SK.SM_BASH] =
 	SkillAction[SK.RG_INTIMIDATE] =
 	SkillAction[SK.CR_SHIELDCHARGE] =
 	SkillAction[SK.CR_HOLYCROSS] =
-	SkillAction[SK.MO_EXTREMITYFIST] =
 	SkillAction[SK.MO_CHAINCOMBO] =
 	SkillAction[SK.MO_COMBOFINISH] =
 	SkillAction[SK.BA_MUSICALSTRIKE] =
@@ -413,6 +412,16 @@ SkillAction[SK.MO_INVESTIGATE] = SkillAction[SK.MO_FINGEROFFENSIVE] = function (
 		repeat: false,
 		play: false,
 		next: false
+	};
+};
+
+SkillAction[SK.MO_EXTREMITYFIST] = function (entity, tick) {
+	return {
+		action: entity.ACTION.ATTACK,
+		delay: tick + 100,
+		frame: 0,
+		repeat: false,
+		play: true
 	};
 };
 

--- a/src/DB/Skills/SkillEffect.js
+++ b/src/DB/Skills/SkillEffect.js
@@ -301,7 +301,7 @@ SkillEffect[SK.MO_INVESTIGATE] = { effectId: 267 }; //Occult Impaction
 SkillEffect[SK.MO_FINGEROFFENSIVE] = { effectId: 265, hitEffectId: 1 }; //Throw Spirit Sphere
 SkillEffect[SK.MO_STEELBODY] = { effectId: [254, 'quake'] }; //Mental Strength
 SkillEffect[SK.MO_BLADESTOP] = {}; //Root
-SkillEffect[SK.MO_EXPLOSIONSPIRITS] = { effectIdOnCaster: [261, 'quake'] }; //Fury
+SkillEffect[SK.MO_EXPLOSIONSPIRITS] = { beginCastEffectId: 12, effectIdOnCaster: [261, 'quake'] }; //Fury
 SkillEffect[SK.MO_EXTREMITYFIST] = {
 	effectId: srcAID => {
 		const src = EntityManager.get(srcAID);
@@ -458,7 +458,7 @@ SkillEffect[SK.LK_JOINTBEAT] = { beginCastEffectId: 400, hitEffectId: 'enemy_hit
 // High Wizard
 SkillEffect[SK.HW_NAPALMVULCAN] = { effectId: 401 }; //Napalm Vulcan
 // Champion
-SkillEffect[SK.CH_SOULCOLLECT] = { effectId: 402 }; //Zen
+SkillEffect[SK.CH_SOULCOLLECT] = { beginCastEffectId: [402, 12] }; //Zen
 // Professor
 SkillEffect[SK.PF_MINDBREAKER] = { successEffectId: 403 }; //Mind Breaker
 SkillEffect[SK.PF_MEMORIZE] = { effectId: 505 }; //Foresight


### PR DESCRIPTION
Implements effect 402 (Dangerous Soul Collect / EF_PORTAL5): a yellow flash → fade-to-normal color animation on the entity.

- Reworks SK.CH_SOULCOLLECT (Zen): changes from a ground effect to a begin-cast effect, and shares the skill action with SK.ST_CHASEWALK.
- Adds beginCastEffectId: 12 to SK.MO_EXPLOSIONSPIRITS (Fury).
- Separates SK.MO_EXTREMITYFIST into its own standalone skill action definition.

<img width="341" height="330" alt="image" src="https://github.com/user-attachments/assets/cc733afd-f1f2-4900-a7e0-75eccbb8a8b4" />

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mrantares/robrowserlegacy/pull/1102" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
