### PR TITLE
Fix audio race conditions in BGM and SoundManager

### DIFF
--- a/src/Audio/BGM.js
+++ b/src/Audio/BGM.js
@@ -12,8 +12,8 @@
 
 import Client from 'Core/Client.js';
 import Preferences from 'Preferences/Audio.js';
-import DB from 'DB/DBManager.js';
-let _lastmp3filename = '';
+
+let _playToken = 0;
 
 /**
  * BGM NameSpace
@@ -81,38 +81,23 @@ class BGM {
 	 *
 	 * @param {string} filename
 	 */
+
 	static play(filename) {
-		// Nothing to play
-		if (!filename) {
-			return;
-		}
-		if (!_lastmp3filename) {
-			_lastmp3filename = filename;
-		} else if (_lastmp3filename === filename && filename === '01.mp3' && !DB.isLoaded) {
-			return;
-		} else {
-			_lastmp3filename = filename;
-		}
-		// Remove the "BGM/" part
+		if (!filename) return;
 		if (filename.match(/bgm/i)) {
 			filename = filename.match(/\w+\.mp3/i)?.toString();
-			if (!filename) {
-				return;
-			}
+			if (!filename) return;
 		}
-
-		// If it's the same file, check if it's already playing
-		if (BGM.filename === filename) {
-			if (!BGM.audio.paused) {
-				return;
-			}
-		} else {
-			BGM.filename = filename;
+		if (BGM.filename === filename && BGM.audio && !BGM.audio.paused) {
+			return;
 		}
-
-		// load the file.
+		BGM.filename = filename;
+		const myToken = ++_playToken;
 		if (Preferences.BGM.play) {
 			Client.loadFile(`BGM/${filename}`, url => {
+				if (myToken !== _playToken) {
+					return;
+				}
 				BGM.load(url);
 			});
 		}
@@ -136,16 +121,24 @@ class BGM {
 
 		BGM.audio.src = url;
 		BGM.audio.volume = BGM.volume;
-		BGM.audio.play().catch(error => {
-			console.error(`Failed to play "BGM/${BGM.filename}": ${error.message}`);
-		});
+		const playPromise = BGM.audio.play();
+		if (playPromise) {
+			playPromise.catch(err => {
+				if (err.name !== 'AbortError') {
+					console.warn('Failed to play:', err);
+				}
+			});
+		}
 	}
 
 	/**
 	 * Stop the BGM
 	 */
 	static stop() {
-		BGM.audio.pause();
+		_playToken++;
+		if (BGM.audio) {
+			BGM.audio.pause();
+		}
 	}
 
 	/**

--- a/src/Audio/SoundManager.js
+++ b/src/Audio/SoundManager.js
@@ -37,6 +37,7 @@ const _cache = {};
  * @Number of existing HTML Media players in the DOM
  */
 let mediaPlayerCount = 0;
+let _playGen = 0;
 
 /**
  * @Constructor
@@ -56,63 +57,69 @@ class SoundManager {
 	 */
 	static play(filename, vol) {
 		let volume;
-
-		// Sound volume * Global volume
 		if (vol) {
 			volume = vol * this.volume;
 		} else {
 			volume = this.volume;
 		}
-
-		// Don't play sound if you can't hear it or sound is stopped
 		if (volume <= 0 || !Preferences.Sound.play) {
 			return;
 		}
-
 		if (!(filename in _sounds)) {
 			_sounds[filename] = {};
 			_sounds[filename].instances = [];
 			_sounds[filename].lastTick = 0;
 		}
-
-		// Re-usable sound
+		// Re-usable sound from cache
 		const sound = getSoundFromCache(filename);
 		if (sound) {
 			sound.volume = Math.min(volume, 1.0);
 			sound._volume = volume;
-			sound.play();
+			const playPromise = sound.play();
+			if (playPromise) {
+				playPromise.catch(err => {
+					// blob revogado / src inválido → descarta e recarrega do zero
+					if (err.name === 'NotSupportedError' || err.name === 'AbortError') {
+						const idx = _sounds[filename]?.instances.indexOf(sound);
+						if (idx !== undefined && idx !== -1) {
+							_sounds[filename].instances.splice(idx, 1);
+						}
+						sound.remove();
+						mediaPlayerCount--;
+						SoundManager.play(filename, vol);
+						return;
+					}
+					console.warn('Failed to play sound:', err);
+				});
+			}
 			_sounds[filename].instances.push(sound);
 			_sounds[filename].lastTick = Date.now();
 			return;
 		}
-
-		// Get the sound from client.
+		const myGen = _playGen;
 		Client.loadFile(`data/wav/${filename}`, url => {
-			if (!(filename in _sounds)) {
+			if (myGen !== _playGen || !(filename in _sounds)) {
 				return;
 			}
-			// Wait a delay to replay a sound and don't play too many times (self balancing formula based on total media players)
 			if (
-				filename in _sounds &&
-				(_sounds[filename].lastTick > Date.now() - C_SAME_SOUND_DELAY ||
-					_sounds[filename].instances.length > balancedMax(C_MAX_SOUND_INSTANCES))
+				_sounds[filename].lastTick > Date.now() - C_SAME_SOUND_DELAY ||
+				_sounds[filename].instances.length > balancedMax(C_MAX_SOUND_INSTANCES)
 			) {
 				return;
 			}
-
-			// Initialiaze the sound and play it
 			const audio = document.createElement('audio');
 			mediaPlayerCount++;
 			audio.filename = filename;
 			audio.src = url;
 			audio.volume = Math.min(volume, 1.0);
 			audio._volume = volume;
-
 			audio.addEventListener('error', onSoundError, false);
 			audio.addEventListener('ended', onSoundEnded, false);
-			audio.play();
-
-			// Add it to the list
+			audio.play().catch(err => {
+				if (err.name !== 'AbortError') {
+					console.warn('Failed to play sound:', err);
+				}
+			});
 			_sounds[filename].instances.push(audio);
 			_sounds[filename].lastTick = Date.now();
 		});
@@ -139,28 +146,37 @@ class SoundManager {
 		if (filename) {
 			if (filename in _sounds) {
 				while (_sounds[filename].instances.length > 0) {
-					const sound = _sounds[filename].instances.shift();
-					sound.pause();
-					sound.remove();
+					const s = _sounds[filename].instances.shift();
+					s.pause();
+					s.remove();
 					mediaPlayerCount--;
 				}
 				delete _sounds[filename];
 			}
 			return;
 		}
-
-		// Remove from memory
+		_playGen++;
+		// limpa instâncias ativas
 		Object.keys(_sounds).forEach(key => {
 			while (_sounds[key].instances.length > 0) {
-				const sound = _sounds[key].instances.shift();
-				sound.pause();
-				sound.remove();
+				const s = _sounds[key].instances.shift();
+				s.pause();
+				s.remove();
 				mediaPlayerCount--;
 			}
 			delete _sounds[key];
 		});
-
-		// Remove from cache
+		// limpa cache (senão sobram <audio> com src revogado)
+		Object.keys(_cache).forEach(key => {
+			_cache[key].instances.forEach(s => {
+				if (s.cleanupHandle) {
+					clearTimeout(s.cleanupHandle);
+				}
+				s.remove();
+				mediaPlayerCount--;
+			});
+			delete _cache[key];
+		});
 		const list = Memory.search(/\.wav$/);
 		list.forEach(key => {
 			Memory.remove(key);
@@ -209,15 +225,16 @@ function onSoundEnded() {
  * Clear sound from dom on error
  */
 function onSoundError() {
-	const pos = _sounds[this.filename].instances.indexOf(this);
-
-	if (pos !== -1) {
-		_sounds[this.filename].instances.splice(pos, 1);
-		if (_sounds[this.filename].instances.length === 0) {
-			delete _sounds[this.filename];
+	const entry = _sounds[this.filename];
+	if (entry) {
+		const pos = entry.instances.indexOf(this);
+		if (pos !== -1) {
+			entry.instances.splice(pos, 1);
+			if (entry.instances.length === 0) {
+				delete _sounds[this.filename];
+			}
 		}
 	}
-
 	this.remove();
 	mediaPlayerCount--;
 }


### PR DESCRIPTION
Fixes a set of race conditions in the audio subsystem that caused interrupted playback errors, stale blob URL access, and silent crashes when switching servers or stopping sounds.

## BGM.js

- Replaced the _lastmp3filename / DB.isLoaded dedup hack with a _playToken generation counter to cancel stale loadFile callbacks when play() or stop() is called again before the previous load resolves.
- Moved BGM/ prefix normalization before the dedup check so 'BGM/01.mp3' and '01.mp3' are treated as the same file.
- play() now silently ignores AbortError (expected when pause()/stop() interrupts a pending play() Promise).
- stop() increments the token to invalidate in-flight loads and is now safe when BGM.audio is not yet initialized.

## SoundManager.js

- Added a _playGen generation counter so Client.loadFile callbacks pending after stop() are discarded instead of creating orphan <audio> elements pointing to revoked blob URLs.
- Cached sounds returned by getSoundFromCache() now have their play() Promise checked: on NotSupportedError / AbortError (typical when the cached blob URL was revoked), the stale instance is dropped and the sound is reloaded from disk.
- stop() (without filename) now also clears _cache, preventing leftover <audio> elements with revoked src from being reused later.
- onSoundError is now defensive against _sounds[this.filename] being undefined, fixing TypeError: Cannot read properties of undefined (reading 'instances').
- Both audio.play() calls catch AbortError silently.

## Fixes
Failed to play "BGM/01.mp3": The play() request was interrupted by a new load request.
AbortError: The play() request was interrupted by a call to pause().
ERR_FILE_NOT_FOUND blob:... followed by TypeError in onSoundError when clicking login/exit buttons after switching servers.
BGM going silent on the second server-select screen until entering and leaving a character.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mrantares/robrowserlegacy/pull/1125" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
