### PR TITLE
Improve frame rate handling: disable Electron FPS cap and throttle UI-only screens

### DIFF
--- a/applications/electron/main.js
+++ b/applications/electron/main.js
@@ -10,6 +10,7 @@ app.commandLine.appendSwitch('enable-webgl');
 app.commandLine.appendSwitch('ignore-gpu-blacklist');
 app.commandLine.appendSwitch('disable-raf-throttling');
 app.commandLine.appendSwitch('disable-gpu-vsync');
+app.commandLine.appendSwitch('disable-frame-rate-limit');
 
 const projectRoot = path.resolve(__dirname, '..', '..');
 

--- a/src/Renderer/Renderer.js
+++ b/src/Renderer/Renderer.js
@@ -330,6 +330,14 @@ class Renderer {
 			}
 		}
 
+		// Force 60 FPS cap on UI-only screens (char select)
+		// where there is no 3D scene and uncapped FPS wastes resources
+		if (!Session.Playing && (this.frameLimit <= 0 || this.frameLimit > 60)) {
+			this.frameLimit = 60;
+		} else if (Session.Playing && this.frameLimit !== GraphicsSettings.fpslimit) {
+			this.frameLimit = GraphicsSettings.fpslimit;
+		}
+
 		// Throttle when frameLimit > 0
 		if (this.frameLimit > 0) {
 			const interval = 1000 / this.frameLimit;

--- a/src/UI/Components/CharSelect/CharSelectV4/CharSelectV4.js
+++ b/src/UI/Components/CharSelect/CharSelectV4/CharSelectV4.js
@@ -166,6 +166,7 @@ CharSelectV4.onRemove = function onRemove() {
 		clearInterval(_bgInterval);
 		_bgInterval = null;
 	}
+	stopCountdownInterval();
 	_preferences.index = _index;
 	_preferences.save();
 	Renderer.stop();

--- a/src/UI/Components/CharSelect/CharSelectV4/CharSelectV4.js
+++ b/src/UI/Components/CharSelect/CharSelectV4/CharSelectV4.js
@@ -134,7 +134,7 @@ CharSelectV4.init = function Init() {
 			_ctx.push(this.getContext('2d'));
 		});
 };
-
+let _bgInterval = null;
 /**
  * Once append to body
  */
@@ -153,7 +153,7 @@ CharSelectV4.onAppend = function onAppend() {
 
 	// Update values
 	moveCursorTo(_index);
-
+	_bgInterval = setInterval(changeBackgroundEverySecond, 150);
 	// Start rendering
 	Renderer.render(render);
 };
@@ -164,6 +164,10 @@ CharSelectV4.onAppend = function onAppend() {
 CharSelectV4.onRemove = function onRemove() {
 	_preferences.index = _index;
 	_preferences.save();
+	if (_bgInterval) {
+		clearInterval(_bgInterval);
+		_bgInterval = null;
+	}
 	Renderer.stop();
 };
 

--- a/src/UI/Components/CharSelect/CharSelectV4/CharSelectV4.js
+++ b/src/UI/Components/CharSelect/CharSelectV4/CharSelectV4.js
@@ -153,7 +153,7 @@ CharSelectV4.onAppend = function onAppend() {
 
 	// Update values
 	moveCursorTo(_index);
-	_bgInterval = setInterval(changeBackgroundEverySecond, 150);
+	_bgInterval = setInterval(changeBackgroundEverySecond, 250);
 	// Start rendering
 	Renderer.render(render);
 };
@@ -162,12 +162,12 @@ CharSelectV4.onAppend = function onAppend() {
  * Stop rendering
  */
 CharSelectV4.onRemove = function onRemove() {
-	_preferences.index = _index;
-	_preferences.save();
 	if (_bgInterval) {
 		clearInterval(_bgInterval);
 		_bgInterval = null;
 	}
+	_preferences.index = _index;
+	_preferences.save();
 	Renderer.stop();
 };
 
@@ -667,9 +667,6 @@ function changeBackgroundEverySecond() {
 		}
 	}
 }
-
-// Change the background every millisecond
-setInterval(changeBackgroundEverySecond, 150);
 
 function updateCharSlot() {
 	for (let i = 0; i < _maxSlots; ++i) {

--- a/src/UI/Components/Intro/Particle.js
+++ b/src/UI/Components/Intro/Particle.js
@@ -75,6 +75,15 @@ class Particle {
 	 */
 	static render() {
 		const now = Date.now();
+		// Throttle to ~60 FPS
+		const interval = 1000 / 60;
+		if (this._lastRenderTime && now - this._lastRenderTime < interval) {
+			if (this.process) {
+				this.requestRender.call(window, this.render.bind(this), this.canvas);
+			}
+			return;
+		}
+
 		let i, count;
 
 		this.ctx.clearRect(0, 0, this.width, this.height);
@@ -90,10 +99,10 @@ class Particle {
 		}
 
 		this.tick = now;
-
 		if (this.process) {
 			this.requestRender.call(window, this.render.bind(this), this.canvas);
 		}
+		this._lastRenderTime = now;
 	}
 
 	/**


### PR DESCRIPTION
This PR improves frame rate behavior and reduces unnecessary CPU/GPU usage on UI-only screens.

### Changes
* Disabled Electron frame rate limit using `disable-frame-rate-limit`
* Added automatic 60 FPS cap when not in-game (e.g., character select, intro screens)
* Restored user-configured FPS limit while playing
* Throttled Intro particle renderer to ~60 FPS
* Added interval lifecycle management for CharSelect background updates (prevent runaway intervals)

### Details
* Electron now runs without the default Chromium frame rate cap, allowing uncapped FPS during gameplay.
* Renderer enforces a 60 FPS cap when `Session.Playing` is false, preventing UI-only screens from consuming excessive resources.
* When entering gameplay, the renderer restores `GraphicsSettings.fpslimit`.
* Intro particle rendering is throttled to ~60 FPS to avoid unnecessary redraws.
* Character Select background update interval is now properly created and cleared on append/remove to prevent leaks.

### Result
* Uncapped FPS during gameplay (in Electron build or initing Chromium with disable-frame-rate-limit flag)
* Reduced CPU/GPU usage on menus and intro screens
* More consistent frame pacing

<img width="231" height="156" alt="image" src="https://github.com/user-attachments/assets/ecc758df-50dd-4f75-b18c-594d721ffd73" />

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mrantares/robrowserlegacy/pull/1109" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
