### PR TITLE
Split DB initialization into two phases and fix duplicate BGM playback

### DIFF
--- a/src/Audio/BGM.js
+++ b/src/Audio/BGM.js
@@ -13,6 +13,8 @@
 import Client from 'Core/Client.js';
 import Preferences from 'Preferences/Audio.js';
 
+let _lastmp3filename = '';
+
 /**
  * BGM NameSpace
  */
@@ -73,7 +75,7 @@ class BGM {
 			}
 		}
 	}
-	_lastmp3filename = '';
+
 	/**
 	 * Play the audio file specify
 	 *
@@ -84,12 +86,12 @@ class BGM {
 		if (!filename) {
 			return;
 		}
-		if (!this._lastmp3filename) {
-			this._lastmp3filename = filename;
-		} else if (this._lastmp3filename === filename && filename === '01.mp3') {
+		if (!_lastmp3filename) {
+			_lastmp3filename = filename;
+		} else if (_lastmp3filename === filename && filename === '01.mp3') {
 			return;
 		} else {
-			this._lastmp3filename = filename;
+			_lastmp3filename = filename;
 		}
 		// Remove the "BGM/" part
 		if (filename.match(/bgm/i)) {

--- a/src/Audio/BGM.js
+++ b/src/Audio/BGM.js
@@ -73,7 +73,7 @@ class BGM {
 			}
 		}
 	}
-
+	_lastmp3filename = '';
 	/**
 	 * Play the audio file specify
 	 *
@@ -84,7 +84,13 @@ class BGM {
 		if (!filename) {
 			return;
 		}
-
+		if (!this._lastmp3filename) {
+			this._lastmp3filename = filename;
+		} else if (this._lastmp3filename === filename && filename === '01.mp3') {
+			return;
+		} else {
+			this._lastmp3filename = filename;
+		}
 		// Remove the "BGM/" part
 		if (filename.match(/bgm/i)) {
 			filename = filename.match(/\w+\.mp3/i)?.toString();

--- a/src/DB/DBManager.js
+++ b/src/DB/DBManager.js
@@ -375,21 +375,8 @@ class DB {
 
 		// CSV Tables - Client Date is not sure since when they were added
 		if (PACKETVER.value >= 20230302) {
-			loadCSV('data/msgstringtable.csv', MsgStringTable, 0, 1, onLoad());
 			loadCSV('data/simplemsg/msg_emotion.csv', MsgEmotionCSV, 0, 2, onLoad());
-		} else {
-			loadTable(
-				'data/msgstringtable.txt',
-				'#',
-				1,
-				function (_index, val) {
-					MsgStringTable[_index] = val;
-				},
-				onLoad(),
-				true
-			);
 		}
-
 		// TODO: load these load files by PACKETVER
 		if (Configs.get('loadLua')) {
 			// Item

--- a/src/DB/DBManager.js
+++ b/src/DB/DBManager.js
@@ -331,7 +331,7 @@ class DB {
 			(_index, val) => {
 				MsgStringTable[_index] = val;
 			},
-			loadCSV('data/msgstringtable.csv', MsgStringTable, 0, 1, loadmsg()),
+			() => loadCSV('data/msgstringtable.csv', MsgStringTable, 0, 1, loadmsg()),
 			true
 		);
 	}

--- a/src/DB/DBManager.js
+++ b/src/DB/DBManager.js
@@ -331,8 +331,18 @@ class DB {
 			(_index, val) => {
 				MsgStringTable[_index] = val;
 			},
-			() => loadCSV('data/msgstringtable.csv', MsgStringTable, 0, 1, loadmsg()),
+			() => loadCSV('data/msgstringtable.csv', MsgStringTable, 0, 1, loadmsg),
 			true
+		);
+
+		loadTable(
+			'data/resnametable.txt',
+			'#',
+			2,
+			function (_index, key, val) {
+				DB.mapalias[key] = val;
+			},
+			onLoad()
 		);
 	}
 
@@ -353,9 +363,8 @@ class DB {
 					DB.onProgress(DB.index, DB.count);
 				}
 
-				if (DB.index === DB.count && DB.onReady) {
+				if (DB.index === DB.count) {
 					DB.isLoaded = true;
-					DB.onReady();
 				}
 			};
 		}
@@ -376,16 +385,6 @@ class DB {
 				true
 			);
 		}
-
-		loadTable(
-			'data/resnametable.txt',
-			'#',
-			2,
-			function (_index, key, val) {
-				DB.mapalias[key] = val;
-			},
-			onLoad()
-		);
 
 		// TODO: load these load files by PACKETVER
 		if (Configs.get('loadLua')) {

--- a/src/DB/DBManager.js
+++ b/src/DB/DBManager.js
@@ -303,9 +303,6 @@ class DB {
 		}
 
 		loadFontFromClient('System/Font/');
-
-		console.log('Loading DB files...');
-
 		// Loading TXT Tables
 		loadTable(
 			'data/mp3nametable.txt',
@@ -326,6 +323,42 @@ class DB {
 			onLoad(),
 			true
 		);
+		const loadmsg = onLoad();
+		loadTable(
+			'data/msgstringtable.txt',
+			'#',
+			1,
+			(_index, val) => {
+				MsgStringTable[_index] = val;
+			},
+			loadCSV('data/msgstringtable.csv', MsgStringTable, 0, 1, loadmsg()),
+			true
+		);
+	}
+
+	static isLoaded = false;
+	static count = 0;
+	static index = 0;
+	static async lazyInit() {
+		console.log('Loading DB files...');
+		// Callback
+		DB.index = 0;
+		DB.count = 0;
+		function onLoad() {
+			DB.count++;
+			return function OnLoadClosure() {
+				DB.index++;
+
+				if (DB.onProgress) {
+					DB.onProgress(DB.index, DB.count);
+				}
+
+				if (DB.index === DB.count && DB.onReady) {
+					DB.isLoaded = true;
+					DB.onReady();
+				}
+			};
+		}
 
 		// CSV Tables - Client Date is not sure since when they were added
 		if (PACKETVER.value >= 20230302) {
@@ -599,18 +632,8 @@ class DB {
 
 			// TODO: System/RecommendedQuests.lub
 
-			// WoldMap
-			loadWorldMapInfo(DB.LUA_PATH + 'worldviewdata/', onLoad());
-
 			// Achievements
 			// TODO: System/achievements.lub
-
-			// Town Info
-			const onTownInfoEnd = onLoad();
-			loadTownInfoFile('System/Towninfo.lub', null, () => {
-				// this is not official, its a translation file
-				loadTownInfoFile('SystemEN/Towninfo.lub', null, onTownInfoEnd);
-			});
 
 			// Cash Shop Banner - implemented early 2018
 			if (Configs.get('enableCashShop') && PACKETVER.value >= 20180000) {
@@ -709,6 +732,15 @@ class DB {
 		if (PACKETVER.value >= 20150422) {
 			loadMoveInfoTable(onLoad());
 		}
+
+		// WoldMap
+		loadWorldMapInfo(DB.LUA_PATH + 'worldviewdata/', onLoad());
+		// Town Info
+		const onTownInfoEnd = onLoad();
+		loadTownInfoFile('System/Towninfo.lub', null, () => {
+			// this is not official, its a translation file
+			loadTownInfoFile('SystemEN/Towninfo.lub', null, onTownInfoEnd);
+		});
 
 		// Forging/Creation
 		loadTable(
@@ -816,7 +848,6 @@ class DB {
 			module.default.initAI(onLoad());
 		});
 	}
-
 	static getHOAI_VM() {
 		return HO_AI;
 	}

--- a/src/DB/DBManager.js
+++ b/src/DB/DBManager.js
@@ -284,6 +284,10 @@ class DB {
 	 * Initialize DB
 	 */
 	static init() {
+		DB.isLoaded = false;
+		DB.count = 0;
+		DB.index = 0;
+
 		// Callback
 		let index = 0,
 			count = 0;
@@ -843,8 +847,9 @@ class DB {
 		Network.hookPacket(PACKET.ZC.ACK_REQNAME_BYGID, onUpdateOwnerName);
 		Network.hookPacket(PACKET.ZC.ACK_REQNAME_BYGID2, onUpdateOwnerName);
 
+		const onAIDriverLoaded = onLoad();
 		import('Core/AIDriver.js').then(module => {
-			module.default.initAI(onLoad());
+			module.default.initAI(onAIDriverLoaded);
 		});
 	}
 	static getHOAI_VM() {

--- a/src/DB/DBManager.js
+++ b/src/DB/DBManager.js
@@ -353,7 +353,7 @@ class DB {
 	static isLoaded = false;
 	static count = 0;
 	static index = 0;
-	static async lazyInit() {
+	static lazyInit() {
 		console.log('Loading DB files...');
 		// Callback
 		DB.index = 0;

--- a/src/Engine/CharEngine.js
+++ b/src/Engine/CharEngine.js
@@ -742,12 +742,15 @@ let retryCount = 0;
 function onReceiveMapInfo(pkt) {
 	if (!DB.isLoaded) {
 		retryCount++;
-		if (retryCount > 100) {
-			console.error('DB not loaded after 100 retries');
+		if (retryCount > 600) {
+			UIManager.showMessageBox('Erro ao iniciar o jogo', 'ok');
+			retryCount = 0;
+			return;
 		}
-		setTimeout(() => onReceiveMapInfo(pkt), 100);
+		Events.setTimeout(() => onReceiveMapInfo(pkt), 100);
 		return;
 	}
+	retryCount = 0;
 	Session.GID = pkt.GID;
 	MapEngine.init(pkt.addr.ip, pkt.addr.port, pkt.mapName);
 }

--- a/src/Engine/CharEngine.js
+++ b/src/Engine/CharEngine.js
@@ -725,7 +725,9 @@ function onConnectRequest(entity) {
 	CharSelect.getUI().remove();
 	UIManager.getComponent('WinLoading').append();
 	Session.Character = entity;
-
+	if (!DB.isLoaded) {
+		DB.lazyInit();
+	}
 	const pkt = new PACKET.CH.SELECT_CHAR();
 	pkt.CharNum = entity.CharNum;
 	Network.sendPacket(pkt);
@@ -737,6 +739,10 @@ function onConnectRequest(entity) {
  * @param {object} pkt - PACKET.HC.NOTIFY_ZONESVR
  */
 function onReceiveMapInfo(pkt) {
+	if (!DB.isLoaded) {
+		setTimeout(() => onReceiveMapInfo(pkt), 100);
+		return;
+	}
 	Session.GID = pkt.GID;
 	MapEngine.init(pkt.addr.ip, pkt.addr.port, pkt.mapName);
 }

--- a/src/Engine/CharEngine.js
+++ b/src/Engine/CharEngine.js
@@ -738,8 +738,13 @@ function onConnectRequest(entity) {
  *
  * @param {object} pkt - PACKET.HC.NOTIFY_ZONESVR
  */
+let retryCount = 0;
 function onReceiveMapInfo(pkt) {
 	if (!DB.isLoaded) {
+		retryCount++;
+		if (retryCount > 100) {
+			console.error('DB not loaded after 100 retries');
+		}
 		setTimeout(() => onReceiveMapInfo(pkt), 100);
 		return;
 	}

--- a/src/Engine/CharEngine.js
+++ b/src/Engine/CharEngine.js
@@ -747,7 +747,7 @@ function onReceiveMapInfo(pkt) {
 			retryCount = 0;
 			return;
 		}
-		Events.setTimeout(() => onReceiveMapInfo(pkt), 100);
+		setTimeout(() => onReceiveMapInfo(pkt), 100);
 		return;
 	}
 	retryCount = 0;

--- a/src/Engine/CharEngine.js
+++ b/src/Engine/CharEngine.js
@@ -743,7 +743,7 @@ function onReceiveMapInfo(pkt) {
 	if (!DB.isLoaded) {
 		retryCount++;
 		if (retryCount > 600) {
-			UIManager.showMessageBox('Erro ao iniciar o jogo', 'ok');
+			UIManager.showMessageBox('Failed loading databases, please restart the game', 'ok');
 			retryCount = 0;
 			return;
 		}

--- a/src/Engine/CharEngine.js
+++ b/src/Engine/CharEngine.js
@@ -743,7 +743,9 @@ function onReceiveMapInfo(pkt) {
 	if (!DB.isLoaded) {
 		retryCount++;
 		if (retryCount > 600) {
-			UIManager.showMessageBox('Failed loading databases, please restart the game', 'ok');
+			UIManager.showMessageBox('Failed loading databases, please restart the game', 'ok', () => {
+				CharEngine.reload();
+			});
 			retryCount = 0;
 			return;
 		}

--- a/src/Engine/LoginEngine.js
+++ b/src/Engine/LoginEngine.js
@@ -119,6 +119,7 @@ class LoginEngine {
 					Background.init();
 					Background.resize(Renderer.width, Renderer.height);
 					Background.setImage('bgi_temp.bmp', () => {
+						DB.isLoaded = false;
 						DB.init();
 					});
 				});


### PR DESCRIPTION
This PR splits the database initialization into two phases (essential and lazy) to improve startup performance and fix a PACKETVER dependency issue. It also fixes a duplicate `01.mp3` playback bug in the BGM system.

## Changes

### Two-phase DB loading (`src/DB/DBManager.js`)
Previously, `DB.init()` loaded **all** database files (items, skills, monsters, navigation, quests, etc.) before the service select screen appeared. This was problematic because:

- Many DB files depend on `PACKETVER`, which is only correctly set after server selection
- The user had to wait for all files to parse before seeing the login screen

Now the loading is split into:
- **`DB.init()` (Phase 1 — Essential):** Loads only what's needed for login/char select UIs: `*.grf`, `mp3nametable`, `mapnametable`, `msgstringtable`, and fonts.
- **`DB.lazyInit()` (Phase 2 — Deferred):** Loads everything else (items, skills, monsters, navigation, lua tables, etc.) asynchronously after the user selects a character, when `PACKETVER` is already correctly set.

A `DB.isLoaded` flag tracks whether Phase 2 has completed. `WorldMap` and `TownInfo` loading were moved outside the `loadLua` conditional so they always load regardless of config. this fix #843

### Deferred loading trigger (`src/Engine/CharEngine.js`)
- `onConnectRequest`: Triggers `DB.lazyInit()` when the user selects a character (if not already loaded).
- `onReceiveMapInfo`: Waits for `DB.isLoaded` before proceeding to `MapEngine.init()`, using a non-blocking `setTimeout` retry pattern.

### Server switch reset (`src/Engine/LoginEngine.js`)
- Resets `DB.isLoaded = false` before calling `DB.init()` on server change, ensuring Phase 2 re-runs with the correct `PACKETVER` for the new server.

### BGM duplicate play fix (`src/Audio/BGM.js`)
- Added `_lastmp3filename` tracking to skip consecutive duplicate plays of `01.mp3`, which was being called twice from somewhere in the codebase.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mrantares/robrowserlegacy/pull/1123" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
