### PR TITLE
Fix HP bar cache for all entities and reverts model rendering to before entitys due it causing artifacts

### DIFF
--- a/src/Engine/MapEngine/Entity.js
+++ b/src/Engine/MapEngine/Entity.js
@@ -130,6 +130,19 @@ function onEntitySpam(pkt) {
 			}
 		}
 		EntityManager.add(entity);
+		const cachedLife = EntityManager.getLife(entity.GID);
+		if (cachedLife && entity.life.hp <= -1) {
+			if (cachedLife.hp !== undefined) entity.life.hp = cachedLife.hp;
+			if (cachedLife.hp_max !== undefined) entity.life.hp_max = cachedLife.hp_max;
+			if (cachedLife.sp !== undefined) entity.life.sp = cachedLife.sp;
+			if (cachedLife.sp_max !== undefined) entity.life.sp_max = cachedLife.sp_max;
+			if (cachedLife.hunger !== undefined) entity.life.hunger = cachedLife.hunger;
+			if (cachedLife.hunger_max !== undefined) entity.life.hunger_max = cachedLife.hunger_max;
+			if (entity.life.hp > -1 && entity.life.hp_max > -1) {
+				entity.life.update();
+				entity.life.display = true;
+			}
+		}
 	}
 
 	if (
@@ -341,6 +354,9 @@ function onEntityVanish(pkt) {
 				// remove aura on non-PC death
 				if (entity.objecttype !== Entity.TYPE_PC) {
 					entity.aura.remove(EffectManager);
+				}
+				if (pkt.type === Entity.VT.DEAD) {
+					EntityManager.removeLife(pkt.GID);
 				}
 		}
 
@@ -1069,6 +1085,8 @@ function onTitleChangeAck(pkt) {
  * @param {object} pkt - PACKET.ZC.NOTIFY_MONSTER_HP
  */
 function onEntityLifeUpdate(pkt) {
+	EntityManager.storeLife(pkt.AID, { hp: pkt.hp, hp_max: pkt.maxhp });
+
 	const entity = EntityManager.get(pkt.AID);
 	if (entity) {
 		entity.life.hp = pkt.hp;

--- a/src/Engine/MapEngine/Group.js
+++ b/src/Engine/MapEngine/Group.js
@@ -362,6 +362,7 @@ function onPartyMemberLeave(pkt) {
  * @param {object} pkt - PACKET.ZC.NOTIFY_HP_TO_GROUPM
  */
 function onMemberLifeUpdate(pkt) {
+	EntityManager.storeLife(pkt.AID, { hp: pkt.hp, hp_max: pkt.maxhp });
 	const entity = EntityManager.get(pkt.AID);
 
 	if (entity) {

--- a/src/Engine/MapEngine/Homun.js
+++ b/src/Engine/MapEngine/Homun.js
@@ -94,6 +94,15 @@ function onHomunInformation(pkt) {
 	entity.life.hunger_max = 100;
 	entity.life.update();
 
+	EntityManager.storeLife(Session.homunId, {
+		hp: pkt.hp,
+		hp_max: pkt.maxHP,
+		sp: pkt.sp,
+		sp_max: pkt.maxSP,
+		hunger: pkt.nFullness,
+		hunger_max: 100
+	});
+
 	HomunInformations.setInformations(pkt);
 	HomunInformations.startAI();
 }
@@ -149,24 +158,28 @@ function onHomunParameterChange(pkt) {
 		case StatusProperty.HP:
 			entity.life.hp = pkt.value;
 			entity.life.update();
+			EntityManager.storeLife(Session.homunId, { hp: pkt.value });
 			HomunInformations.setHpSpBar('hp', entity.life.hp, entity.life.hp_max);
 			break;
 
 		case StatusProperty.MAXHP:
 			entity.life.hp_max = pkt.value;
 			entity.life.update();
+			EntityManager.storeLife(Session.homunId, { hp_max: pkt.value });
 			HomunInformations.setHpSpBar('hp', entity.life.hp, entity.life.hp_max);
 			break;
 
 		case StatusProperty.SP:
 			entity.life.sp = pkt.value;
 			entity.life.update();
+			EntityManager.storeLife(Session.homunId, { sp: pkt.value });
 			HomunInformations.setHpSpBar('sp', entity.life.sp, entity.life.sp_max);
 			break;
 
 		case StatusProperty.MAXSP:
 			entity.life.sp_max = pkt.value;
 			entity.life.update();
+			EntityManager.storeLife(Session.homunId, { sp_max: pkt.value });
 			HomunInformations.setHpSpBar('sp', entity.life.sp, entity.life.sp_max);
 			break;
 

--- a/src/Engine/MapEngine/Mercenary.js
+++ b/src/Engine/MapEngine/Mercenary.js
@@ -35,6 +35,12 @@ function onMercenaryInit(pkt) {
 		entity.life.sp = pkt.sp;
 		entity.life.sp_max = pkt.maxSP;
 		entity.life.update();
+		EntityManager.storeLife(pkt.AID, {
+			hp: pkt.hp,
+			hp_max: pkt.maxHP,
+			sp: pkt.sp,
+			sp_max: pkt.maxSP
+		});
 	}
 
 	if (entity && entity.life.display) {
@@ -63,6 +69,12 @@ function onMercenaryProperty(pkt) {
 		entity.life.sp = pkt.sp;
 		entity.life.sp_max = pkt.maxSP;
 		entity.life.update();
+		EntityManager.storeLife(Session.mercId, {
+			hp: pkt.hp,
+			hp_max: pkt.maxHP,
+			sp: pkt.sp,
+			sp_max: pkt.maxSP
+		});
 	}
 
 	if (entity && entity.life.display) {
@@ -87,21 +99,25 @@ function onParameterChange(pkt) {
 		case 0x0: // HP
 			entity.life.hp = pkt.value;
 			entity.life.update();
+			EntityManager.storeLife(Session.mercId, { hp: pkt.value });
 			break;
 
 		case 0x1: // SP
 			entity.life.sp = pkt.value;
 			entity.life.update();
+			EntityManager.storeLife(Session.mercId, { sp: pkt.value });
 			break;
 
 		case 0x2: // MaxHP
 			entity.life.hp_max = pkt.value;
 			entity.life.update();
+			EntityManager.storeLife(Session.mercId, { hp_max: pkt.value });
 			break;
 
 		case 0x3: // MaxSP
 			entity.life.sp_max = pkt.value;
 			entity.life.update();
+			EntityManager.storeLife(Session.mercId, { sp_max: pkt.value });
 			break;
 	}
 }

--- a/src/Renderer/EntityManager.js
+++ b/src/Renderer/EntityManager.js
@@ -573,6 +573,10 @@ function removeLife(gid) {
 	_lifeCache.delete(gid);
 }
 
+function clearLifeCache() {
+	_lifeCache.clear();
+}
+
 const EntityManager = {
 	free: free,
 	add: addEntity,
@@ -593,6 +597,7 @@ const EntityManager = {
 	storeLife: storeLife,
 	getLife: getLife,
 	removeLife: removeLife,
+	clearLifeCache: clearLifeCache,
 
 	render: render,
 	intersect: intersect,

--- a/src/Renderer/EntityManager.js
+++ b/src/Renderer/EntityManager.js
@@ -551,6 +551,28 @@ function getPathDistance(fromEntity, toEntity) {
 	return count;
 }
 
+const _lifeCache = new Map();
+
+function storeLife(gid, data) {
+	const existing = _lifeCache.get(gid) || {};
+	// Merge parcial: só atualiza campos que foram passados (não undefined)
+	if (data.hp !== undefined) existing.hp = data.hp;
+	if (data.hp_max !== undefined) existing.hp_max = data.hp_max;
+	if (data.sp !== undefined) existing.sp = data.sp;
+	if (data.sp_max !== undefined) existing.sp_max = data.sp_max;
+	if (data.hunger !== undefined) existing.hunger = data.hunger;
+	if (data.hunger_max !== undefined) existing.hunger_max = data.hunger_max;
+	_lifeCache.set(gid, existing);
+}
+
+function getLife(gid) {
+	return _lifeCache.get(gid) || null;
+}
+
+function removeLife(gid) {
+	_lifeCache.delete(gid);
+}
+
 const EntityManager = {
 	free: free,
 	add: addEntity,
@@ -567,6 +589,10 @@ const EntityManager = {
 
 	getClosestEntity: getClosestEntity,
 	getLowestHpEntity: getLowestHpEntity,
+
+	storeLife: storeLife,
+	getLife: getLife,
+	removeLife: removeLife,
 
 	render: render,
 	intersect: intersect,

--- a/src/Renderer/MapRenderer.js
+++ b/src/Renderer/MapRenderer.js
@@ -180,6 +180,7 @@ class MapRenderer {
 		const gl = Renderer.getContext();
 
 		EntityManager.free();
+		EntityManager.clearLifeCache();
 		GridSelector.free(gl);
 		Sounds.free();
 		Effects.free();

--- a/src/Renderer/MapRenderer.js
+++ b/src/Renderer/MapRenderer.js
@@ -273,6 +273,10 @@ class MapRenderer {
 
 		// Display zone effects and entities
 		Sky.render(gl, modelView, projection, fog, tick);
+
+		Models.render(gl, modelView, projection, normalMat, fog, light);
+		AnimatedModels.render(gl, modelView, projection, normalMat, fog, light, tick);
+
 		EffectManager.render(gl, modelView, projection, fog, tick, true);
 
 		//Render Entities (no effects)
@@ -280,8 +284,6 @@ class MapRenderer {
 
 		// Rendering water (after sprites, billboard projection pushes it to back)
 		Water.render(gl, modelView, projection, fog, light, tick);
-		Models.render(gl, modelView, projection, normalMat, fog, light);
-		AnimatedModels.render(gl, modelView, projection, normalMat, fog, light, tick);
 
 		EffectManager.render(gl, modelView, projection, fog, tick, false);
 		EntityManager.render(gl, modelView, projection, fog, true);


### PR DESCRIPTION
This PR adds a life cache in `EntityManager` that stores HP/SP/hunger data by GID. Now when any entity re-enters the screen, the cached life data is restored and the HP bar is displayed correctly.

**1. HP/Life bar cache by GID**
this fixes #515
When an entity (monster, homunculus, mercenary, or party member) goes out of sight and comes back, the HP bar was disappearing because the life data was lost on entity removal.

**2. Revert model rendering order**
Moved `Models.render()` and `AnimatedModels.render()` to render before `EffectManager` and `EntityManager` instead of after `Water.render()`. The previous order was causing visual artifacts.


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mrantares/robrowserlegacy/pull/1122" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
