### PR TITLE
Fix entities not rendering behind transparent model walls

### DIFF
--- a/applications/browser-examples/demo.html
+++ b/applications/browser-examples/demo.html
@@ -54,6 +54,7 @@
 					development: true,
 					version: gitHash,
 					remoteClient: 'https://grf.robrowser.com/',
+					packetver: 20250618,
 					servers: [
 						{
 							display: 'roBrowser Demo Server[PRÉ]',
@@ -121,7 +122,7 @@
 					skipServerList: true,
 					skipIntro: false,
 					aura: {},
-					autoLogin: [],
+					autoLogin: ['aoshinho', '000000'],
 					BGMFileExtension: ['mp3'],
 					calculateHash: false,
 					CameraMaxZoomOut: 5,
@@ -140,6 +141,7 @@
 					grfList: null,
 					hashFiles: [],
 					loadLua: true,
+					customItemInfo: ['itemInfo.lub', 'itemInfo.lua'],
 					onReady: null,
 					plugins: {},
 					registrationweb: '',

--- a/applications/browser-examples/demo.html
+++ b/applications/browser-examples/demo.html
@@ -54,7 +54,6 @@
 					development: true,
 					version: gitHash,
 					remoteClient: 'https://grf.robrowser.com/',
-					packetver: 20250618,
 					servers: [
 						{
 							display: 'roBrowser Demo Server[PRÉ]',
@@ -122,7 +121,7 @@
 					skipServerList: true,
 					skipIntro: false,
 					aura: {},
-					autoLogin: ['aoshinho', '000000'],
+					autoLogin: [],
 					BGMFileExtension: ['mp3'],
 					calculateHash: false,
 					CameraMaxZoomOut: 5,
@@ -141,7 +140,6 @@
 					grfList: null,
 					hashFiles: [],
 					loadLua: true,
-					customItemInfo: ['itemInfo.lub', 'itemInfo.lua'],
 					onReady: null,
 					plugins: {},
 					registrationweb: '',

--- a/src/Renderer/Entity/EntityRender.js
+++ b/src/Renderer/Entity/EntityRender.js
@@ -465,9 +465,7 @@ const renderEntity = (function renderEntityClosure() {
 				SpriteRenderer.position[2] = SpriteRenderer.position[2] + 0.2;
 				SpriteRenderer.zIndex = 150;
 				// Non-player entities:
-				// - Do not write depth to avoid breaking PC occlusion and internal layer issues
-				// - Still use depth test for correct ordering
-				SpriteRenderer.runWithDepth(true, false, false, function () {
+				SpriteRenderer.runWithDepth(true, true, false, function () {
 					renderElement(self, self.files.body, 'body', _position, true);
 				});
 				break;
@@ -786,6 +784,13 @@ const renderElement = (function renderElementClosure() {
 		// Render all frames
 		for (let i = 0, count = layers.length; i < count; ++i) {
 			entity.renderLayer(layers[i], spr, pal, files.size, _position, type, isBlendModeOne);
+			if (
+				count > 1 &&
+				entity.objecttype !== entity.constructor.TYPE_PC &&
+				entity.objecttype !== entity.constructor.TYPE_MERC
+			) {
+				SpriteRenderer.zIndex += 250;
+			}
 		}
 
 		// Save reference

--- a/src/Renderer/Entity/EntityRender.js
+++ b/src/Renderer/Entity/EntityRender.js
@@ -260,14 +260,9 @@ const renderEntity = (function renderEntityClosure() {
 		// ------------------------------------------------------------------
 		// ENTITY RENDER PIPELINE
 		//
-		// PC / MERC:
 		// - Write depth (3D world occluders)
 		// - Use depth correction (isometric projection)
 		// - Use zIndex only for same-entity layering
-		//
-		// Others (npcs, mobs, items, effects, etc...):
-		// - Depth test only
-		// - Do NOT write depth (avoid occluding sprite layers)
 		// ------------------------------------------------------------------
 		switch (self.objecttype) {
 			case Entity.TYPE_PC:
@@ -464,7 +459,6 @@ const renderEntity = (function renderEntityClosure() {
 			default:
 				SpriteRenderer.position[2] = SpriteRenderer.position[2] + 0.2;
 				SpriteRenderer.zIndex = 150;
-				// Non-player entities:
 				SpriteRenderer.runWithDepth(true, true, false, function () {
 					renderElement(self, self.files.body, 'body', _position, true);
 				});

--- a/src/Renderer/Entity/EntityRender.js
+++ b/src/Renderer/Entity/EntityRender.js
@@ -263,6 +263,7 @@ const renderEntity = (function renderEntityClosure() {
 		// - Write depth (3D world occluders)
 		// - Use depth correction (isometric projection)
 		// - Use zIndex only for same-entity layering
+		//
 		// ------------------------------------------------------------------
 		switch (self.objecttype) {
 			case Entity.TYPE_PC:

--- a/src/Renderer/Map/AnimatedModels.js
+++ b/src/Renderer/Map/AnimatedModels.js
@@ -13,6 +13,7 @@ import WebGL from 'Utils/WebGL.js';
 import GraphicsSettings from 'Preferences/Graphics.js';
 import _vertexShader from './AnimatedModels.vs?raw';
 import _fragmentShader from './AnimatedModels.fs?raw';
+import SpriteRenderer from 'Renderer/SpriteRenderer';
 
 const mat3 = glMatrix.mat3;
 const mat4 = glMatrix.mat4;
@@ -723,31 +724,31 @@ function render(gl, modelView, projection, normalMat, fog, light, tick) {
 
 	gl.activeTexture(gl.TEXTURE0);
 	gl.uniform1i(uniform.uDiffuse, 0);
+	SpriteRenderer.runWithDepth(true, true, true, function () {
+		// Render each animated model
+		for (let m = 0; m < _animatedModels.length; m++) {
+			const model = _animatedModels[m];
+			const frame = tick % (model.animLen || 1);
 
-	// Render each animated model
-	for (let m = 0; m < _animatedModels.length; m++) {
-		const model = _animatedModels[m];
-		const frame = tick % (model.animLen || 1);
+			updateModelBuffer(gl, model, frame, false);
 
-		updateModelBuffer(gl, model, frame, false);
+			if (!model.buffer || model.meshInfos.length === 0) {
+				continue;
+			}
 
-		if (!model.buffer || model.meshInfos.length === 0) {
-			continue;
-		}
+			gl.bindVertexArray(model.vao);
 
-		gl.bindVertexArray(model.vao);
+			for (let i = 0; i < model.meshInfos.length; i++) {
+				const info = model.meshInfos[i];
+				const texture = model.textureObjects[info.textureIdx];
 
-		for (let i = 0; i < model.meshInfos.length; i++) {
-			const info = model.meshInfos[i];
-			const texture = model.textureObjects[info.textureIdx];
-
-			if (texture) {
-				gl.bindTexture(gl.TEXTURE_2D, texture);
-				gl.drawArrays(gl.TRIANGLES, info.vertOffset, info.vertCount);
+				if (texture) {
+					gl.bindTexture(gl.TEXTURE_2D, texture);
+					gl.drawArrays(gl.TRIANGLES, info.vertOffset, info.vertCount);
+				}
 			}
 		}
-	}
-
+	});
 	// Disable attributes
 	gl.bindVertexArray(null);
 }

--- a/src/Renderer/Map/AnimatedModels.js
+++ b/src/Renderer/Map/AnimatedModels.js
@@ -13,7 +13,7 @@ import WebGL from 'Utils/WebGL.js';
 import GraphicsSettings from 'Preferences/Graphics.js';
 import _vertexShader from './AnimatedModels.vs?raw';
 import _fragmentShader from './AnimatedModels.fs?raw';
-import SpriteRenderer from 'Renderer/SpriteRenderer';
+import SpriteRenderer from 'Renderer/SpriteRenderer.js';
 
 const mat3 = glMatrix.mat3;
 const mat4 = glMatrix.mat4;

--- a/src/Renderer/Map/Models.js
+++ b/src/Renderer/Map/Models.js
@@ -12,6 +12,7 @@ import _vertexShader from 'Renderer/Effects/Shaders/GLSL/Models.vs?raw';
 import _fragmentShader from 'Renderer/Effects/Shaders/GLSL/Models.fs?raw';
 import WebGL from 'Utils/WebGL.js';
 import Preferences from 'Preferences/Map.js';
+import SpriteRenderer from 'Renderer/SpriteRenderer';
 
 /**
  * @let {WebGLProgram}
@@ -181,26 +182,27 @@ function render(gl, modelView, projection, normalMat, fog, light) {
 	// Textures
 	gl.activeTexture(gl.TEXTURE0);
 	gl.uniform1i(uniform.uDiffuse, 0);
-
-	if (_batchesReady) {
-		// Optimized path: use pre-built batches with conditional texture binding
-		let lastTexture = null;
-		for (i = 0, count = _batches.length; i < count; ++i) {
-			if (_batches[i].texture !== lastTexture) {
-				gl.bindTexture(gl.TEXTURE_2D, _batches[i].texture);
-				lastTexture = _batches[i].texture;
+	SpriteRenderer.runWithDepth(true, true, true, function () {
+		if (_batchesReady) {
+			// Optimized path: use pre-built batches with conditional texture binding
+			let lastTexture = null;
+			for (i = 0, count = _batches.length; i < count; ++i) {
+				if (_batches[i].texture !== lastTexture) {
+					gl.bindTexture(gl.TEXTURE_2D, _batches[i].texture);
+					lastTexture = _batches[i].texture;
+				}
+				gl.drawArrays(gl.TRIANGLES, _batches[i].vertOffset, _batches[i].vertCount);
 			}
-			gl.drawArrays(gl.TRIANGLES, _batches[i].vertOffset, _batches[i].vertCount);
-		}
-	} else {
-		// Fallback: render individually while textures are still loading
-		for (i = 0, count = _objects.length; i < count; ++i) {
-			if (_objects[i].complete) {
-				gl.bindTexture(gl.TEXTURE_2D, _objects[i].texture);
-				gl.drawArrays(gl.TRIANGLES, _objects[i].vertOffset, _objects[i].vertCount);
+		} else {
+			// Fallback: render individually while textures are still loading
+			for (i = 0, count = _objects.length; i < count; ++i) {
+				if (_objects[i].complete) {
+					gl.bindTexture(gl.TEXTURE_2D, _objects[i].texture);
+					gl.drawArrays(gl.TRIANGLES, _objects[i].vertOffset, _objects[i].vertCount);
+				}
 			}
 		}
-	}
+	});
 
 	// Is it needed ?
 	gl.disableVertexAttribArray(attribute.aPosition);

--- a/src/Renderer/Map/Models.js
+++ b/src/Renderer/Map/Models.js
@@ -12,7 +12,7 @@ import _vertexShader from 'Renderer/Effects/Shaders/GLSL/Models.vs?raw';
 import _fragmentShader from 'Renderer/Effects/Shaders/GLSL/Models.fs?raw';
 import WebGL from 'Utils/WebGL.js';
 import Preferences from 'Preferences/Map.js';
-import SpriteRenderer from 'Renderer/SpriteRenderer';
+import SpriteRenderer from 'Renderer/SpriteRenderer.js';
 
 /**
  * @let {WebGLProgram}

--- a/src/Renderer/MapRenderer.js
+++ b/src/Renderer/MapRenderer.js
@@ -280,14 +280,13 @@ class MapRenderer {
 
 		// Rendering water (after sprites, billboard projection pushes it to back)
 		Water.render(gl, modelView, projection, fog, light, tick);
+		Models.render(gl, modelView, projection, normalMat, fog, light);
+		AnimatedModels.render(gl, modelView, projection, normalMat, fog, light, tick);
 
-		// Rendering effects
-		Damage.render(gl, modelView, projection, fog, tick);
 		EffectManager.render(gl, modelView, projection, fog, tick, false);
 		EntityManager.render(gl, modelView, projection, fog, true);
 
-		Models.render(gl, modelView, projection, normalMat, fog, light);
-		AnimatedModels.render(gl, modelView, projection, normalMat, fog, light, tick);
+		Damage.render(gl, modelView, projection, fog, tick);
 
 		// Render signboards
 		SignboardManager.render(gl, modelView, projection);

--- a/src/Renderer/MapRenderer.js
+++ b/src/Renderer/MapRenderer.js
@@ -235,8 +235,6 @@ class MapRenderer {
 		Effects.spam(Session.Entity.position, tick);
 
 		Ground.render(gl, modelView, projection, normalMat, fog, light);
-		Models.render(gl, modelView, projection, normalMat, fog, light);
-		AnimatedModels.render(gl, modelView, projection, normalMat, fog, light, tick);
 
 		if (Mouse.intersect && Altitude.intersect(modelView, projection, _pos)) {
 			x = _pos[0];
@@ -287,6 +285,9 @@ class MapRenderer {
 		Damage.render(gl, modelView, projection, fog, tick);
 		EffectManager.render(gl, modelView, projection, fog, tick, false);
 		EntityManager.render(gl, modelView, projection, fog, true);
+
+		Models.render(gl, modelView, projection, normalMat, fog, light);
+		AnimatedModels.render(gl, modelView, projection, normalMat, fog, light, tick);
 
 		// Render signboards
 		SignboardManager.render(gl, modelView, projection);


### PR DESCRIPTION
This PR fixes an issue where entities were occluded by transparent geometry from models and animated models. The problem occurred because `Models` and `AnimatedModels` were rendered before entities, while entities also avoided writing to the depth buffer, preventing proper ordering.
Since entities now write to depth, an automatic layer-based z-index increment was added for multi-layer monsters to avoid internal layer conflicts.

### Changes
* Render `Models` and `AnimatedModels` after entities
* Enable depth writing for non-player entities
* Implement automatic z-index increment per layer for multi-layer monsters

### Result
* Transparent model walls now correctly non-occlude entities
* Proper ordering between entities and models/animated models
* Multi-layer monsters render correctly without layer conflicts
* Consistent rendering with depth + distance-based z-index

this is same fix applyed on water rendering

<img width="767" height="556" alt="image" src="https://github.com/user-attachments/assets/e621132b-fa17-4ded-a7fd-48363215778d" />

this fixes #95 and fixes #53
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mrantares/robrowserlegacy/pull/1106" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
