### PR TITLE
restore non-players depth using non-zindex based layers and an small fix in lazyinit

### DIFF
--- a/src/Engine/CharEngine.js
+++ b/src/Engine/CharEngine.js
@@ -725,9 +725,6 @@ function onConnectRequest(entity) {
 	CharSelect.getUI().remove();
 	UIManager.getComponent('WinLoading').append();
 	Session.Character = entity;
-	if (!DB.isLoaded) {
-		DB.lazyInit();
-	}
 	const pkt = new PACKET.CH.SELECT_CHAR();
 	pkt.CharNum = entity.CharNum;
 	Network.sendPacket(pkt);
@@ -741,6 +738,10 @@ function onConnectRequest(entity) {
 let retryCount = 0;
 function onReceiveMapInfo(pkt) {
 	if (!DB.isLoaded) {
+		if (!DB.startedLazyInit) {
+			DB.lazyInit();
+			DB.startedLazyInit = true;
+		}
 		retryCount++;
 		if (retryCount > 600) {
 			UIManager.showMessageBox('Failed loading databases, please restart the game', 'ok', () => {
@@ -752,6 +753,7 @@ function onReceiveMapInfo(pkt) {
 		setTimeout(() => onReceiveMapInfo(pkt), 100);
 		return;
 	}
+	DB.startedLazyInit = false;
 	retryCount = 0;
 	Session.GID = pkt.GID;
 	MapEngine.init(pkt.addr.ip, pkt.addr.port, pkt.mapName);

--- a/src/Renderer/Entity/EntityRender.js
+++ b/src/Renderer/Entity/EntityRender.js
@@ -460,7 +460,10 @@ const renderEntity = (function renderEntityClosure() {
 			default:
 				SpriteRenderer.position[2] = SpriteRenderer.position[2] + 0.2;
 				SpriteRenderer.zIndex = 150;
-				SpriteRenderer.runWithDepth(true, true, false, function () {
+				// Non-player entities:
+				// - Do not write depth to avoid breaking PC occlusion and internal layer issues
+				// - Still use depth test for correct ordering
+				SpriteRenderer.runWithDepth(true, false, false, function () {
 					renderElement(self, self.files.body, 'body', _position, true);
 				});
 				break;
@@ -779,13 +782,6 @@ const renderElement = (function renderElementClosure() {
 		// Render all frames
 		for (let i = 0, count = layers.length; i < count; ++i) {
 			entity.renderLayer(layers[i], spr, pal, files.size, _position, type, isBlendModeOne);
-			if (
-				count > 1 &&
-				entity.objecttype !== entity.constructor.TYPE_PC &&
-				entity.objecttype !== entity.constructor.TYPE_MERC
-			) {
-				SpriteRenderer.zIndex += 250;
-			}
 		}
 
 		// Save reference


### PR DESCRIPTION
Restore the old depth rendering without broken inner layers based onz-index (gravity doesn't follow patterns :/), move lazyinit to onReceiveMapInfo to prevent lazyinit from starting to load files when the map server is not yet available.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mrantares/robrowserlegacy/pull/1128" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
