### PR TITLE
Add HTML pre-loader to eliminate white screen on startup

### DIFF
--- a/applications/browser-examples/demo.html
+++ b/applications/browser-examples/demo.html
@@ -1,200 +1,254 @@
-<!doctype html>
-<html>
-	<head>
-		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-		<meta charset="UTF-8" />
-		<title>Demo - roBrowserLegacy</title>
-		<link rel="icon" type="image/png" href="./icon.png" />
-
-		<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-		<meta name="HandheldFriendly" content="true" />
-
-		<meta name="apple-mobile-web-app-capable" content="yes" />
-		<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
-		<meta name="apple-mobile-web-app-title" content="roBrowser" />
-		<meta name="mobile-web-app-capable" content="yes" />
-
-		<meta name="description" content="roBrowser" />
-		<meta name="keywords" content="roBrowser" />
-		<meta name="author" content="roBrowser" />
-		<meta name="robots" content="index" />
-
-		<meta name="theme-color" content="#ff8cb5" />
-
-		<meta property="og:title" content="roBrowser" />
-		<meta property="og:description" content="roBrowser" />
-		<meta property="og:type" content="website" />
-		<meta property="og:locale" content="en_US" />
-
-		<link rel="apple-touch-icon" href="./icon.png" />
-
-		<style type="text/css">
-			html,
-			body {
-				margin: 0;
-				padding: 0;
-				border: 0;
-				height: 100%;
-				width: 100%;
-				overflow: hidden;
-			}
-			#robrowser {
-				height: 100%;
-				width: 100%;
-			}
-		</style>
-
-		<script type="text/javascript" src="../api/api.js"></script>
-		<script type="text/javascript">
-			function initialize(gitHash) {
-				var ROConfig = {
-					target: document.getElementById('robrowser'),
-					type: ROBrowser.TYPE.INLINE,
-					application: ROBrowser.APP.ONLINE,
-					development: true,
-					version: gitHash,
-					remoteClient: 'https://grf.robrowser.com/',
-					servers: [
-						{
-							display: 'roBrowser Demo Server[PRÉ]',
-							desc: '2013 demo server',
-							address: '127.0.0.1',
-							port: 6900,
-							version: 25,
-							langtype: 12,
-							packetver: 20130618,
-							renewal: false,
-							worldMapSettings: { episode: 12 },
-							packetKeys: false,
-							socketProxy: 'ws://localhost:5999',
-							adminList: []
-						},
-						{
-							display: 'roBrowser Demo Server[RE]',
-							desc: '2025 demo server',
-							address: '127.0.0.1',
-							port: 6900,
-							version: 55,
-							langtype: 12,
-							packetver: 20250618,
-							renewal: true,
-							worldMapSettings: { episode: 21 },
-							packetKeys: false,
-							socketProxy: 'ws://localhost:5999',
-							adminList: []
-						},
-						{
-							display: 'Ragna.ro',
-							desc: 'Ragna.ro [1/1/1] Renewal II',
-							address: 'ragna.ro',
-							port: 6900,
-							version: 30,
-							langtype: 240,
-							packetver: 20120410,
-							renewal: true,
-							worldMapSettings: { episode: 15 },
-							packetKeys: false,
-							socketProxy: 'wss://ragna.ro:5999',
-							remoteClient: 'https://client.ragna.ro/',
-							adminList: [2000000, 2000001],
-							FirstPersonCamera: true,
-							ThirdPersonCamera: true
-						},
-						{
-							display: 'NiktoutRO Chaos',
-							desc: 'NiktoutRO Chaos [100k/100k/10%]',
-							address: 'chaos.niktoutro.com',
-							port: 6905,
-							version: 55,
-							langtype: 1,
-							packetver: 20151104,
-							renewal: true,
-							socketProxy: 'wss://classicweb.niktoutro.com:5999',
-							remoteClient: 'https://classicweb.niktoutro.com/chaosclient/',
-							registrationweb: 'https://niktoutro.com/?module=account&action=create',
-							packetKeys: true,
-							adminList: [2000002]
-						}
-						// ADD PUBLIC TEST SERVERS HERE. IF YOU DON'T ALLOW _M _F REGISTRATION BE SURE TO ADD THE registrationweb CONFIG
-					],
-					packetDump: false,
-					skipServerList: true,
-					skipIntro: false,
-					aura: {},
-					autoLogin: [],
-					BGMFileExtension: ['mp3'],
-					calculateHash: false,
-					CameraMaxZoomOut: 5,
-					charBlockSize: 0,
-					clientHash: null,
-					clientVersionMode: 'PacketVer',
-					disableConsole: false,
-					enableBank: true,
-					enableCashShop: true,
-					enableCheckAttendance: true,
-					enableDmgSuffix: true,
-					enableHomunAutoFeed: true,
-					enableMapName: true,
-					enableRoulette: true,
-					FirstPersonCamera: false,
-					grfList: null,
-					hashFiles: [],
-					loadLua: true,
-					onReady: null,
-					plugins: {},
-					registrationweb: '',
-					saveFiles: false,
-					ThirdPersonCamera: false,
-					transitionDuration: 500,
-					restoreChatFocus: false
-				};
-				var RO = new ROBrowser(ROConfig);
-				RO.start();
-			}
-
-			var getJSON = function (url, callback) {
-				var xhr = new XMLHttpRequest();
-				xhr.open('GET', url, true);
-				xhr.responseType = 'json';
-				xhr.onload = function () {
-					var status = xhr.status;
-					if (status === 200) {
-						callback(null, xhr.response);
-					} else {
-						callback(status, xhr.response);
-					}
-				};
-				xhr.send();
-			};
-
-			window.addEventListener(
-				'load',
-				function () {
-					//Get latest GIT hash first then initialize
-					getJSON(
-						'https://api.github.com/repos/MrAntares/roBrowserLegacy/commits/master',
-						function (err, data) {
-							var gitHash = 'NO_INFO';
-							if (err !== null) {
-								console.warn('Error reading latest GIT hash.');
-							} else {
-								if (data && data.sha) {
-									gitHash = data.sha;
-									console.log('Latest GIT hash: ' + gitHash);
-								} else {
-									console.warn('No hash found in response');
-								}
-							}
-							initialize(gitHash);
-						}
-					);
-				},
-				false
-			);
-		</script>
-	</head>
-
-	<body>
-		<div id="robrowser">Initializing roBrowser [DevMode]...</div>
-	</body>
+<!doctype html>  
+<html>  
+	<head>  
+		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />  
+		<meta charset="UTF-8" />  
+		<title>Demo - roBrowserLegacy</title>  
+		<link rel="icon" type="image/png" href="./icon.png" />  
+  
+		<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />  
+		<meta name="HandheldFriendly" content="true" />  
+  
+		<meta name="apple-mobile-web-app-capable" content="yes" />  
+		<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />  
+		<meta name="apple-mobile-web-app-title" content="roBrowser" />  
+		<meta name="mobile-web-app-capable" content="yes" />  
+  
+		<meta name="description" content="roBrowser" />  
+		<meta name="keywords" content="roBrowser" />  
+		<meta name="author" content="roBrowser" />  
+		<meta name="robots" content="index" />  
+  
+		<meta name="theme-color" content="#ff8cb5" />  
+  
+		<meta property="og:title" content="roBrowser" />  
+		<meta property="og:description" content="roBrowser" />  
+		<meta property="og:type" content="website" />  
+		<meta property="og:locale" content="en_US" />  
+  
+		<link rel="apple-touch-icon" href="./icon.png" />  
+  
+		<style type="text/css">  
+			html,  
+			body {  
+				margin: 0;  
+				padding: 0;  
+				border: 0;  
+				height: 100%;  
+				width: 100%;  
+				overflow: hidden;  
+			}  
+			#robrowser {  
+				height: 100%;  
+				width: 100%;  
+			}  
+			/* Pre-loader — aparece instantaneamente, antes de qualquer JS */  
+			#ro-preloader {  
+				position: fixed;  
+				top: 0;  
+				left: 0;  
+				width: 100%;  
+				height: 100%;  
+				z-index: 99999;  
+				background: rgba(6, 8, 16, 0.97);  
+				display: flex;  
+				align-items: center;  
+				justify-content: center;  
+				flex-direction: column;  
+			}  
+			#ro-preloader .pre-spinner {  
+				width: 48px;  
+				height: 48px;  
+				margin: 0 auto 16px;  
+				border: 4px solid rgba(232, 184, 75, 0.2);  
+				border-top-color: #e8b84b;  
+				border-radius: 50%;  
+				animation: ro-pre-spin 0.8s linear infinite;  
+			}  
+			#ro-preloader .pre-text {  
+				font-family: serif;  
+				font-size: 16px;  
+				letter-spacing: 3px;  
+				text-transform: uppercase;  
+				color: #e8b84b;  
+			}  
+			#ro-preloader .pre-text span {  
+				display: inline-block;  
+				animation: ro-pre-wave 1.2s ease-in-out infinite;  
+				animation-delay: calc(var(--i) * 0.08s);  
+			}  
+			@keyframes ro-pre-spin {  
+				to { transform: rotate(360deg); }  
+			}  
+			@keyframes ro-pre-wave {  
+				0%, 60%, 100% { transform: translateY(0); }  
+				30% { transform: translateY(-8px); }  
+			}  
+			#ro-preloader.fade-out {  
+				opacity: 0;  
+				transition: opacity 0.3s ease;  
+			}  
+		</style>  
+  
+		<script type="text/javascript" src="../api/api.js"></script>  
+		<script type="text/javascript">  
+			function initialize(gitHash) {  
+				var ROConfig = {  
+					target: document.getElementById('robrowser'),  
+					type: ROBrowser.TYPE.INLINE,  
+					application: ROBrowser.APP.ONLINE,  
+					development: true,  
+					version: gitHash,  
+					remoteClient: 'https://grf.robrowser.com/',  
+					servers: [  
+						{  
+							display: 'roBrowser Demo Server[PRÉ]',  
+							desc: '2013 demo server',  
+							address: '127.0.0.1',  
+							port: 6900,  
+							version: 25,  
+							langtype: 12,  
+							packetver: 20130618,  
+							renewal: false,  
+							worldMapSettings: { episode: 12 },  
+							packetKeys: false,  
+							socketProxy: 'ws://localhost:5999',  
+							adminList: []  
+						},  
+						{  
+							display: 'roBrowser Demo Server[RE]',  
+							desc: '2025 demo server',  
+							address: '127.0.0.1',  
+							port: 6900,  
+							version: 55,  
+							langtype: 12,  
+							packetver: 20250618,  
+							renewal: true,  
+							worldMapSettings: { episode: 21 },  
+							packetKeys: false,  
+							socketProxy: 'ws://localhost:5999',  
+							adminList: []  
+						},  
+						{  
+							display: 'Ragna.ro',  
+							desc: 'Ragna.ro [1/1/1] Renewal II',  
+							address: 'ragna.ro',  
+							port: 6900,  
+							version: 30,  
+							langtype: 240,  
+							packetver: 20120410,  
+							renewal: true,  
+							worldMapSettings: { episode: 15 },  
+							packetKeys: false,  
+							socketProxy: 'wss://ragna.ro:5999',  
+							remoteClient: 'https://client.ragna.ro/',  
+							adminList: [2000000, 2000001],  
+							FirstPersonCamera: true,  
+							ThirdPersonCamera: true  
+						},  
+						{  
+							display: 'NiktoutRO Chaos',  
+							desc: 'NiktoutRO Chaos [100k/100k/10%]',  
+							address: 'chaos.niktoutro.com',  
+							port: 6905,  
+							version: 55,  
+							langtype: 1,  
+							packetver: 20151104,  
+							renewal: true,  
+							socketProxy: 'wss://classicweb.niktoutro.com:5999',  
+							remoteClient: 'https://classicweb.niktoutro.com/chaosclient/',  
+							registrationweb: 'https://niktoutro.com/?module=account&action=create',  
+							packetKeys: true,  
+							adminList: [2000002]  
+						}  
+						// ADD PUBLIC TEST SERVERS HERE. IF YOU DON'T ALLOW _M _F REGISTRATION BE SURE TO ADD THE registrationweb CONFIG  
+					],  
+					packetDump: false,  
+					skipServerList: true,  
+					skipIntro: false,  
+					aura: {},  
+					autoLogin: [],  
+					BGMFileExtension: ['mp3'],  
+					calculateHash: false,  
+					CameraMaxZoomOut: 5,  
+					charBlockSize: 0,  
+					clientHash: null,  
+					clientVersionMode: 'PacketVer',  
+					disableConsole: false,  
+					enableBank: true,  
+					enableCashShop: true,  
+					enableCheckAttendance: true,  
+					enableDmgSuffix: true,  
+					enableHomunAutoFeed: true,  
+					enableMapName: true,  
+					enableRoulette: true,  
+					FirstPersonCamera: false,  
+					grfList: null,  
+					hashFiles: [],  
+					loadLua: true,  
+					onReady: null,  
+					plugins: {},  
+					registrationweb: '',  
+					saveFiles: false,  
+					ThirdPersonCamera: false,  
+					transitionDuration: 500,  
+					restoreChatFocus: false  
+				};  
+				var RO = new ROBrowser(ROConfig);  
+				RO.start();  
+			}  
+  
+			var getJSON = function (url, callback) {  
+				var xhr = new XMLHttpRequest();  
+				xhr.open('GET', url, true);  
+				xhr.responseType = 'json';  
+				xhr.onload = function () {  
+					var status = xhr.status;  
+					if (status === 200) {  
+						callback(null, xhr.response);  
+					} else {  
+						callback(status, xhr.response);  
+					}  
+				};  
+				xhr.send();  
+			};  
+  
+			window.addEventListener(  
+				'load',  
+				function () {  
+					//Get latest GIT hash first then initialize  
+					getJSON(  
+						'https://api.github.com/repos/MrAntares/roBrowserLegacy/commits/master',  
+						function (err, data) {  
+							var gitHash = 'NO_INFO';  
+							if (err !== null) {  
+								console.warn('Error reading latest GIT hash.');  
+							} else {  
+								if (data && data.sha) {  
+									gitHash = data.sha;  
+									console.log('Latest GIT hash: ' + gitHash);  
+								} else {  
+									console.warn('No hash found in response');  
+								}  
+							}  
+							initialize(gitHash);  
+						}  
+					);  
+				},  
+				false  
+			);  
+		</script>  
+	</head>  
+  
+	<body>  
+		<!-- Pre-loader: aparece ANTES de qualquer JS carregar -->  
+		<div id="ro-preloader">  
+			<div class="pre-spinner"></div>  
+			<p class="pre-text">  
+				<span style="--i:0">L</span><span style="--i:1">o</span><span style="--i:2">a</span><span style="--i:3">d</span><span style="--i:4">i</span><span style="--i:5">n</span><span style="--i:6">g</span><span style="--i:7">.</span><span style="--i:8">.</span><span style="--i:9">.</span>  
+			</p>  
+		</div>  
+  
+		<div id="robrowser">Initializing roBrowser [DevMode]...</div>  
+	</body>  
 </html>

--- a/applications/electron/index.html
+++ b/applications/electron/index.html
@@ -1,26 +1,80 @@
-<!doctype html>
-<html>
-	<head>
-		<meta charset="UTF-8" />
-		<title>roBrowserLegacy</title>
-		<link rel="icon" type="image/png" href="icon.png" />
-		<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-		<style>
-			html,
-			body {
-				margin: 0;
-				padding: 0;
-				border: 0;
-				height: 100%;
-				width: 100%;
-				overflow: hidden;
-			}
-		</style>
-		<script src="../shared/importmap.js"></script>
-	</head>
-	<body>
-		<div id="robrowser"></div>
-		<script>
+<!doctype html>  
+<html>  
+	<head>  
+		<meta charset="UTF-8" />  
+		<title>Electron - roBrowserLegacy</title>  
+		<link rel="icon" type="image/png" href="icon.png" />  
+		<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />  
+		<style>  
+			html,  
+			body {  
+				margin: 0;  
+				padding: 0;  
+				border: 0;  
+				height: 100%;  
+				width: 100%;  
+				overflow: hidden;  
+			}  
+			/* Pre-loader — appears instantly, before any JS */
+			#ro-preloader {  
+				position: fixed;  
+				top: 0;  
+				left: 0;  
+				width: 100%;  
+				height: 100%;  
+				z-index: 99999;  
+				background: rgba(6, 8, 16, 0.97);  
+				display: flex;  
+				align-items: center;  
+				justify-content: center;  
+				flex-direction: column;  
+			}  
+			#ro-preloader .pre-spinner {  
+				width: 48px;  
+				height: 48px;  
+				margin: 0 auto 16px;  
+				border: 4px solid rgba(232, 184, 75, 0.2);  
+				border-top-color: #e8b84b;  
+				border-radius: 50%;  
+				animation: ro-pre-spin 0.8s linear infinite;  
+			}  
+			#ro-preloader .pre-text {  
+				font-family: serif;  
+				font-size: 16px;  
+				letter-spacing: 3px;  
+				text-transform: uppercase;  
+				color: #e8b84b;  
+			}  
+			#ro-preloader .pre-text span {  
+				display: inline-block;  
+				animation: ro-pre-wave 1.2s ease-in-out infinite;  
+				animation-delay: calc(var(--i) * 0.08s);  
+			}  
+			@keyframes ro-pre-spin {  
+				to { transform: rotate(360deg); }  
+			}  
+			@keyframes ro-pre-wave {  
+				0%, 60%, 100% { transform: translateY(0); }  
+				30% { transform: translateY(-8px); }  
+			}  
+			#ro-preloader.fade-out {  
+				opacity: 0;  
+				transition: opacity 0.3s ease;  
+			}  
+		</style>  
+		<script src="../shared/importmap.js"></script>  
+	</head>  
+	<body>  
+		<!-- Pre-loader: appears BEFORE any JS loads -->  
+		<div id="ro-preloader">  
+			<div class="pre-spinner"></div>  
+			<p class="pre-text">  
+				<span style="--i:0">L</span><span style="--i:1">o</span><span style="--i:2">a</span><span style="--i:3">d</span><span style="--i:4">i</span><span style="--i:5">n</span><span style="--i:6">g</span><span style="--i:7">.</span><span style="--i:8">.</span><span style="--i:9">.</span>  
+			</p>  
+		</div>  
+  
+		<div id="robrowser"></div>  
+		<script>  
 			var ROConfig = {
 				target: document.getElementById('robrowser'),
 				type: 2,

--- a/applications/pwa/index.html
+++ b/applications/pwa/index.html
@@ -45,6 +45,60 @@
 				width: 100%;
 				overflow: hidden;
 			}
+			/* Pre-loader — appears instantly, before any JS */
+			#ro-preloader {
+				position: fixed;
+				top: 0;
+				left: 0;
+				width: 100%;
+				height: 100%;
+				z-index: 99999;
+				background: rgba(6, 8, 16, 0.97);
+				display: flex;
+				align-items: center;
+				justify-content: center;
+				flex-direction: column;
+			}
+			#ro-preloader .pre-spinner {
+				width: 48px;
+				height: 48px;
+				margin: 0 auto 16px;
+				border: 4px solid rgba(232, 184, 75, 0.2);
+				border-top-color: #e8b84b;
+				border-radius: 50%;
+				animation: ro-pre-spin 0.8s linear infinite;
+			}
+			#ro-preloader .pre-text {
+				font-family: serif;
+				font-size: 16px;
+				letter-spacing: 3px;
+				text-transform: uppercase;
+				color: #e8b84b;
+			}
+			#ro-preloader .pre-text span {
+				display: inline-block;
+				animation: ro-pre-wave 1.2s ease-in-out infinite;
+				animation-delay: calc(var(--i) * 0.08s);
+			}
+			@keyframes ro-pre-spin {
+				to {
+					transform: rotate(360deg);
+				}
+			}
+			@keyframes ro-pre-wave {
+				0%,
+				60%,
+				100% {
+					transform: translateY(0);
+				}
+				30% {
+					transform: translateY(-8px);
+				}
+			}
+			#ro-preloader.fade-out {
+				opacity: 0;
+				transition: opacity 0.3s ease;
+			}
 		</style>
 
 		<script type="text/javascript" src="../api/api.js"></script>
@@ -135,6 +189,17 @@
 	</head>
 
 	<body>
+		<!-- Pre-loader: aparece ANTES de qualquer JS carregar -->
+		<div id="ro-preloader">
+			<div class="pre-spinner"></div>
+			<p class="pre-text">
+				<span style="--i: 0">L</span><span style="--i: 1">o</span><span style="--i: 2">a</span
+				><span style="--i: 3">d</span><span style="--i: 4">i</span><span style="--i: 5">n</span
+				><span style="--i: 6">g</span><span style="--i: 7">.</span><span style="--i: 8">.</span
+				><span style="--i: 9">.</span>
+			</p>
+		</div>
+
 		<div id="robrowser">Initializing roBrowser...</div>
 	</body>
 </html>

--- a/applications/tools/builder-web.mjs
+++ b/applications/tools/builder-web.mjs
@@ -167,80 +167,136 @@ async function compile(appName, isMinify) {
 function createHTML(includeManifest = false) {
 	const start = Date.now();
 	let manifest = includeManifest ? `<link rel="manifest" href="./manifest.webmanifest">` : ``;
-	const body = `<!DOCTYPE html>  
-<html>  
-    <head>  
-        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>  
-        <meta charset="UTF-8">  
-        <title>roBrowser [${pkg.version} - ${buildDate}]</title>  
-        <link rel="icon" type="image/png" href="./icon.png">  
+	const body = `<!DOCTYPE html>    
+<html>    
+    <head>    
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>    
+        <meta charset="UTF-8">    
+        <title>roBrowser [${pkg.version} - ${buildDate}]</title>    
+        <link rel="icon" type="image/png" href="./icon.png">    
+    
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">    
+        <meta name="HandheldFriendly" content="true">    
+    
+        <meta name="apple-mobile-web-app-capable" content="yes">    
+        <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">    
+        <meta name="apple-mobile-web-app-title" content="roBrowser">    
+        <meta name="mobile-web-app-capable" content="yes">    
+    
+        <meta name="description" content="roBrowser">    
+        <meta name="keywords" content="roBrowser">    
+        <meta name="author" content="roBrowser">    
+        <meta name="robots" content="index">    
+    
+        <meta name="theme-color" content="#ff8cb5">    
+    
+        <meta property="og:title" content="roBrowser">    
+        <meta property="og:description" content="roBrowser">    
+        <meta property="og:type" content="website">    
+        <meta property="og:locale" content="en_US">    
+    
+        <link rel="apple-touch-icon" href="./icon.png">    
+        ${manifest}    
   
-        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">  
-        <meta name="HandheldFriendly" content="true">  
+        <style>    
+            html, div, body {    
+                margin: 0; padding: 0; border: 0;    
+                height: 100%; width: 100%; overflow: hidden;    
+            }    
+            #ro-preloader {    
+                position: fixed;    
+                top: 0; left: 0;    
+                width: 100%; height: 100%;    
+                z-index: 99999;    
+                background: rgba(6, 8, 16, 0.97);    
+                display: flex;    
+                align-items: center;    
+                justify-content: center;    
+                flex-direction: column;    
+            }    
+            #ro-preloader .pre-spinner {    
+                width: 48px; height: 48px;    
+                margin: 0 auto 16px;    
+                border: 4px solid rgba(232, 184, 75, 0.2);    
+                border-top-color: #e8b84b;    
+                border-radius: 50%;    
+                animation: ro-pre-spin 0.8s linear infinite;    
+            }    
+            #ro-preloader .pre-text {    
+                font-family: serif;    
+                font-size: 16px;    
+                letter-spacing: 3px;    
+                text-transform: uppercase;    
+                color: #e8b84b;    
+            }    
+            #ro-preloader .pre-text span {    
+                display: inline-block;    
+                animation: ro-pre-wave 1.2s ease-in-out infinite;    
+                animation-delay: calc(var(--i) * 0.08s);    
+            }    
+            @keyframes ro-pre-spin {    
+                to { transform: rotate(360deg); }    
+            }    
+            @keyframes ro-pre-wave {    
+                0%, 60%, 100% { transform: translateY(0); }    
+                30% { transform: translateY(-8px); }    
+            }    
+            #ro-preloader.fade-out {    
+                opacity: 0;    
+                transition: opacity 0.3s ease;    
+            }    
+        </style>    
+    </head>    
+    <body>    
+        <div id="ro-preloader">    
+            <div class="pre-spinner"></div>    
+            <p class="pre-text">    
+                <span style="--i:0">L</span><span style="--i:1">o</span><span style="--i:2">a</span><span style="--i:3">d</span><span style="--i:4">i</span><span style="--i:5">n</span><span style="--i:6">g</span><span style="--i:7">.</span><span style="--i:8">.</span><span style="--i:9">.</span>    
+            </p>    
+        </div>    
   
-        <meta name="apple-mobile-web-app-capable" content="yes">  
-        <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">  
-        <meta name="apple-mobile-web-app-title" content="roBrowser">  
-        <meta name="mobile-web-app-capable" content="yes">  
-  
-        <meta name="description" content="roBrowser">  
-        <meta name="keywords" content="roBrowser">  
-        <meta name="author" content="roBrowser">  
-        <meta name="robots" content="index">  
-  
-        <meta name="theme-color" content="#ff8cb5">  
-  
-        <meta property="og:title" content="roBrowser">  
-        <meta property="og:description" content="roBrowser">  
-        <meta property="og:type" content="website">  
-        <meta property="og:locale" content="en_US">  
-  
-        <link rel="apple-touch-icon" href="./icon.png">  
-        ${manifest}  
-    </head>  
-    <body>  
-        <script src="Config.js"></script>  
-        <script>  
-            // Load optional Config.local.js for overrides (fails silently if not present)  
-            (function() {  
-                var script = document.createElement('script');  
-                script.src = 'Config.local.js';  
-                script.onerror = function() {  
-                    console.log('Config.local.js not found, using defaults from Config.js');  
-                };  
-                document.head.appendChild(script);  
-            })();  
-        </script>  
-        <script>  
-            function deepMerge(target, source) {  
-                for (var key in source) {  
-                    if (source.hasOwnProperty(key)) {  
-                        if (source[key] && typeof source[key] === 'object' && !Array.isArray(source[key])) {  
-                            target[key] = deepMerge(target[key] || {}, source[key]);  
-                        } else {  
-                            target[key] = source[key];  
-                        }  
-                    }  
-                }  
-                return target;  
-            }  
-  
-            window.addEventListener("load", (event) => {  
-                // Merge Config.js defaults with Config.local.js overrides  
-                var config = deepMerge({}, window.ROConfigBase || {});  
-                if (window.ROConfigLocal) {  
-                    config = deepMerge(config, window.ROConfigLocal);  
-                }  
-                window.ROConfig = config;  
-  
-				var script = document.createElement('script');  
-				script.type = 'module';  
-				script.src = 'Online.js';  
-				document.getElementsByTagName('body')[0].appendChild(script);
-            });  
-        </script>  
-    </body>  
-</html>  
+        <script src="Config.js"></script>    
+        <script>    
+            // Load optional Config.local.js for overrides (fails silently if not present)    
+            (function() {    
+                var script = document.createElement('script');    
+                script.src = 'Config.local.js';    
+                script.onerror = function() {    
+                    console.log('Config.local.js not found, using defaults from Config.js');    
+                };    
+                document.head.appendChild(script);    
+            })();    
+        </script>    
+        <script>    
+            function deepMerge(target, source) {    
+                for (var key in source) {    
+                    if (source.hasOwnProperty(key)) {    
+                        if (source[key] && typeof source[key] === 'object' && !Array.isArray(source[key])) {    
+                            target[key] = deepMerge(target[key] || {}, source[key]);    
+                        } else {    
+                            target[key] = source[key];    
+                        }    
+                    }    
+                }    
+                return target;    
+            }    
+    
+            window.addEventListener("load", (event) => {    
+                // Merge Config.js defaults with Config.local.js overrides    
+                var config = deepMerge({}, window.ROConfigBase || {});    
+                if (window.ROConfigLocal) {    
+                    config = deepMerge(config, window.ROConfigLocal);    
+                }    
+                window.ROConfig = config;    
+    
+				var script = document.createElement('script');    
+				script.type = 'module';    
+				script.src = 'Online.js';    
+				document.getElementsByTagName('body')[0].appendChild(script);  
+            });    
+        </script>    
+    </body>    
+</html>    
 `;
 	fs.writeFileSync(dist + platform + '/index.html', body, { encoding: 'utf8' });
 	createConfigJS();

--- a/src/App/Online.js
+++ b/src/App/Online.js
@@ -3,62 +3,29 @@ import Plugins from 'Plugins/PluginManager.js';
 
 export const roInitSpinner = {
 	add: function () {
-		// Loading spinner ring
-		const loading = document.createElement('div');
-		loading.id = 'loading-element';
-		loading.className = 'lds-dual-ring';
-
-		const loadingStyle = document.createElement('style');
-		loadingStyle.id = 'loading-style';
-		loadingStyle.textContent = `
-			.lds-dual-ring { color: #1c4c5b }
-			.lds-dual-ring,
-			.lds-dual-ring:after { box-sizing: border-box; }
-			.lds-dual-ring {
-				position: absolute;
-				display: inline-block;
-				width: 80px;
-				height: 80px;
-				top: 50%;
-				left: 50%;
-				margin-top: -40px;
-				margin-left: -40px;
-			}
-			.lds-dual-ring:after {
-				content: " ";
-				display: block;
-				width: 64px;
-				height: 64px;
-				margin: 8px;
-				border-radius: 50%;
-				border: 6.4px solid currentColor;
-				border-color: currentColor transparent currentColor transparent;
-				animation: lds-dual-ring 1.2s linear infinite;
-			}
-			@keyframes lds-dual-ring {
-				0% { transform: rotate(0deg); }
-				100% { transform: rotate(360deg); }
-			}
-		`;
-
-		// roBrowser will append all the css in the first style tag in the DOM,
-		// so we add a style tag before our own to avoid removing every style altogether,
-		// when we remove the spinner later.
-		document.head.appendChild(document.createElement('style'));
-		// We also need to store a direct reference, because iframe messes with document
-		roInitSpinner.styleElem = document.head.appendChild(loadingStyle);
-		roInitSpinner.divElem = document.body.appendChild(loading);
+		// The preloader already exists in index.html.
+		// Just save the reference so it can be removed later.
+		roInitSpinner.divElem = document.getElementById('ro-preloader');
 	},
 	remove: function () {
-		roInitSpinner.styleElem?.remove();
-		roInitSpinner.divElem?.remove();
+		const el = roInitSpinner.divElem;
+		if (!el) return;
+		// Fade out, depois remove
+		el.classList.add('fade-out');
+		const cleanup = () => {
+			el.remove();
+			roInitSpinner.divElem = null;
+		};
+		el.addEventListener('transitionend', cleanup);
+		// Fallback in case transitionend does not trigger.
+		setTimeout(cleanup, 400);
 	}
 };
 
 window.roInitSpinner = roInitSpinner;
 
 export function init() {
-	// Add spinner before starting the engine
+	// Save the reference to the preloader that is already in the HTML
 	roInitSpinner.add();
 
 	Plugins.init();

--- a/src/UI/Components/Intro/Intro.js
+++ b/src/UI/Components/Intro/Intro.js
@@ -293,8 +293,27 @@ Intro.onAppend = function onAppend() {
 	window.addEventListener('resize', _resizeHandler);
 	_resizeHandler();
 
-	// Initialize particles
-	Particle.init(30, root.querySelector('canvas'));
+	// Wait for background and fonts, then remove the HTML preloader.
+	let particleReady = false;
+	let fontsReady = false;
+
+	function checkReady() {
+		if (particleReady && fontsReady) {
+			if (window.roInitSpinner) {
+				window.roInitSpinner.remove();
+			}
+		}
+	}
+
+	Particle.init(30, root.querySelector('canvas'), () => {
+		particleReady = true;
+		checkReady();
+	});
+
+	document.fonts.ready.then(() => {
+		fontsReady = true;
+		checkReady();
+	});
 };
 
 /**

--- a/src/UI/Components/Intro/Particle.js
+++ b/src/UI/Components/Intro/Particle.js
@@ -36,9 +36,11 @@ class Particle {
 	/**
 	 * Initialize particles
 	 *
-	 * @param {number} particles count
+	 * @param {number} count - particles count
+	 * @param {HTMLCanvasElement} canvas
+	 * @param {function} [onReady] - callback when background image is loaded
 	 */
-	static init(count, canvas) {
+	static init(count, canvas, onReady) {
 		this.list = new Array(count);
 
 		this.width = canvas.width;
@@ -52,6 +54,10 @@ class Particle {
 		this.bg.src = new URL('./images/background.jpg', import.meta.url).href;
 		this.bg.onload = function () {
 			this.ready = true;
+			if (onReady) onReady();
+		};
+		this.bg.onerror = function () {
+			if (onReady) onReady();
 		};
 
 		for (let i = 0; i < count; ++i) {


### PR DESCRIPTION
Adds an inline CSS/HTML pre-loader (#ro-preloader) directly in all entry-point HTML files (demo, electron, pwa, builder-web) so it renders instantly before any JavaScript loads. The roInitSpinner in Online.js now references the existing HTML element instead of creating one via JS. The pre-loader is removed with a fade-out transition once the Intro assets (background image + fonts) are fully loaded, via a new onReady callback in Particle.init().
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mrantares/robrowserlegacy/pull/1116" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
