### PR TITLE
Migrate ChatRoom, ChatRoomCreate, EntitySignboard and EntityRoom to GUIComponent

### DIFF
--- a/doc/UIComponent_to_GUIComponent.md
+++ b/doc/UIComponent_to_GUIComponent.md
@@ -480,6 +480,120 @@ this._host.style.top = '100px';
 this._host.style.left = '200px';
 ```
 
+### ~~8. Keyboard input stolen from `<input>` / `<textarea>` inside Shadow DOM~~ (FIXED)
+
+**Bug**: When a GUIComponent contains `<input>`, `<select>`, or `<textarea>` elements inside its Shadow DOM, users cannot type in them — keystrokes are intercepted by other global `keydown` handlers (ChatBox battle mode, shortcut system, etc.).
+
+**Root cause**: Shadow DOM encapsulates focus. When an `<input>` inside a shadow root is focused:
+
+- `document.activeElement` returns the **shadow host** (`<div>`) — not the actual `<input>`
+- `event.target` on bubbled events is **retargeted** to the shadow host
+
+Other global handlers (e.g., ChatBox line 816–826, line 928–941) check `document.activeElement.tagName` or `event.target.tagName` to detect focused inputs. They see `DIV` instead of `INPUT`, so they consume the keystroke instead of letting it through.
+
+```
+document.activeElement          → <div#ChatRoomCreate>  (host)
+shadowRoot.activeElement        → <input name="title">  (real element)
+event.target                    → <div#ChatRoomCreate>  (retargeted)
+event.composedPath()[0]         → <input name="title">  (real element)
+```
+
+**Fix — two parts:**
+
+**Part 1: Register `onKeyDown` in the capture phase**
+
+The component's `onKeyDown` handler must run **before** all other `window.keydown` handlers. Set `captureKeyEvents = true` on the component instance. This makes `_bindKeyDown()` register the handler with `useCapture = true`, so it fires during the capture phase (before the bubble phase where other handlers listen).
+
+```javascript
+// In _bindKeyDown() — GUIComponent.js
+_bindKeyDown() {
+    if (!this.onKeyDown) return;
+    this._unbindKeyDown();
+    const handler = this.onKeyDown.bind(this);
+    this._keyHandler = event => {
+        if (handler(event) === false) {
+            event.preventDefault();
+        }
+    };
+    var useCapture = !!this.captureKeyEvents;
+    window.addEventListener('keydown', this._keyHandler, useCapture);
+}
+```
+
+**Part 2: Guard the `onKeyDown` handler**
+
+Inside the component's `onKeyDown`, check if an input element inside the shadow is focused. If so, call `stopImmediatePropagation()` to block all other handlers, and return `true` (NOT `false`) so the wrapper does not call `preventDefault()` — the browser must execute the default action (typing the character).
+
+Use `shadowRoot.activeElement` (not `document.activeElement`) to get the real focused element inside the shadow.
+
+```javascript
+ChatRoomCreate.onKeyDown = function onKeyDown(event) {
+	var shadow = this._shadow || this._host;
+	var focused = shadow.activeElement;
+
+	// If an input inside the shadow is focused, let the browser handle the keystroke
+	if (focused && focused.tagName && focused.tagName.match(/input|select|textarea/i)) {
+		// Still handle Enter/Escape for form submission/close
+		if (event.which === KEYS.ENTER) {
+			submitForm.call(this);
+			event.stopImmediatePropagation();
+			return false;
+		}
+		if (event.which === KEYS.ESCAPE || event.key === 'Escape') {
+			this.hide();
+			event.stopImmediatePropagation();
+			return false;
+		}
+		// Block other handlers from consuming the keystroke, but let the browser type it
+		event.stopImmediatePropagation();
+		return true; // ← CRITICAL: true, not false
+	}
+
+	// Normal key handling when no input is focused
+	// ...
+	return true;
+};
+```
+
+**Component setup:**
+
+```javascript
+ChatRoomCreate.captureKeyEvents = true; // ← capture phase
+```
+
+**Why `return true` is critical**: The `_bindKeyDown` wrapper calls `event.preventDefault()` when the handler returns `false`. For text inputs, `preventDefault()` on `keydown` blocks the character from being inserted. Returning `true` (or any non-`false` value) skips `preventDefault()`, allowing normal typing.
+
+**Why only some keys worked without the fix**: Keys like `z`, `x`, `c`, `v`, `b`, `n`, `m` are not mapped to any shortcut in the default `ShortCutControls.js`. All other keys (`a`–`y`, `0`–`9`, `F1`–`F12`) are consumed by the ChatBox battle mode handler (line 928–941) or the shortcut system before reaching the input.
+
+**RULE**: Any GUIComponent with `<input>`, `<select>`, or `<textarea>` inside its Shadow DOM **must** set `captureKeyEvents = true` and guard its `onKeyDown` with a `shadowRoot.activeElement` check. Without this, users will not be able to type in those fields.
+
+**Affected components**: ChatRoomCreate, ChatRoom, and any future GUIComponent with text input fields.
+
+````
+
+Also add a new row to the "Quick Reference: What NOT to do" table (around line 528):
+
+| Don't | Do instead | Why |
+|---|---|---|
+| `onKeyDown` without `shadowRoot.activeElement` guard | Check `(this._shadow \|\| this._host).activeElement.tagName` | `document.activeElement` returns host, not the real input inside shadow |
+
+And also update `_unbindKeyDown()` in `src/UI/GUIComponent.js` (line 424-430) — it already removes both normal and capture listeners, which is correct. But `_bindKeyDown()` (line 412-422) needs to be updated to check `this.captureKeyEvents`:
+
+```javascript
+_bindKeyDown() {
+    if (!this.onKeyDown) return;
+    this._unbindKeyDown();
+    const handler = this.onKeyDown.bind(this);
+    this._keyHandler = event => {
+        if (handler(event) === false) {
+            event.preventDefault();
+        }
+    };
+    var useCapture = !!this.captureKeyEvents;
+    window.addEventListener('keydown', this._keyHandler, useCapture);
+}
+````
+
 ---
 
 ## Reference: Clan Component (first GUIComponent migration)

--- a/doc/UIComponent_to_GUIComponent.md
+++ b/doc/UIComponent_to_GUIComponent.md
@@ -569,14 +569,6 @@ ChatRoomCreate.captureKeyEvents = true; // ← capture phase
 
 **Affected components**: ChatRoomCreate, ChatRoom, and any future GUIComponent with text input fields.
 
-````
-
-Also add a new row to the "Quick Reference: What NOT to do" table (around line 528):
-
-| Don't | Do instead | Why |
-|---|---|---|
-| `onKeyDown` without `shadowRoot.activeElement` guard | Check `(this._shadow \|\| this._host).activeElement.tagName` | `document.activeElement` returns host, not the real input inside shadow |
-
 And also update `_unbindKeyDown()` in `src/UI/GUIComponent.js` (line 424-430) — it already removes both normal and capture listeners, which is correct. But `_bindKeyDown()` (line 412-422) needs to be updated to check `this.captureKeyEvents`:
 
 ```javascript
@@ -641,3 +633,4 @@ _bindKeyDown() {
 | Register click handlers on `document.body` expecting shadow targets | Register inside `this._container`               | Event retargeting hides real target                |
 | Bind events in `onAppend()`                                         | Bind in `init()`, restore state in `onAppend()` | `onAppend()` runs every time — duplicates bindings |
 | Set `position`/`z-index` on `:host` in CSS                          | Omit — set automatically by JS                  | Redundant, may conflict                            |
+| `onKeyDown` without `shadowRoot.activeElement` guard | Check `(this._shadow \|\| this._host).activeElement.tagName` | `document.activeElement` returns host, not the real input inside shadow |

--- a/src/Engine/MapEngine/ChatRoom.js
+++ b/src/Engine/MapEngine/ChatRoom.js
@@ -25,12 +25,17 @@ import Session from 'Engine/SessionStorage.js';
  * PACKET.CZ.CREATE_CHATROOM
  */
 ChatRoomCreate.requestRoom = function requestRoom() {
-	const pkt = new PACKET.CZ.CREATE_CHATROOM();
-	pkt.size = this.limit;
-	pkt.type = this.type;
-	pkt.passwd = this.password;
-	pkt.title = this.title;
-	Network.sendPacket(pkt);
+	if (ChatRoomCreate.editMode) {
+		ChatRoom.changeChatRoom(this.title, this.limit, this.type, this.password);
+		ChatRoomCreate.editMode = false;
+	} else {
+		const pkt = new PACKET.CZ.CREATE_CHATROOM();
+		pkt.size = this.limit;
+		pkt.type = this.type;
+		pkt.passwd = this.password;
+		pkt.title = this.title;
+		Network.sendPacket(pkt);
+	}
 };
 
 /**

--- a/src/Engine/MapEngine/ChatRoom.js
+++ b/src/Engine/MapEngine/ChatRoom.js
@@ -35,41 +35,42 @@ ChatRoomCreate.requestRoom = function requestRoom() {
 
 /**
  * Request a change in the chat room
- * PACKET.CZ.CHANGE_CHATROOM
+ * PACKET.CZ.CHANGE_CHATROOM (0xde)
+ * @param {string} title
+ * @param {number} limit
+ * @param {number} type - 0=private, 1=public
+ * @param {string} password
  */
-ChatRoom.changeChatRoom = function changeChatRoom() {
+ChatRoom.changeChatRoom = function changeChatRoom(title, limit, type, password) {
 	const pkt = new PACKET.CZ.CHANGE_CHATROOM();
-	/*
-		this.size         = 0;
-		this.type         = 0;
-		this.passwd       = '';
-		this.title        = '';
-		*/
+	pkt.size = limit;
+	pkt.type = type;
+	pkt.passwd = password || '';
+	pkt.title = title;
 	Network.sendPacket(pkt);
 };
 
 /**
- * Request to change the role from a member in your chatroom
- * PACKET.CZ.REQ_ROLE_CHANGE
+ * Request to change the role of a member (transfer leadership)
+ * PACKET.CZ.REQ_ROLE_CHANGE (0xe0)
+ * @param {number} role - 0=owner, 1=normal
+ * @param {string} name
  */
-ChatRoom.requestRoleChange = function requestRoleChange() {
+ChatRoom.requestRoleChange = function requestRoleChange(role, name) {
 	const pkt = new PACKET.CZ.REQ_ROLE_CHANGE();
-	/*
-			this.role       = 0;
-			this.name       = '';
-		*/
+	pkt.role = role;
+	pkt.name = name;
 	Network.sendPacket(pkt);
 };
 
 /**
  * Request to expel a member from current chatroom
- * PACKET.CZ.REQ_EXPEL_MEMBER
+ * PACKET.CZ.REQ_EXPEL_MEMBER (0xe2)
+ * @param {string} name
  */
-ChatRoom.requestExpelMember = function requestExpelMember() {
+ChatRoom.requestExpelMember = function requestExpelMember(name) {
 	const pkt = new PACKET.CZ.REQ_EXPEL_MEMBER();
-	/*
-			this.name       = '';
-		*/
+	pkt.name = name;
 	Network.sendPacket(pkt);
 };
 
@@ -177,7 +178,7 @@ function onRoleChange(pkt) {
 	// The server will send two of this packets!
 	// One to remove the ownership and one to add ownership, we dont need the first packet !
 
-	if (pkt.role === 1) {
+	if (pkt.role === 0) {
 		ChatRoom.owner = pkt.name;
 		ChatRoom.updateChat();
 	}

--- a/src/UI/Components/ChatRoom/ChatRoom.css
+++ b/src/UI/Components/ChatRoom/ChatRoom.css
@@ -1,8 +1,18 @@
+:host {
+	width: 279px;
+	height: 200px;
+	top: 100px;
+	left: 100px;
+}
+
 #ChatRoom {
 	position: absolute;
-	top: 50%;
-	left: 50%;
+	width: 279px;
+	border-radius: 5px;
+	background-color: white;
+	background-repeat: no-repeat;
 }
+
 #ChatRoom table {
 	border-spacing: 0px;
 	display: inline-block;
@@ -126,4 +136,14 @@
 	position: absolute;
 	bottom: 0px;
 	right: 0px;
+}
+
+#ChatRoom .content .members span.member {
+	cursor: pointer;
+}
+#ChatRoom .content .members span.member:hover {
+	text-decoration: underline;
+}
+#ChatRoom .content .members span.owner {
+	font-weight: bold;
 }

--- a/src/UI/Components/ChatRoom/ChatRoom.js
+++ b/src/UI/Components/ChatRoom/ChatRoom.js
@@ -393,9 +393,8 @@ ChatRoom.requestExpelMember = function requestExpelMember() {};
  * Resize ChatRoom via drag
  */
 function onResize() {
-	const rect = ChatRoom._host.getBoundingClientRect();
-	const top = rect.top;
-	const left = rect.left;
+	const top = ChatRoom._host.offsetTop;
+	const left = ChatRoom._host.offsetLeft;
 	let lastWidth = 0;
 	let lastHeight = 0;
 

--- a/src/UI/Components/ChatRoom/ChatRoom.js
+++ b/src/UI/Components/ChatRoom/ChatRoom.js
@@ -468,8 +468,18 @@ ChatRoom.openRoomSettings = function openRoomSettings() {
 
 	ChatRoomCreate.requestRoom = function () {
 		ChatRoom.changeChatRoom(this.title, this.limit, this.type, this.password);
-		// Restore original after use
+		// Restore immediately after use
 		ChatRoomCreate.requestRoom = originalRequestRoom;
+	};
+
+	// Also restore on close/cancel
+	const originalOnRemove = ChatRoomCreate.onRemove;
+	ChatRoomCreate.onRemove = function () {
+		ChatRoomCreate.requestRoom = originalRequestRoom;
+		ChatRoomCreate.onRemove = originalOnRemove;
+		if (originalOnRemove) {
+			originalOnRemove.call(this);
+		}
 	};
 
 	ChatRoomCreate.prefill(ChatRoom.title, ChatRoom.limit, ChatRoom.type, ChatRoom.password);

--- a/src/UI/Components/ChatRoom/ChatRoom.js
+++ b/src/UI/Components/ChatRoom/ChatRoom.js
@@ -464,25 +464,8 @@ function resize(width, height) {
  * Open ChatRoomCreate pre-filled
  */
 ChatRoom.openRoomSettings = function openRoomSettings() {
-	const originalRequestRoom = ChatRoomCreate.requestRoom;
-
-	ChatRoomCreate.requestRoom = function () {
-		ChatRoom.changeChatRoom(this.title, this.limit, this.type, this.password);
-		// Restore immediately after use
-		ChatRoomCreate.requestRoom = originalRequestRoom;
-	};
-
-	// Also restore on close/cancel
-	const originalOnRemove = ChatRoomCreate.onRemove;
-	ChatRoomCreate.onRemove = function () {
-		ChatRoomCreate.requestRoom = originalRequestRoom;
-		ChatRoomCreate.onRemove = originalOnRemove;
-		if (originalOnRemove) {
-			originalOnRemove.call(this);
-		}
-	};
-
-	ChatRoomCreate.prefill(ChatRoom.title, ChatRoom.limit, ChatRoom.type, ChatRoom.password);
+	ChatRoomCreate.editMode = true;
+	ChatRoomCreate.prefill(ChatRoom.title, ChatRoom.limit, ChatRoom.type);
 	ChatRoomCreate.show();
 };
 

--- a/src/UI/Components/ChatRoom/ChatRoom.js
+++ b/src/UI/Components/ChatRoom/ChatRoom.js
@@ -1,20 +1,40 @@
+/**
+ * UI/Components/ChatRoom/ChatRoom.js
+ *
+ * Chat room UI
+ *
+ * This file is part of ROBrowser, (http://www.robrowser.com/).
+ *
+ * @author Vincent Thibault, AoShinHo
+ */
+
 import Preferences from 'Core/Preferences.js';
-import jQuery from 'Utils/jquery.js';
 import Renderer from 'Renderer/Renderer.js';
 import Session from 'Engine/SessionStorage.js';
 import Mouse from 'Controls/MouseEventHandler.js';
 import KEYS from 'Controls/KeyEventHandler.js';
 import ChatBox from 'UI/Components/ChatBox/ChatBox.js';
 import UIManager from 'UI/UIManager.js';
-import UIComponent from 'UI/UIComponent.js';
+import GUIComponent from 'UI/GUIComponent.js';
+import ContextMenu from 'UI/Components/ContextMenu/ContextMenu.js';
+import ChatRoomCreate from 'UI/Components/ChatRoomCreate/ChatRoomCreate.js';
 import htmlText from './ChatRoom.html?raw';
 import cssText from './ChatRoom.css?raw';
 import ProcessCommand from 'Controls/ProcessCommand.js';
+import DB from 'DB/DBManager.js';
+import EntityManager from 'Renderer/EntityManager.js';
+import Equipment from 'UI/Components/Equipment/Equipment.js';
+import Friends from 'Engine/MapEngine/Friends.js';
 
 /**
  * Create Component
  */
-const ChatRoom = new UIComponent('ChatRoom', htmlText, cssText);
+const ChatRoom = new GUIComponent('ChatRoom', cssText);
+
+/**
+ * Render HTML
+ */
+ChatRoom.render = () => htmlText;
 
 /**
  * @var {string} Chat Room title
@@ -52,6 +72,12 @@ ChatRoom.owner = '';
 ChatRoom.isOpen = false;
 
 /**
+ * Track current grid dimensions for preferences
+ */
+let _gridWidth = 7;
+let _gridHeight = 3;
+
+/**
  * @var {Preference} structure to save
  */
 const _preferences = Preferences.get(
@@ -60,7 +86,7 @@ const _preferences = Preferences.get(
 		x: 480,
 		y: 200,
 		width: 7,
-		height: 4
+		height: 3
 	},
 	1.0
 );
@@ -69,36 +95,44 @@ const _preferences = Preferences.get(
  * Initialize UI
  */
 ChatRoom.init = function init() {
-	// Bindings
-	this.ui.find('.extend').mousedown(onResize);
-	this.ui
-		.find('.close')
-		.mousedown(function (event) {
-			event.stopImmediatePropagation();
-			return false;
-		})
-		.click(this.remove.bind(this));
+	const root = this._shadow || this._host;
 
-	this.ui.find('.sendmsg').mousedown(function (event) {
+	// Close button
+	const closeBtn = root.querySelector('.close');
+	closeBtn.addEventListener('mousedown', event => {
+		event.stopImmediatePropagation();
+		event.preventDefault();
+	});
+	closeBtn.addEventListener('click', this.remove.bind(this));
+
+	// Prevent input from moving character
+	root.querySelector('.sendmsg').addEventListener('mousedown', event => {
 		event.stopImmediatePropagation();
 	});
 
-	this.draggable(this.ui.find('.titlebar'));
+	// Resize handle
+	root.querySelector('.extend').addEventListener('mousedown', onResize);
+
+	this.draggable('.titlebar');
 };
 
 /**
- * Initialize UI
+ * Once appended to DOM
  */
 ChatRoom.onAppend = function onAppend() {
+	const root = this._shadow || this._host;
+
 	this.isOpen = true;
-	resize(_preferences.width, _preferences.height);
+	_gridWidth = _preferences.width;
+	_gridHeight = _preferences.height;
+	resize(_gridWidth, _gridHeight);
 
-	this.ui.css({
-		top: Math.min(Math.max(0, _preferences.y), Renderer.height - this.ui.height()),
-		left: Math.min(Math.max(0, _preferences.x), Renderer.width - this.ui.width())
-	});
+	this._host.style.top =
+		Math.min(Math.max(0, _preferences.y), Renderer.height - this._host.getBoundingClientRect().height) + 'px';
+	this._host.style.left =
+		Math.min(Math.max(0, _preferences.x), Renderer.width - this._host.getBoundingClientRect().width) + 'px';
 
-	this.ui.find('.sendmsg').focus();
+	root.querySelector('.sendmsg').focus();
 	this.updateChat();
 };
 
@@ -114,131 +148,254 @@ ChatRoom.onRemove = function onRemove() {
 	this.owner = '';
 	this.isOpen = false;
 
-	this.ui.find('.messages').empty();
+	const root = this._shadow || this._host;
+	const messages = root.querySelector('.messages');
+	if (messages) messages.innerHTML = '';
 
-	_preferences.y = parseInt(this.ui.css('top'), 10);
-	_preferences.x = parseInt(this.ui.css('left'), 10);
-	_preferences.width = Math.floor((this.ui.width() - (23 + 16 + 16 - 30)) / 32);
-	_preferences.height = Math.floor((this.ui.height() - -30) / 32);
+	_preferences.y = parseInt(this._host.style.top, 10);
+	_preferences.x = parseInt(this._host.style.left, 10);
+	_preferences.width = _gridWidth;
+	_preferences.height = _gridHeight;
 	_preferences.save();
 
 	this.exitRoom();
 };
 
+function viewMemberEquip(name) {
+	// Find entity by name
+	let found = null;
+	EntityManager.forEach(function (entity) {
+		if (entity.display && entity.display.name === name) {
+			found = entity;
+			return false; // stop iteration
+		}
+	});
+
+	if (found) {
+		Equipment.onCheckPlayerEquipment(found.GID);
+	}
+}
+
+function onMemberContextMenu(event) {
+	event.preventDefault();
+	event.stopImmediatePropagation();
+
+	const memberName = this.dataset.name;
+	if (!memberName) return;
+
+	const isOwner = ChatRoom.owner === Session.Entity.display.name;
+	const isSelf = memberName === Session.Entity.display.name;
+
+	// Update mouse position for ContextMenu positioning
+	Mouse.screen.x = event.pageX || event.clientX;
+	Mouse.screen.y = event.pageY || event.clientY;
+
+	ContextMenu.remove();
+	ContextMenu.append();
+
+	if (isOwner && isSelf) {
+		// Owner clicking on self: "Change room" + "View info"
+		// 126 = Change room settings
+		ContextMenu.addElement(DB.getMessage(126, 'Change room settings'), () => {
+			ChatRoom.openRoomSettings();
+		});
+		// 1360 = View Info (%s)
+		ContextMenu.addElement(DB.getMessage(1360, 'View Info %s').replace('%s', memberName), () => {
+			viewMemberEquip(memberName);
+		});
+	} else if (isOwner && !isSelf) {
+		// Owner clicking on other member: all options
+		// 127 = Kick member
+		ContextMenu.addElement(DB.getMessage(127, 'Kick member'), () => {
+			ChatRoom.requestExpelMember(memberName);
+		});
+		// 128 = Transfer leadership
+		ContextMenu.addElement(DB.getMessage(128, 'Transfer leadership'), () => {
+			ChatRoom.requestRoleChange(0, memberName);
+		});
+		// 1360 = View Info (%s)
+		ContextMenu.addElement(DB.getMessage(1360, 'View Info %s').replace('%s', memberName), () => {
+			viewMemberEquip(memberName);
+		});
+		// 358 = Add as friend
+		if (!Friends.isFriend(memberName)) {
+			ContextMenu.addElement(DB.getMessage(358, 'Add as friend'), () => {
+				Friends.addFriend(memberName);
+			});
+		}
+		// 126 = Change room settings
+		ContextMenu.addElement(DB.getMessage(126, 'Change room settings'), () => {
+			ChatRoom.openRoomSettings();
+		});
+	} else if (!isOwner && !isSelf) {
+		// Non-owner clicking on other member
+		// 1360 = View Info (%s)
+		ContextMenu.addElement(DB.getMessage(1360, 'View Info %s').replace('%s', memberName), () => {
+			viewMemberEquip(memberName);
+		});
+		// 358 = Add as friend
+		if (!Friends.isFriend(memberName)) {
+			ContextMenu.addElement(DB.getMessage(358, 'Add as friend'), () => {
+				Friends.addFriend(memberName);
+			});
+		}
+	} else {
+		// Non-owner clicking on self
+		// 1360 = View Info (%s)
+		ContextMenu.addElement(DB.getMessage(1360, 'View Info %s').replace('%s', memberName), () => {
+			viewMemberEquip(memberName);
+		});
+	}
+}
+
 /**
- * Update ChatRoom parameters
+ * Update ChatRoom parameters (title, count, members list)
  */
 ChatRoom.updateChat = function updateChat() {
-	let members = '';
+	const root = this._shadow || this._host;
+	const titleEl = root.querySelector('.titlebar .title');
+	const countEl = root.querySelector('.titlebar .count');
+	const membersEl = root.querySelector('.members');
+
+	if (titleEl) titleEl.textContent = this.title;
+	if (countEl) countEl.textContent = this.count + '/' + this.limit;
+	if (!membersEl) return;
+
+	membersEl.innerHTML = '';
+
 	const count = this.members.length;
 
-	this.ui.find('.titlebar .title').text(this.title);
-	this.ui.find('.titlebar .count').text(this.count + '/' + this.limit);
-
+	// Owner first
 	for (let i = 0; i < count; ++i) {
-		if (this.members[i] == this.owner) {
-			members = '<span class="owner">' + jQuery.escape(this.members[i]) + '</span><br/>' + members;
-			continue;
+		if (this.members[i] === this.owner) {
+			const ownerSpan = document.createElement('span');
+			ownerSpan.className = 'owner member';
+			ownerSpan.dataset.name = this.members[i];
+			ownerSpan.textContent = this.members[i];
+			ownerSpan.addEventListener('contextmenu', onMemberContextMenu);
+			membersEl.appendChild(ownerSpan);
+			membersEl.appendChild(document.createElement('br'));
 		}
-		members += jQuery.escape(this.members[i]) + '<br/>';
 	}
 
-	this.ui.find('.members').html(members);
+	// Then other members
+	for (let j = 0; j < count; ++j) {
+		if (this.members[j] !== this.owner) {
+			const memberSpan = document.createElement('span');
+			memberSpan.className = 'member';
+			memberSpan.dataset.name = this.members[j];
+			memberSpan.textContent = this.members[j];
+			memberSpan.addEventListener('contextmenu', onMemberContextMenu);
+			membersEl.appendChild(memberSpan);
+			membersEl.appendChild(document.createElement('br'));
+		}
+	}
 };
 
 /**
  * Parse and send chat room messages
  */
 function sendChatMessage() {
-	const ui = ChatRoom.ui;
-	const message = ui.find('.send input[name=message]').val();
+	const root = ChatRoom._shadow || ChatRoom._host;
+	const input = root.querySelector('.send input[name=message]');
+	const message = input.value;
 
-	// Nothing to submit
 	if (message.length < 1) {
 		return false;
 	}
 
-	// Process commands
 	if (message[0] === '/') {
 		ProcessCommand.processCommand.call(ChatBox, message.substr(1));
-		ui.find('.send input[name=message]').val('');
+		input.value = '';
 		return true;
 	}
 
 	ChatBox.onRequestTalk('', message);
-	ui.find('.send input[name=message]').val('');
-
+	input.value = '';
 	return true;
 }
 
 /**
  * Display a message in the chat room
  * @param {string} message
+ * @param {string} type
  */
 ChatRoom.message = function displayMessage(message, type) {
-	// Escape html tag
-	const element = jQuery('<div/>');
-	element.text(message);
+	const root = this._shadow || this._host;
+	const element = document.createElement('div');
+	element.textContent = message;
 
 	if (type) {
-		element.addClass(type);
+		element.className = type;
 	} else if (message.indexOf(Session.Entity.display.name + ' : ') === 0) {
-		element.addClass('self');
+		element.className = 'self';
 	}
 
-	const content = this.ui.find('.messages');
-
-	// Append content, move to the bottom
-	content.append(element);
-	content[0].scrollTop = content[0].scrollHeight;
+	const content = root.querySelector('.messages');
+	content.appendChild(element);
+	content.scrollTop = content.scrollHeight;
 
 	return true;
 };
 
 /**
  * Remove a member from the chat
- * @param {string} member name
+ * @param {string} name
  */
 ChatRoom.removeMember = function removeMember(name) {
 	const pos = this.members.indexOf(name);
-
 	if (pos > -1) {
 		this.members.splice(pos, 1);
 		return true;
 	}
-
 	return false;
 };
 
 /**
  * Key Event Handler
- *
- * @param {object} event - KeyEventHandler
- * @return {boolean}
  */
 ChatRoom.onKeyDown = function onKeyDown(event) {
+	const root = this._shadow || this._host;
+	const active = root.activeElement;
+
+	if (active && active.tagName && active.tagName.match(/input|textarea|select/i)) {
+		// Input focused — let the keystroke through but block other handlers
+		if (event.which === KEYS.ENTER) {
+			sendChatMessage();
+			event.stopImmediatePropagation();
+			return false;
+		}
+		if (event.which === KEYS.ESCAPE || event.key === 'Escape') {
+			active.blur();
+			event.stopImmediatePropagation();
+			return false;
+		}
+		event.stopImmediatePropagation();
+		return true;
+	}
+
 	if (event.which === KEYS.ENTER) {
 		sendChatMessage();
-
 		event.stopImmediatePropagation();
 		return false;
 	}
-
 	return true;
 };
 
 /**
- * Functions to define
+ * Functions to define (overridden by Engine/MapEngine/ChatRoom.js)
  */
 ChatRoom.exitRoom = function exitRoom() {};
-
+ChatRoom.changeChatRoom = function changeChatRoom() {};
+ChatRoom.requestRoleChange = function requestRoleChange() {};
+ChatRoom.requestExpelMember = function requestExpelMember() {};
 /**
- * Resize ChatRoom
+ * Resize ChatRoom via drag
  */
 function onResize() {
-	const ui = ChatRoom.ui;
-	const top = ui.position().top;
-	const left = ui.position().left;
+	const rect = ChatRoom._host.getBoundingClientRect();
+	const top = rect.top;
+	const left = rect.left;
 	let lastWidth = 0;
 	let lastHeight = 0;
 
@@ -265,25 +422,63 @@ function onResize() {
 	// Start resizing
 	const _Interval = setInterval(resizeProcess, 30);
 
-	// Stop resizing
-	jQuery(window).one('mouseup', function (event) {
-		// Only on left click
+	// Stop resizing (native DOM instead of jQuery(window).one)
+	function onMouseUp(event) {
 		if (event.which === 1) {
 			clearInterval(_Interval);
+			window.removeEventListener('mouseup', onMouseUp);
 		}
-	});
+	}
+	window.addEventListener('mouseup', onMouseUp);
 }
 
 /**
- * Extend inventory window size
+ * Extend chat room window size
  */
 function resize(width, height) {
 	width = Math.min(Math.max(width, 7), 14);
 	height = Math.min(Math.max(height, 3), 8);
 
-	ChatRoom.ui.css('width', 23 + 16 + 16 + width * 32);
-	ChatRoom.ui.find('.resize').css('height', height * 32);
+	_gridWidth = width;
+	_gridHeight = height;
+
+	const root = ChatRoom._shadow || ChatRoom._host;
+	const inner = root.querySelector('#ChatRoom');
+	if (inner) {
+		inner.style.width = 23 + 16 + 16 + width * 32 + 'px';
+	}
+	root.querySelectorAll('.resize').forEach(function (el) {
+		el.style.height = height * 32 + 'px';
+	});
+
+	// Update host dimensions to match
+	if (ChatRoom._host) {
+		ChatRoom._host.style.width = 23 + 16 + 16 + width * 32 + 'px';
+		if (inner) {
+			ChatRoom._host.style.height = inner.offsetHeight + 'px';
+		}
+	}
 }
+
+/**
+ * Open ChatRoomCreate pre-filled
+ */
+ChatRoom.openRoomSettings = function openRoomSettings() {
+	const originalRequestRoom = ChatRoomCreate.requestRoom;
+
+	ChatRoomCreate.requestRoom = function () {
+		ChatRoom.changeChatRoom(this.title, this.limit, this.type, this.password);
+		// Restore original after use
+		ChatRoomCreate.requestRoom = originalRequestRoom;
+	};
+
+	ChatRoomCreate.prefill(ChatRoom.title, ChatRoom.limit, ChatRoom.type, ChatRoom.password);
+	ChatRoomCreate.show();
+};
+
+ChatRoom.mouseMode = GUIComponent.MouseMode.STOP;
+ChatRoom.captureKeyEvents = true;
+ChatRoom.needFocus = true;
 
 /**
  * Create component and export it

--- a/src/UI/Components/ChatRoomCreate/ChatRoomCreate.css
+++ b/src/UI/Components/ChatRoomCreate/ChatRoomCreate.css
@@ -1,7 +1,12 @@
-#ChatRoomCreate {
-	position: absolute;
+:host {
+	width: 280px;
+	height: 120px;
 	top: 50%;
 	left: 50%;
+}
+
+#ChatRoomCreate {
+	position: absolute;
 	width: 280px;
 	height: 120px;
 }
@@ -68,16 +73,16 @@
 }
 #ChatRoomCreate .container .title {
 	height: 16px;
-	width: 214px;
+	width: 198px;
 	padding-left: 5px;
 }
 #ChatRoomCreate .container .limit,
 #ChatRoomCreate .container .password {
-	width: 81px;
+	width: 58px;
 	padding-left: 5px;
 }
 #ChatRoomCreate .container .type {
-	width: 88px;
+	width: 110px;
 }
 #ChatRoomCreate .head {
 	color: #0f4b8c;
@@ -86,8 +91,10 @@
 	width: 40px;
 	white-space: nowrap;
 }
+#ChatRoomCreate .mode {
+	white-space: nowrap;
+}
 #ChatRoomCreate .mode span {
-	width: 43px;
 	overflow: hidden;
 	display: inline-block;
 	white-space: nowrap;

--- a/src/UI/Components/ChatRoomCreate/ChatRoomCreate.html
+++ b/src/UI/Components/ChatRoomCreate/ChatRoomCreate.html
@@ -25,11 +25,11 @@
 					<td class="head">Limit :</td>
 					<td>
 						<select name="limit" class="limit">
-							<option value="20">20 People</option>
-							<option value="12">12 People</option>
-							<option value="8">8 People</option>
-							<option value="4">4 People</option>
-							<option value="2">2 People</option>
+							<option value="20">20</option>
+							<option value="12">12</option>
+							<option value="8">8</option>
+							<option value="4">4</option>
+							<option value="2">2</option>
 						</select>
 					</td>
 					<td class="head">Type :</td>
@@ -40,19 +40,15 @@
 					</td>
 				</tr>
 				<tr>
-					<td class="head">Public :</td>
-					<td class="mode">
-						<span>
-							<input type="radio" name="public" value="1" checked="checked" /><span data-text="201"
-								>Public</span
-							>
-						</span>
-						<span>
-							<input type="radio" name="public" value="0" /><span data-text="200">Private</span>
-						</span>
-					</td>
-					<td class="head">Sign :</td>
-					<td>
+					<td class="head">Restrict :</td>
+					<td class="mode" colspan="3">
+						<span
+							><input type="radio" name="public" value="1" checked="checked" /><span data-text="201"
+								>Púb.</span
+							></span
+						>
+						<span><input type="radio" name="public" value="0" /><span data-text="200">Priv.</span></span>
+						<span class="head">Sign :</span>
 						<input class="password" type="password" name="password" value="" maxlength="16" />
 					</td>
 				</tr>

--- a/src/UI/Components/ChatRoomCreate/ChatRoomCreate.js
+++ b/src/UI/Components/ChatRoomCreate/ChatRoomCreate.js
@@ -174,6 +174,7 @@ ChatRoomCreate.onKeyDown = function onKeyDown(event) {
 	if (this._host.style.display === 'none') {
 		return true;
 	}
+
 	// Input inside our shadow is focused — protect keystrokes
 	if (active && active.tagName && /input|select|textarea/i.test(active.tagName)) {
 		if (event.which === KEYS.ENTER) {
@@ -181,7 +182,7 @@ ChatRoomCreate.onKeyDown = function onKeyDown(event) {
 			event.stopImmediatePropagation();
 			return false;
 		}
-		if (event.which === KEYS.ESCAPE || event.key === 'Escape') {
+		if ((event.which === KEYS.ESCAPE || event.key === 'Escape') && this._host.style.display !== 'none') {
 			this._host.style.display = 'none';
 			event.stopImmediatePropagation();
 			return false;
@@ -192,7 +193,7 @@ ChatRoomCreate.onKeyDown = function onKeyDown(event) {
 	}
 
 	// No input focused — only handle Escape
-	if (event.which === KEYS.ESCAPE || event.key === 'Escape') {
+	if ((event.which === KEYS.ESCAPE || event.key === 'Escape') && this._host.style.display !== 'none') {
 		this._host.style.display = 'none';
 		event.stopImmediatePropagation();
 		return false;

--- a/src/UI/Components/ChatRoomCreate/ChatRoomCreate.js
+++ b/src/UI/Components/ChatRoomCreate/ChatRoomCreate.js
@@ -5,23 +5,26 @@
  *
  * This file is part of ROBrowser, (http://www.robrowser.com/).
  *
- * @author Vincent Thibault
+ * @author Vincent Thibault, AoShinHo
  */
-
-import jQuery from 'Utils/jquery.js';
 import DB from 'DB/DBManager.js';
 import KEYS from 'Controls/KeyEventHandler.js';
 import Renderer from 'Renderer/Renderer.js';
 import Preferences from 'Core/Preferences.js';
 import UIManager from 'UI/UIManager.js';
-import UIComponent from 'UI/UIComponent.js';
+import GUIComponent from 'UI/GUIComponent.js';
 import htmlText from './ChatRoomCreate.html?raw';
 import cssText from './ChatRoomCreate.css?raw';
 
 /**
  * Create Component
  */
-const ChatRoomCreate = new UIComponent('ChatRoomCreate', htmlText, cssText);
+const ChatRoomCreate = new GUIComponent('ChatRoomCreate', cssText);
+
+/**
+ * Render HTML
+ */
+ChatRoomCreate.render = () => htmlText;
 
 /**
  * @var {string} chat room title
@@ -62,46 +65,57 @@ const _preferences = Preferences.get(
  * Initialize UI
  */
 ChatRoomCreate.init = function init() {
-	// Bindings
-	this.ui.find('.close, .cancel').mousedown(stopPropagation).click(this.hide.bind(this));
-	this.ui.find('.ok').on('click', parseChatSetup.bind(this));
-	this.ui.find('.setup').submit(function () {
-		return false;
-	});
+	const root = this._shadow || this._host;
 
-	this.ui.find('input, select').mousedown(function (event) {
+	// Close / Cancel
+	root.querySelector('.close').addEventListener('mousedown', event => {
 		event.stopImmediatePropagation();
 	});
+	root.querySelector('.close').addEventListener('click', () => ChatRoomCreate.hide());
 
-	this.draggable(this.ui.find('.titlebar'));
-	this.ui.hide();
+	root.querySelector('.cancel').addEventListener('mousedown', event => {
+		event.stopImmediatePropagation();
+	});
+	root.querySelector('.cancel').addEventListener('click', () => ChatRoomCreate.hide());
+
+	// OK button
+	root.querySelector('.ok').addEventListener('click', () => parseChatSetup.call(ChatRoomCreate));
+
+	// Prevent form submit
+	root.querySelector('.setup').addEventListener('submit', event => {
+		event.preventDefault();
+	});
+
+	// Prevent inputs from moving character
+	root.querySelectorAll('input, select').forEach(el => {
+		el.addEventListener('mousedown', event => {
+			event.stopImmediatePropagation();
+		});
+	});
+
+	this.draggable('.titlebar');
+	this._host.style.display = 'none';
 };
 
 /**
  * Once append to body
  */
-ChatRoomCreate.onAppend = function OnAppend() {
+ChatRoomCreate.onAppend = function onAppend() {
 	if (!_preferences.show) {
-		this.ui.hide();
+		this._host.style.display = 'none';
 	}
 
-	this.ui.css({
-		top: Math.min(Math.max(0, _preferences.y), Renderer.height - this.ui.height()),
-		left: Math.min(Math.max(0, _preferences.x), Renderer.width - this.ui.width())
-	});
-
-	// Escape key order
-	const events = jQuery._data(window, 'events').keydown;
-	events.unshift(events.pop());
+	this._host.style.top = Math.min(Math.max(0, _preferences.y), Renderer.height - this._host.offsetHeight) + 'px';
+	this._host.style.left = Math.min(Math.max(0, _preferences.x), Renderer.width - this._host.offsetWidth) + 'px';
 };
 
 /**
  * Once removed from DOM, save preferences
  */
-ChatRoomCreate.onRemove = function OnRemove() {
-	_preferences.show = this.ui.is(':visible');
-	_preferences.y = parseInt(this.ui.css('top'), 10);
-	_preferences.x = parseInt(this.ui.css('left'), 10);
+ChatRoomCreate.onRemove = function onRemove() {
+	_preferences.show = this._host.style.display !== 'none';
+	_preferences.y = parseInt(this._host.style.top, 10);
+	_preferences.x = parseInt(this._host.style.left, 10);
 	_preferences.save();
 };
 
@@ -109,8 +123,10 @@ ChatRoomCreate.onRemove = function OnRemove() {
  * Show the setup for room creation
  */
 ChatRoomCreate.show = function showSetup() {
-	this.ui.show();
-	this.ui.find('.title').focus();
+	this._host.style.display = '';
+	const root = this._shadow || this._host;
+	root.querySelector('.title').focus();
+	this._fixPositionOverflow();
 
 	_preferences.show = true;
 };
@@ -119,10 +135,29 @@ ChatRoomCreate.show = function showSetup() {
  * Hide the setup ui
  */
 ChatRoomCreate.hide = function hideSetup() {
-	this.ui.hide();
-	this.ui.find('.setup')[0].reset();
+	this._host.style.display = 'none';
+	const root = this._shadow || this._host;
+	root.querySelector('.setup').reset();
 
 	_preferences.show = false;
+};
+
+/**
+ * Pre-fill form with values (used by ChatRoom.openRoomSettings)
+ * @param {string} title
+ * @param {number} limit
+ * @param {number} type
+ * @param {string} password
+ */
+ChatRoomCreate.prefill = function prefill(title, limit, type, password) {
+	const root = this._shadow || this._host;
+	root.querySelector('input[name=title]').value = title || '';
+	root.querySelector('select[name=limit]').value = limit || 20;
+
+	const radio = root.querySelector('input[name=public][value="' + (type || 1) + '"]');
+	if (radio) radio.checked = true;
+
+	root.querySelector('input[name=password]').value = password || '';
 };
 
 /**
@@ -132,18 +167,32 @@ ChatRoomCreate.hide = function hideSetup() {
  * @return {boolean}
  */
 ChatRoomCreate.onKeyDown = function onKeyDown(event) {
-	if (this.ui.is(':visible')) {
+	const root = this._shadow || this._host;
+	const active = root.activeElement;
+
+	// Input inside our shadow is focused — protect keystrokes
+	if (active && active.tagName && /input|select|textarea/i.test(active.tagName)) {
 		if (event.which === KEYS.ENTER) {
 			parseChatSetup.call(this);
 			event.stopImmediatePropagation();
 			return false;
-		} else if (event.which === KEYS.ESCAPE || event.key === 'Escape') {
-			this.hide();
+		}
+		if (event.which === KEYS.ESCAPE || event.key === 'Escape') {
+			this._host.style.display = 'none';
 			event.stopImmediatePropagation();
 			return false;
 		}
+		// Block other window handlers from consuming the key
+		event.stopImmediatePropagation();
+		return true; // Don't preventDefault — let the character be typed
 	}
 
+	// No input focused — only handle Escape
+	if (event.which === KEYS.ESCAPE || event.key === 'Escape') {
+		this._host.style.display = 'none';
+		event.stopImmediatePropagation();
+		return false;
+	}
 	return true;
 };
 
@@ -152,7 +201,7 @@ ChatRoomCreate.onKeyDown = function onKeyDown(event) {
  *
  * @param {object} key
  */
-ChatRoomCreate.onShortCut = function onShurtCut(key) {
+ChatRoomCreate.onShortCut = function onShortCut(key) {
 	switch (key.cmd) {
 		case 'TOGGLE':
 			ChatRoomCreate.toggle();
@@ -161,28 +210,25 @@ ChatRoomCreate.onShortCut = function onShurtCut(key) {
 };
 
 ChatRoomCreate.toggle = function toggle() {
-	this.ui.toggle();
-	if (this.ui.is(':visible')) {
+	if (this._host.style.display === 'none') {
+		this._host.style.display = '';
+		this._fixPositionOverflow();
 		this.focus();
+	} else {
+		this._host.style.display = 'none';
 	}
 };
-
-/**
- * Stop event propagation
- */
-function stopPropagation(event) {
-	event.stopImmediatePropagation();
-	return false;
-}
 
 /**
  * Parse and send chat room request
  */
 function parseChatSetup() {
-	this.title = this.ui.find('input[name=title]').val();
-	this.limit = parseInt(this.ui.find('select[name=limit]').val(), 10);
-	this.type = parseInt(this.ui.find('input[name=public]:checked').val(), 10);
-	this.password = this.ui.find('input[name=password]').val();
+	const root = this._shadow || this._host;
+
+	this.title = root.querySelector('input[name=title]').value;
+	this.limit = parseInt(root.querySelector('select[name=limit]').value, 10);
+	this.type = parseInt(root.querySelector('input[name=public]:checked').value, 10);
+	this.password = root.querySelector('input[name=password]').value;
 
 	if (this.title.length < 1) {
 		const overlay = document.createElement('div');
@@ -192,16 +238,13 @@ function parseChatSetup() {
 		const popup = UIManager.showMessageBox(
 			DB.getMessage(13),
 			'ok',
-			function () {
+			() => {
 				document.body.removeChild(overlay);
 			},
 			true
 		);
-
-		popup.ui.css({
-			top: parseInt(this.ui.css('top'), 10) - 120,
-			left: parseInt(this.ui.css('left'), 10)
-		});
+		popup.ui._host.style.top = parseInt(this._host.style.top, 10) - 120;
+		popup.ui._host.style.left = parseInt(this._host.style.left, 10);
 		return;
 	}
 
@@ -214,6 +257,8 @@ function parseChatSetup() {
  */
 ChatRoomCreate.requestRoom = function requestRoom() {};
 
+ChatRoomCreate.mouseMode = GUIComponent.MouseMode.STOP;
+ChatRoomCreate.captureKeyEvents = true;
 /**
  * Create component and export it
  */

--- a/src/UI/Components/ChatRoomCreate/ChatRoomCreate.js
+++ b/src/UI/Components/ChatRoomCreate/ChatRoomCreate.js
@@ -151,13 +151,12 @@ ChatRoomCreate.hide = function hideSetup() {
  */
 ChatRoomCreate.prefill = function prefill(title, limit, type, password) {
 	const root = this._shadow || this._host;
-	root.querySelector('input[name=title]').value = title || '';
-	root.querySelector('select[name=limit]').value = limit || 20;
-
-	const radio = root.querySelector('input[name=public][value="' + (type || 1) + '"]');
+	root.querySelector('input[name=title]').value = title ?? '';
+	root.querySelector('select[name=limit]').value = limit ?? 20;
+	const radio = root.querySelector('input[name=public][value="' + (type ?? 1) + '"]');
 	if (radio) radio.checked = true;
 
-	root.querySelector('input[name=password]').value = password || '';
+	root.querySelector('input[name=password]').value = password ?? '';
 };
 
 /**
@@ -170,6 +169,10 @@ ChatRoomCreate.onKeyDown = function onKeyDown(event) {
 	const root = this._shadow || this._host;
 	const active = root.activeElement;
 
+	// Guard: don't intercept keys when hidden
+	if (this._host.style.display === 'none') {
+		return true;
+	}
 	// Input inside our shadow is focused — protect keystrokes
 	if (active && active.tagName && /input|select|textarea/i.test(active.tagName)) {
 		if (event.which === KEYS.ENTER) {
@@ -243,8 +246,8 @@ function parseChatSetup() {
 			},
 			true
 		);
-		popup.ui._host.style.top = parseInt(this._host.style.top, 10) - 120;
-		popup.ui._host.style.left = parseInt(this._host.style.left, 10);
+		popup._host.style.top = parseInt(this._host.style.top, 10) - 120 + 'px';
+		popup._host.style.left = parseInt(this._host.style.left, 10) + 'px';
 		return;
 	}
 

--- a/src/UI/Components/ChatRoomCreate/ChatRoomCreate.js
+++ b/src/UI/Components/ChatRoomCreate/ChatRoomCreate.js
@@ -183,7 +183,7 @@ ChatRoomCreate.onKeyDown = function onKeyDown(event) {
 			return false;
 		}
 		if ((event.which === KEYS.ESCAPE || event.key === 'Escape') && this._host.style.display !== 'none') {
-			this._host.style.display = 'none';
+			ChatRoomCreate.hide();
 			event.stopImmediatePropagation();
 			return false;
 		}
@@ -194,7 +194,7 @@ ChatRoomCreate.onKeyDown = function onKeyDown(event) {
 
 	// No input focused — only handle Escape
 	if ((event.which === KEYS.ESCAPE || event.key === 'Escape') && this._host.style.display !== 'none') {
-		this._host.style.display = 'none';
+		ChatRoomCreate.hide();
 		event.stopImmediatePropagation();
 		return false;
 	}

--- a/src/UI/Components/ChatRoomCreate/ChatRoomCreate.js
+++ b/src/UI/Components/ChatRoomCreate/ChatRoomCreate.js
@@ -117,6 +117,7 @@ ChatRoomCreate.onRemove = function onRemove() {
 	_preferences.y = parseInt(this._host.style.top, 10);
 	_preferences.x = parseInt(this._host.style.left, 10);
 	_preferences.save();
+	ChatRoomCreate.editMode = false;
 };
 
 /**
@@ -138,7 +139,7 @@ ChatRoomCreate.hide = function hideSetup() {
 	this._host.style.display = 'none';
 	const root = this._shadow || this._host;
 	root.querySelector('.setup').reset();
-
+	ChatRoomCreate.editMode = false;
 	_preferences.show = false;
 };
 
@@ -149,14 +150,14 @@ ChatRoomCreate.hide = function hideSetup() {
  * @param {number} type
  * @param {string} password
  */
-ChatRoomCreate.prefill = function prefill(title, limit, type, password) {
+ChatRoomCreate.prefill = function prefill(title, limit, type) {
 	const root = this._shadow || this._host;
 	root.querySelector('input[name=title]').value = title ?? '';
 	root.querySelector('select[name=limit]').value = limit ?? 20;
 	const radio = root.querySelector('input[name=public][value="' + (type ?? 1) + '"]');
 	if (radio) radio.checked = true;
 
-	root.querySelector('input[name=password]').value = password ?? '';
+	root.querySelector('input[name=password]').value = '';
 };
 
 /**
@@ -262,6 +263,8 @@ ChatRoomCreate.requestRoom = function requestRoom() {};
 
 ChatRoomCreate.mouseMode = GUIComponent.MouseMode.STOP;
 ChatRoomCreate.captureKeyEvents = true;
+ChatRoomCreate.needFocus = true;
+ChatRoomCreate.editMode = false;
 /**
  * Create component and export it
  */

--- a/src/UI/Components/EntityRoom/EntityRoom.css
+++ b/src/UI/Components/EntityRoom/EntityRoom.css
@@ -52,16 +52,19 @@
 	margin-bottom: -3px;
 }
 
-.EntityRoom .title {
-	overflow: hidden;
-	text-overflow: ellipsis;
+.EntityRoom .title {  
+	overflow: hidden;  
+	text-overflow: ellipsis;  
+	white-space: nowrap;  
+	min-width: 0;
+	flex: 1;
 }
 
 .EntityRoom .overlay {
+	display: none;
 	position: absolute;
 	top: 0;
 	left: 26px;
-	display: none;
 	z-index: 900;
 	padding: 5px;
 	background-color: rgba(0, 0, 0, 0.6);
@@ -69,9 +72,4 @@
 	text-shadow: 1px 1px black;
 	border: 1px solid #5a5a5a;
 	white-space: nowrap;
-}
-
-.EntityRoom button:hover .overlay {
-	display: block;
-	border-radius: 3px;
 }

--- a/src/UI/Components/EntityRoom/EntityRoom.css
+++ b/src/UI/Components/EntityRoom/EntityRoom.css
@@ -1,3 +1,8 @@
+:host {
+	width: 140px;
+	height: 26px;
+}
+
 .EntityRoom {
 	box-sizing: border-box;
 	position: absolute;

--- a/src/UI/Components/EntityRoom/EntityRoom.js
+++ b/src/UI/Components/EntityRoom/EntityRoom.js
@@ -41,6 +41,15 @@ EntityRoom.onAppend = function onAppend() {
 	const root = this._shadow || this._host;
 	const btn = root.querySelector('button');
 
+	if (btn) {
+		if (this._dblclickHandler) {
+			btn.removeEventListener('dblclick', this._dblclickHandler);
+		}
+		if (this._mousedownHandler) {
+			btn.removeEventListener('mousedown', this._mousedownHandler);
+		}
+	}
+
 	// Save reference for cleanup on onRemove
 	this._dblclickHandler = () => {
 		if (this.onEnter) {
@@ -48,12 +57,14 @@ EntityRoom.onAppend = function onAppend() {
 		}
 	};
 
+	this._mousedownHandler = e => {
+		e.stopImmediatePropagation();
+		e.preventDefault();
+	};
+
 	if (btn) {
 		btn.addEventListener('dblclick', this._dblclickHandler);
-		btn.addEventListener('mousedown', e => {
-			e.stopImmediatePropagation();
-			e.preventDefault();
-		});
+		btn.addEventListener('mousedown', this._mousedownHandler);
 	}
 
 	this._host.style.zIndex = '45';
@@ -67,9 +78,15 @@ EntityRoom.onRemove = function onRemove() {
 	const btn = root.querySelector('button');
 
 	// Remove the handler to avoid stacking when re-append
-	if (btn && this._dblclickHandler) {
-		btn.removeEventListener('dblclick', this._dblclickHandler);
-		this._dblclickHandler = null;
+	if (btn) {
+		if (this._dblclickHandler) {
+			btn.removeEventListener('dblclick', this._dblclickHandler);
+			this._dblclickHandler = null;
+		}
+		if (this._mousedownHandler) {
+			btn.removeEventListener('mousedown', this._mousedownHandler);
+			this._mousedownHandler = null;
+		}
 	}
 };
 

--- a/src/UI/Components/EntityRoom/EntityRoom.js
+++ b/src/UI/Components/EntityRoom/EntityRoom.js
@@ -5,18 +5,23 @@
  *
  * This file is part of ROBrowser, (http://www.robrowser.com/).
  *
- * @author Vincent Thibault
+ * @author Vincent Thibault, AoShinHo
  */
 
 import UIManager from 'UI/UIManager.js';
-import UIComponent from 'UI/UIComponent.js';
+import GUIComponent from 'UI/GUIComponent.js';
 import htmlText from './EntityRoom.html?raw';
 import cssText from './EntityRoom.css?raw';
 
 /**
- * Createcomponent
+ * Create component
  */
-const EntityRoom = new UIComponent('EntityRoom', htmlText, cssText);
+const EntityRoom = new GUIComponent('EntityRoom', cssText);
+
+/**
+ * Render HTML
+ */
+EntityRoom.render = () => htmlText;
 
 /**
  * @var {boolean} do not focus this UI
@@ -24,30 +29,43 @@ const EntityRoom = new UIComponent('EntityRoom', htmlText, cssText);
 EntityRoom.needFocus = false;
 
 /**
- * Once in HTML, focus the input
+ * Initialize events
+ */
+EntityRoom.init = function init() {};
+
+/**
+ * Once in HTML
  */
 EntityRoom.onAppend = function onAppend() {
-	this.ui.find('button').dblclick(
-		function () {
-			if (this.onEnter) {
-				this.onEnter();
-			}
-		}.bind(this)
-	);
+	const root = this._shadow || this._host;
+	const btn = root.querySelector('button');
 
-	// Avoid player to move to the cell
-	this.ui.mousedown(function () {
-		return false;
-	});
+	// Save reference for cleanup on onRemove
+	this._dblclickHandler = () => {
+		if (this.onEnter) {
+			this.onEnter();
+		}
+	};
 
-	this.ui.css('zIndex', 45);
+	if (btn) {
+		btn.addEventListener('dblclick', this._dblclickHandler);
+	}
+
+	this._host.style.zIndex = '45';
 };
 
 /**
  * Remove data from UI
  */
 EntityRoom.onRemove = function onRemove() {
-	this.ui.find('button').unbind();
+	const root = this._shadow || this._host;
+	const btn = root.querySelector('button');
+
+	// Remove the handler to avoid stacking when re-append
+	if (btn && this._dblclickHandler) {
+		btn.removeEventListener('dblclick', this._dblclickHandler);
+		this._dblclickHandler = null;
+	}
 };
 
 /**
@@ -57,14 +75,19 @@ EntityRoom.onRemove = function onRemove() {
  * @param {string} url - icon url
  */
 EntityRoom.setTitle = function setTitle(title, url) {
-	this.ui.find('button img').attr('src', url);
-	this.ui.find('.title, .overlay').text(title);
+	const root = this._shadow || this._host;
+	root.querySelector('button img').src = url;
+	root.querySelectorAll('.title, .overlay').forEach(el => {
+		el.textContent = title;
+	});
 };
 
 /**
- * function to define
+ * function to be hooked
  */
 EntityRoom.onEnter = function onEnter() {};
+
+EntityRoom.mouseMode = GUIComponent.MouseMode.STOP;
 
 /**
  * Stored component and return it

--- a/src/UI/Components/EntityRoom/EntityRoom.js
+++ b/src/UI/Components/EntityRoom/EntityRoom.js
@@ -37,6 +37,7 @@ EntityRoom.init = function init() {};
  * Once in HTML
  */
 EntityRoom.onAppend = function onAppend() {
+	// event listeners registered here because src/Renderer/Entity/EntityRoom.js:99 overrides init (this.node = EntityRoom.clone('EntityRoom', true); this.node.init = init;)
 	const root = this._shadow || this._host;
 	const btn = root.querySelector('button');
 

--- a/src/UI/Components/EntityRoom/EntityRoom.js
+++ b/src/UI/Components/EntityRoom/EntityRoom.js
@@ -98,10 +98,32 @@ EntityRoom.onRemove = function onRemove() {
  */
 EntityRoom.setTitle = function setTitle(title, url) {
 	const root = this._shadow || this._host;
-	root.querySelector('button img').src = url;
-	root.querySelectorAll('.title, .overlay').forEach(el => {
-		el.textContent = title;
-	});
+	const imgEl = root.querySelector('button img');
+	const titleEl = root.querySelector('.title');
+	const overlayEl = root.querySelector('.overlay');
+
+	imgEl.src = url;
+	titleEl.textContent = title;
+	overlayEl.textContent = title;
+
+	// Remove old listeners (setTitle can be called multiple times on clones)
+	if (this._hoverEnter) {
+		titleEl.removeEventListener('mouseenter', this._hoverEnter);
+		titleEl.removeEventListener('mouseleave', this._hoverLeave);
+	}
+
+	// Only show overlay when text is truncated (ellipsis)
+	this._hoverEnter = () => {
+		if (titleEl.scrollWidth > titleEl.clientWidth) {
+			overlayEl.style.display = 'block';
+		}
+	};
+	this._hoverLeave = () => {
+		overlayEl.style.display = 'none';
+	};
+
+	titleEl.addEventListener('mouseenter', this._hoverEnter);
+	titleEl.addEventListener('mouseleave', this._hoverLeave);
 };
 
 /**

--- a/src/UI/Components/EntityRoom/EntityRoom.js
+++ b/src/UI/Components/EntityRoom/EntityRoom.js
@@ -49,6 +49,9 @@ EntityRoom.onAppend = function onAppend() {
 
 	if (btn) {
 		btn.addEventListener('dblclick', this._dblclickHandler);
+		btn.addEventListener('mousedown', e => {
+			e.preventDefault();
+		});
 	}
 
 	this._host.style.zIndex = '45';

--- a/src/UI/Components/EntityRoom/EntityRoom.js
+++ b/src/UI/Components/EntityRoom/EntityRoom.js
@@ -51,6 +51,7 @@ EntityRoom.onAppend = function onAppend() {
 	if (btn) {
 		btn.addEventListener('dblclick', this._dblclickHandler);
 		btn.addEventListener('mousedown', e => {
+			e.stopImmediatePropagation();
 			e.preventDefault();
 		});
 	}

--- a/src/UI/Components/EntitySignboard/EntitySignboard.css
+++ b/src/UI/Components/EntitySignboard/EntitySignboard.css
@@ -1,3 +1,10 @@
+:host {
+	width: 161px;
+	height: 30px;
+	top: 0;
+	left: 0;
+}
+
 .EntitySignboard {
 	position: absolute;
 	z-index: 45;
@@ -32,14 +39,12 @@
 }
 
 .EntitySignboard button .title {
-	display: none;
 	position: relative;
 	left: 30px;
 	width: 122px;
 	color: white;
 	overflow: hidden;
 	text-overflow: ellipsis;
-	overflow: hidden;
 	white-space: nowrap;
 	display: inline-block;
 	max-width: 100%;
@@ -52,7 +57,6 @@
 	position: absolute;
 	top: 0px;
 	left: 26px;
-	display: none;
 	white-space: nowrap;
 	z-index: 900;
 	height: 13px;
@@ -60,8 +64,4 @@
 	background-color: rgba(0, 0, 0, 0.6);
 	color: white;
 	text-shadow: 1px 1px black;
-}
-
-.EntitySignboard button:hover .overlay {
-	display: block;
 }

--- a/src/UI/Components/EntitySignboard/EntitySignboard.js
+++ b/src/UI/Components/EntitySignboard/EntitySignboard.js
@@ -102,16 +102,22 @@ EntitySignboard.setTitle = function setTitle(title, icon_location) {
 	overlayEl.textContent = title;
 	titleEl.style.display = 'inline-block';
 
+	// Remove old listeners (setTitle can be called multiple times on clones)
+	if (this._hoverEnter) {
+		titleEl.removeEventListener('mouseenter', this._hoverEnter);
+		titleEl.removeEventListener('mouseleave', this._hoverLeave);
+	}
 	// Show overlay only when text is truncated
-	titleEl.addEventListener('mouseenter', () => {
+	this._hoverEnter = () => {
 		if (titleEl.scrollWidth > titleEl.clientWidth) {
 			overlayEl.style.display = 'block';
 		}
-	});
-
-	titleEl.addEventListener('mouseleave', () => {
+	};
+	this._hoverLeave = () => {
 		overlayEl.style.display = 'none';
-	});
+	};
+	titleEl.addEventListener('mouseenter', this._hoverEnter);
+	titleEl.addEventListener('mouseleave', this._hoverLeave);
 
 	// Load icon
 	Client.loadFile(icon_location, url => {

--- a/src/UI/Components/EntitySignboard/EntitySignboard.js
+++ b/src/UI/Components/EntitySignboard/EntitySignboard.js
@@ -9,15 +9,18 @@
  */
 
 import UIManager from 'UI/UIManager.js';
-import UIComponent from 'UI/UIComponent.js';
+import GUIComponent from 'UI/GUIComponent.js';
+import Client from 'Core/Client.js';
+import DB from 'DB/DBManager.js';
 import htmlText from './EntitySignboard.html?raw';
 import cssText from './EntitySignboard.css?raw';
-import Client from 'Core/Client.js';
 
 /**
- * Createcomponent
+ * Create component
  */
-const EntitySignboard = new UIComponent('EntitySignboard', htmlText, cssText);
+const EntitySignboard = new GUIComponent('EntitySignboard', cssText);
+
+EntitySignboard.render = () => htmlText;
 
 /**
  * @var {boolean} do not focus this UI
@@ -25,78 +28,111 @@ const EntitySignboard = new UIComponent('EntitySignboard', htmlText, cssText);
 EntitySignboard.needFocus = false;
 
 /**
- * Once in HTML, focus the input
+ * Once in HTML
  */
 EntitySignboard.onAppend = function onAppend() {
-	this.ui.find('button').dblclick(
-		function () {
-			if (this.onEnter) {
-				this.onEnter();
-			}
-		}.bind(this)
-	);
+	const root = this._shadow || this._host;
+	const btn = root.querySelector('button');
 
-	// Avoid player to move to the cell
-	this.ui.mousedown(function () {
-		return false;
-	});
+	if (btn) {
+		// Cleanup previous handlers (clone reuse)
+		if (this._dblclickHandler) {
+			btn.removeEventListener('dblclick', this._dblclickHandler);
+		}
+		if (this._mousedownHandler) {
+			btn.removeEventListener('mousedown', this._mousedownHandler);
+		}
+	}
 
-	this.ui.css('zIndex', 45);
+	this._dblclickHandler = () => {
+		this.onEnter();
+	};
+
+	this._mousedownHandler = e => {
+		e.stopImmediatePropagation();
+		e.preventDefault();
+	};
+
+	if (btn) {
+		btn.addEventListener('dblclick', this._dblclickHandler);
+		btn.addEventListener('mousedown', this._mousedownHandler);
+	}
+
+	this._host.style.zIndex = '45';
 };
 
 /**
  * Remove data from UI
  */
 EntitySignboard.onRemove = function onRemove() {
-	this.ui.find('button').unbind();
-	//this.ui.find('button').removeClass('icon-only');
+	const root = this._shadow || this._host;
+	const btn = root.querySelector('button');
+
+	if (btn) {
+		if (this._dblclickHandler) {
+			btn.removeEventListener('dblclick', this._dblclickHandler);
+			this._dblclickHandler = null;
+		}
+		if (this._mousedownHandler) {
+			btn.removeEventListener('mousedown', this._mousedownHandler);
+			this._mousedownHandler = null;
+		}
+	}
 };
 
 /**
  * Define title and icons
  *
  * @param {string} title
- * @param {string} url - icon url
+ * @param {string} icon_location - icon url
  */
 EntitySignboard.setTitle = function setTitle(title, icon_location) {
-	// add data-background attribute
-	this.ui.attr('data-background', 'signboard/bg_signboard.bmp');
-	this.ui.find('.title, .overlay').text(title);
-	this.ui.find('.title').show();
+	const root = this._shadow || this._host;
+	const signboard = root.querySelector('.EntitySignboard');
 
-	const self = this;
-
-	// show overlay when mouse over .title
-	this.ui.find('.title').hover(function () {
-		self.ui.find('.overlay').show();
+	// Load signboard background
+	Client.loadFile(`${DB.INTERFACE_PATH}signboard/bg_signboard.bmp`, url => {
+		signboard.style.backgroundImage = `url('${url}')`;
 	});
 
-	// hide overlay when mouse out .title
-	this.ui.find('.title').mouseout(function () {
-		self.ui.find('.overlay').hide();
+	const titleEl = root.querySelector('.title');
+	const overlayEl = root.querySelector('.overlay');
+
+	titleEl.textContent = title;
+	overlayEl.textContent = title;
+	titleEl.style.display = 'inline-block';
+
+	// Show overlay only when text is truncated
+	titleEl.addEventListener('mouseenter', () => {
+		if (titleEl.scrollWidth > titleEl.clientWidth) {
+			overlayEl.style.display = 'block';
+		}
 	});
 
-	Client.loadFile(icon_location, function (url) {
-		self.ui.find('button').css('backgroundImage', 'url(' + url + ')');
-		self.ui.each(self.parseHTML).find('*').each(self.parseHTML);
+	titleEl.addEventListener('mouseleave', () => {
+		overlayEl.style.display = 'none';
+	});
+
+	// Load icon
+	Client.loadFile(icon_location, url => {
+		root.querySelector('button').style.backgroundImage = `url('${url}')`;
 	});
 };
 
 /**
- * Define title and icons
+ * Set icon only mode (no title text)
  *
- * @param {string} title
- * @param {string} url - icon url
+ * @param {string} icon_location - icon url
  */
 EntitySignboard.setIconOnly = function setIconOnly(icon_location) {
-	this.ui.find('.title').hide();
-	this.ui.find('.overlay').hide();
-	const self = this;
-	Client.loadFile(icon_location, function (url) {
-		self.ui
-			.find('button')
-			.addClass('icon-only')
-			.css('backgroundImage', 'url(' + url + ')');
+	const root = this._shadow || this._host;
+	root.querySelector('.title').style.display = 'none';
+	root.querySelector('.overlay').style.display = 'none';
+
+	Client.loadFile(icon_location, url => {
+		const btn = root.querySelector('button');
+		btn.classList.add('icon-only');
+		btn.style.backgroundImage = `url('${url}')`;
 	});
 };
 
@@ -104,6 +140,8 @@ EntitySignboard.setIconOnly = function setIconOnly(icon_location) {
  * function to define
  */
 EntitySignboard.onEnter = function onEnter() {};
+
+EntitySignboard.mouseMode = GUIComponent.MouseMode.STOP;
 
 /**
  * Stored component and return it

--- a/src/UI/GUIComponent.js
+++ b/src/UI/GUIComponent.js
@@ -418,7 +418,8 @@ class GUIComponent {
 				event.preventDefault();
 			}
 		};
-		window.addEventListener('keydown', this._keyHandler);
+		const useCapture = !!this.captureKeyEvents;
+		window.addEventListener('keydown', this._keyHandler, useCapture);
 	}
 
 	_unbindKeyDown() {


### PR DESCRIPTION
This PR migrates the ChatRoom, ChatRoomCreate, EntityRoom and EntitySignboard UI components from jQuery-based UIComponent to native DOM-based GUIComponent (shadow DOM). It also:

- Implements previously stubbed-out engine packet functions (changeChatRoom, requestRoleChange, requestExpelMember)
- Adds a right-click context menu on chat room members (kick, transfer ownership, view equip, add friend)
- Adds ChatRoom.openRoomSettings() to edit room settings via ChatRoomCreate.prefill()
- Fixes a role-check bug (pkt.role === 1 → pkt.role === 0 for owner)
- Adds captureKeyEvents support to GUIComponent for capture-phase key handlers
- Fixes text overflow hidden in EntityRoom

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mrantares/robrowserlegacy/pull/1138" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
