### PR TITLE
Migrate ChatBoxSettings to GUIComponent

### DIFF
--- a/.github/workflows/devin_apply_label.yml
+++ b/.github/workflows/devin_apply_label.yml
@@ -3,7 +3,6 @@ on:
     workflow_run:  
         workflows: ["Devin PR Labeler - Analyze"]  
         types: [completed]  
-    workflow_dispatch:
 permissions:
     actions: read
     issues: write

--- a/.github/workflows/devin_apply_label.yml
+++ b/.github/workflows/devin_apply_label.yml
@@ -3,6 +3,7 @@ on:
     workflow_run:  
         workflows: ["Devin PR Labeler - Analyze"]  
         types: [completed]  
+    workflow_dispatch:
 permissions:
     actions: read
     issues: write

--- a/.github/workflows/devin_auto_labeler.yml
+++ b/.github/workflows/devin_auto_labeler.yml
@@ -4,6 +4,7 @@ on:
         types: [submitted]
     pull_request_review_comment:
         types: [created, edited]
+    workflow_dispatch:
 permissions:
     contents: read
 jobs:

--- a/src/UI/Components/ChatBoxSettings/ChatBoxSettings.css
+++ b/src/UI/Components/ChatBoxSettings/ChatBoxSettings.css
@@ -1,5 +1,6 @@
 :host {
 	width: 255px;
+	height: 232px;
 	top: 50%;
 	left: 50%;
 }

--- a/src/UI/Components/ChatBoxSettings/ChatBoxSettings.css
+++ b/src/UI/Components/ChatBoxSettings/ChatBoxSettings.css
@@ -8,6 +8,7 @@
 #ChatBoxSettings {
 	position: absolute;
 	width: 255px;
+	height: auto;
 }
 
 #ChatBoxSettings table {

--- a/src/UI/Components/ChatBoxSettings/ChatBoxSettings.css
+++ b/src/UI/Components/ChatBoxSettings/ChatBoxSettings.css
@@ -1,10 +1,14 @@
-#ChatBoxSettings {
-	position: absolute;
+:host {
+	width: 255px;
 	top: 50%;
 	left: 50%;
-	display: none;
+}
+
+#ChatBoxSettings {
+	position: absolute;
 	width: 255px;
 }
+
 #ChatBoxSettings table {
 	border-spacing: 0px;
 	display: inline-block;

--- a/src/UI/Components/ChatBoxSettings/ChatBoxSettings.html
+++ b/src/UI/Components/ChatBoxSettings/ChatBoxSettings.html
@@ -18,7 +18,7 @@
 		<div class="clear"></div>
 	</div>
 	<div class="panel" data-background="basic_interface/chatwin1_mid.bmp">
-		<div class="content">
+		<div class="content resize">
 			<div class="listoption">
 				<button data-id="0" data-background="basic_interface/grp_offline.bmp" data-text="1291">
 					Public Log
@@ -74,4 +74,5 @@
 			<div class="footer-opt">All on</div>
 		</div>
 	</div>
+	<button class="extend"></button>
 </div>

--- a/src/UI/Components/ChatBoxSettings/ChatBoxSettings.js
+++ b/src/UI/Components/ChatBoxSettings/ChatBoxSettings.js
@@ -4,23 +4,27 @@
  * Chat Box Settings
  *
  * This file is part of ROBrowser, (http://www.robrowser.com/).
- *
  */
 
 import DB from 'DB/DBManager.js';
 import Preferences from 'Core/Preferences.js';
-import jQuery from 'Utils/jquery.js';
 import Renderer from 'Renderer/Renderer.js';
 import Client from 'Core/Client.js';
 import Mouse from 'Controls/MouseEventHandler.js';
 import UIManager from 'UI/UIManager.js';
-import UIComponent from 'UI/UIComponent.js';
+import GUIComponent from 'UI/GUIComponent.js';
 import htmlText from './ChatBoxSettings.html?raw';
 import cssText from './ChatBoxSettings.css?raw';
+
 /**
  * Create Component
  */
-const ChatBoxSettings = new UIComponent('ChatBoxSettings', htmlText, cssText);
+const ChatBoxSettings = new GUIComponent('ChatBoxSettings', cssText);
+
+/**
+ * Render HTML
+ */
+ChatBoxSettings.render = () => htmlText;
 
 /**
  * @var {boolean} is ChatBoxSettings open ? (Temporary fix)
@@ -49,71 +53,77 @@ const _preferences = Preferences.get(
  * Initialize UI
  */
 ChatBoxSettings.init = function init() {
-	// Bindings
-	this.ui.find('.extend').mousedown(onResize);
-	this.ui.find('.close').click(function () {
-		ChatBoxSettings.ui.hide();
-	});
+	const root = this._shadow || this._host;
 
-	this.ui.find('.listoption');
+	const extendBtn = root.querySelector('.extend');
+	if (extendBtn) {
+		extendBtn.addEventListener('mousedown', onResize);
+	}
 
-	this.ui.on('click', '.content .listoption button', onClickOption);
-	this.draggable(this.ui.find('.titlebar'));
+	const closeBtn = root.querySelector('.close');
+	if (closeBtn) {
+		closeBtn.addEventListener('click', () => {
+			this._host.style.display = 'none';
+		});
+	}
+
+	// Event delegation for option buttons
+	const listOption = root.querySelector('.listoption');
+	if (listOption) {
+		listOption.addEventListener('click', event => {
+			const btn = event.target.closest('button');
+			if (btn) {
+				onClickOption(btn);
+			}
+		});
+	}
+
+	this.draggable('.titlebar');
 };
 
 /**
- * Initialize UI
+ * Once in HTML
  */
 ChatBoxSettings.onAppend = function onAppend() {
-	//resize( _preferences.width, _preferences.height );
+	const rect = this._host.getBoundingClientRect();
+	this._host.style.top = Math.min(Math.max(0, _preferences.y), Renderer.height - rect.height) + 'px';
+	this._host.style.left = Math.min(Math.max(0, _preferences.x), Renderer.width - rect.width) + 'px';
+	this._host.style.display = 'none';
 
-	this.ui.css({
-		top: Math.min(Math.max(0, _preferences.y), Renderer.height - this.ui.height()),
-		left: Math.min(Math.max(0, _preferences.x), Renderer.width - this.ui.width())
-	});
+	resize(_preferences.width, _preferences.height);
 };
 
 /**
  * Key Event Handler
- *
- * @param {object} event - KeyEventHandler
- * @return {boolean}
  */
 ChatBoxSettings.onKeyDown = function onKeyDown(event) {};
 
-function onClickOption(evt) {
-	const _elem = jQuery(evt.currentTarget);
-	const _dataId = _elem.data('id');
-	let isOn = false;
-
-	if (!_elem) {
-		return;
-	}
-
-	isOn = _elem.hasClass('on');
+/**
+ * Handle option button click
+ */
+function onClickOption(btn) {
+	const dataId = parseInt(btn.getAttribute('data-id'), 10);
+	let isOn = btn.classList.contains('on');
 
 	if (isOn) {
-		_elem.removeClass('on');
+		btn.classList.remove('on');
 		isOn = false;
 	} else {
-		_elem.addClass('on');
+		btn.classList.add('on');
 		isOn = true;
 	}
 
-	Client.loadFile(
-		DB.INTERFACE_PATH + 'basic_interface/grp_' + (isOn ? 'online' : 'offline') + '.bmp',
-		function (data) {
-			_elem.css('backgroundImage', 'url(' + data + ')');
-		}
-	);
+	Client.loadFile(DB.INTERFACE_PATH + 'basic_interface/grp_' + (isOn ? 'online' : 'offline') + '.bmp', data => {
+		btn.style.backgroundImage = 'url(' + data + ')';
+	});
 
-	if (!isNaN(_dataId)) {
-		const idsIndex = ChatBoxSettings.tabOption[ChatBoxSettings.activeTab].indexOf(_dataId);
+	if (!isNaN(dataId)) {
+		const idsIndex = ChatBoxSettings.tabOption[ChatBoxSettings.activeTab].indexOf(dataId);
 
 		if (idsIndex > -1) {
 			ChatBoxSettings.tabOption[ChatBoxSettings.activeTab].splice(idsIndex, 1);
 		} else {
-			ChatBoxSettings.tabOption[ChatBoxSettings.activeTab].push(_dataId);
+			ChatBoxSettings.tabOption[ChatBoxSettings.activeTab].push(dataId);
 		}
 	}
 }
@@ -122,9 +132,9 @@ function onClickOption(evt) {
  * Resize ChatBoxSettings
  */
 function onResize() {
-	const ui = ChatBoxSettings.ui;
-	const top = ui.position().top;
-	const left = ui.position().left;
+	const rect = ChatBoxSettings._host.getBoundingClientRect();
+	const top = rect.top;
+	const left = rect.left;
 	let lastWidth = 0;
 	let lastHeight = 0;
 
@@ -135,7 +145,6 @@ function onResize() {
 		let w = Math.floor((Mouse.screen.x - left - extraX) / 32);
 		let h = Math.floor((Mouse.screen.y - top - extraY) / 32);
 
-		// Maximum and minimum window size
 		w = Math.min(Math.max(w, 7), 14);
 		h = Math.min(Math.max(h, 3), 8);
 
@@ -148,62 +157,85 @@ function onResize() {
 		lastHeight = h;
 	}
 
-	// Start resizing
-	const _Interval = setInterval(resizeProcess, 30);
+	const interval = setInterval(resizeProcess, 30);
 
-	// Stop resizing
-	jQuery(window).one('mouseup', function (event) {
-		// Only on left click
+	const onMouseUp = event => {
 		if (event.which === 1) {
-			clearInterval(_Interval);
+			clearInterval(interval);
+			window.removeEventListener('mouseup', onMouseUp);
 		}
-	});
+	};
+	window.addEventListener('mouseup', onMouseUp);
 }
 
 ChatBoxSettings.toggle = function toggle() {
-	if (this.ui.is(':visible')) {
-		this.ui.hide();
+	if (this._host.style.display === 'none') {
+		this._host.style.display = '';
 	} else {
-		this.ui.show();
+		this._host.style.display = 'none';
 	}
 };
 
 ChatBoxSettings.updateTab = function updateTab(tabID, tabName) {
+	const root = this._shadow || this._host;
 	const optList = ChatBoxSettings.tabOption[tabID];
-	const elems = this.ui.find('.content .listoption button');
+	const buttons = root.querySelectorAll('.content .listoption button');
 
 	this.activeTab = tabID;
 
-	this.ui.find('.tabname').html(tabName);
+	root.querySelector('.tabname').textContent = tabName;
 
-	elems.removeClass('on');
-	Client.loadFile(DB.INTERFACE_PATH + 'basic_interface/grp_offline.bmp', function (data) {
-		elems.css('backgroundImage', 'url(' + data + ')');
+	buttons.forEach(btn => {
+		btn.classList.remove('on');
+		Client.loadFile(DB.INTERFACE_PATH + 'basic_interface/grp_offline.bmp', data => {
+			btn.style.backgroundImage = 'url(' + data + ')';
+		});
 	});
 
-	this.ui.find('.content .listoption button').each(function () {
-		const _elem = jQuery(this);
-		const id = _elem.data('id');
+	buttons.forEach(btn => {
+		const id = parseInt(btn.getAttribute('data-id'), 10);
 
-		if (optList.includes(id)) {
-			Client.loadFile(DB.INTERFACE_PATH + 'basic_interface/grp_online.bmp', function (data) {
-				_elem.css('backgroundImage', 'url(' + data + ')');
+		if (optList && optList.includes(id)) {
+			Client.loadFile(DB.INTERFACE_PATH + 'basic_interface/grp_online.bmp', data => {
+				btn.style.backgroundImage = 'url(' + data + ')';
 			});
-			_elem.addClass('on');
+			btn.classList.add('on');
 		}
 	});
 };
 
 /**
- * Extend inventory window size
+ * Extend window size
  */
 function resize(width, height) {
 	width = Math.min(Math.max(width, 7), 14);
 	height = Math.min(Math.max(height, 3), 8);
 
-	ChatBoxSettings.ui.css('width', 23 + 16 + 16 + width * 32);
-	ChatBoxSettings.ui.find('.resize').css('height', height * 32);
+	const root = ChatBoxSettings._shadow || ChatBoxSettings._host;
+	ChatBoxSettings._host.style.width = 23 + 16 + 16 + width * 32 + 'px';
+
+	const content = root.querySelector('.content');
+	if (content) {
+		content.style.height = height * 32 + 'px';
+	}
+
+	const list = root.querySelector('.listoption');
+	if (list) {
+		list.style.height = height * 32 - 31 + 'px';
+	}
+
+	_preferences.width = width;
+	_preferences.height = height;
+	_preferences.save();
 }
+
+ChatBoxSettings.onRemove = function onRemove() {
+	_preferences.y = parseInt(this._host.style.top, 10) || 0;
+	_preferences.x = parseInt(this._host.style.left, 10) || 0;
+	_preferences.save();
+};
+
+ChatBoxSettings.mouseMode = GUIComponent.MouseMode.STOP;
 
 /**
  * Create component and export it

--- a/src/UI/Components/ChatBoxSettings/ChatBoxSettings.js
+++ b/src/UI/Components/ChatBoxSettings/ChatBoxSettings.js
@@ -86,7 +86,7 @@ ChatBoxSettings.init = function init() {
  */
 ChatBoxSettings.onAppend = function onAppend() {
 	// Call resize first while visible so scrollHeight works and host height is updated
-	resize(_preferences.width, _preferences.height);
+	resize(_preferences.height);
 
 	const rect = this._host.getBoundingClientRect();
 	this._host.style.top = Math.min(Math.max(0, _preferences.y), Renderer.height - rect.height) + 'px';

--- a/src/UI/Components/ChatBoxSettings/ChatBoxSettings.js
+++ b/src/UI/Components/ChatBoxSettings/ChatBoxSettings.js
@@ -209,7 +209,10 @@ function resize(height) {
 	if (list) {
 		list.style.height = height * 32 - 31 + 'px';
 	}
-	ChatBoxSettings._host.style.height = ChatBoxSettings._host.scrollHeight + 'px';
+	const inner = root.querySelector('#ChatBoxSettings');
+	if (inner) {
+		ChatBoxSettings._host.style.height = inner.offsetHeight + 'px';
+	}
 	_preferences.height = height;
 	_preferences.save();
 }

--- a/src/UI/Components/ChatBoxSettings/ChatBoxSettings.js
+++ b/src/UI/Components/ChatBoxSettings/ChatBoxSettings.js
@@ -135,26 +135,16 @@ function onClickOption(btn) {
 function onResize() {
 	const rect = ChatBoxSettings._host.getBoundingClientRect();
 	const top = rect.top;
-	const left = rect.left;
-	let lastWidth = 0;
 	let lastHeight = 0;
 
 	function resizeProcess() {
-		const extraX = 23 + 16 + 16 - 30;
 		const extraY = 31 + 19 - 30;
-
-		let w = Math.floor((Mouse.screen.x - left - extraX) / 32);
 		let h = Math.floor((Mouse.screen.y - top - extraY) / 32);
-
-		w = Math.min(Math.max(w, 7), 14);
 		h = Math.min(Math.max(h, 3), 8);
-
-		if (w === lastWidth && h === lastHeight) {
+		if (h === lastHeight) {
 			return;
 		}
-
-		resize(w, h);
-		lastWidth = w;
+		resize(h);
 		lastHeight = h;
 	}
 
@@ -208,27 +198,18 @@ ChatBoxSettings.updateTab = function updateTab(tabID, tabName) {
 /**
  * Extend window size
  */
-function resize(width, height) {
-	width = Math.min(Math.max(width, 7), 14);
+function resize(height) {
 	height = Math.min(Math.max(height, 3), 8);
-
 	const root = ChatBoxSettings._shadow || ChatBoxSettings._host;
-	ChatBoxSettings._host.style.width = 23 + 16 + 16 + width * 32 + 'px';
-
 	const content = root.querySelector('.content');
 	if (content) {
 		content.style.height = height * 32 + 'px';
 	}
-
 	const list = root.querySelector('.listoption');
 	if (list) {
 		list.style.height = height * 32 - 31 + 'px';
 	}
-
-	// Update host height after content heights are set
 	ChatBoxSettings._host.style.height = ChatBoxSettings._host.scrollHeight + 'px';
-
-	_preferences.width = width;
 	_preferences.height = height;
 	_preferences.save();
 }

--- a/src/UI/Components/ChatBoxSettings/ChatBoxSettings.js
+++ b/src/UI/Components/ChatBoxSettings/ChatBoxSettings.js
@@ -85,12 +85,13 @@ ChatBoxSettings.init = function init() {
  * Once in HTML
  */
 ChatBoxSettings.onAppend = function onAppend() {
+	// Call resize first while visible so scrollHeight works and host height is updated
+	resize(_preferences.width, _preferences.height);
+
 	const rect = this._host.getBoundingClientRect();
 	this._host.style.top = Math.min(Math.max(0, _preferences.y), Renderer.height - rect.height) + 'px';
 	this._host.style.left = Math.min(Math.max(0, _preferences.x), Renderer.width - rect.width) + 'px';
 	this._host.style.display = 'none';
-
-	resize(_preferences.width, _preferences.height);
 };
 
 /**
@@ -213,7 +214,7 @@ function resize(width, height) {
 
 	const root = ChatBoxSettings._shadow || ChatBoxSettings._host;
 	ChatBoxSettings._host.style.width = 23 + 16 + 16 + width * 32 + 'px';
-	ChatBoxSettings._host.style.height = ChatBoxSettings._host.scrollHeight + 'px';
+
 	const content = root.querySelector('.content');
 	if (content) {
 		content.style.height = height * 32 + 'px';
@@ -223,6 +224,9 @@ function resize(width, height) {
 	if (list) {
 		list.style.height = height * 32 - 31 + 'px';
 	}
+
+	// Update host height after content heights are set
+	ChatBoxSettings._host.style.height = ChatBoxSettings._host.scrollHeight + 'px';
 
 	_preferences.width = width;
 	_preferences.height = height;

--- a/src/UI/Components/ChatBoxSettings/ChatBoxSettings.js
+++ b/src/UI/Components/ChatBoxSettings/ChatBoxSettings.js
@@ -213,7 +213,7 @@ function resize(width, height) {
 
 	const root = ChatBoxSettings._shadow || ChatBoxSettings._host;
 	ChatBoxSettings._host.style.width = 23 + 16 + 16 + width * 32 + 'px';
-
+	ChatBoxSettings._host.style.height = ChatBoxSettings._host.scrollHeight + 'px';
 	const content = root.querySelector('.content');
 	if (content) {
 		content.style.height = height * 32 + 'px';

--- a/src/UI/Components/ChatBoxSettings/ChatBoxSettings.js
+++ b/src/UI/Components/ChatBoxSettings/ChatBoxSettings.js
@@ -170,9 +170,9 @@ function onResize() {
 
 ChatBoxSettings.toggle = function toggle() {
 	if (this._host.style.display === 'none') {
-		this._host.style.display = '';
+		this.ui.show();
 	} else {
-		this._host.style.display = 'none';
+		this.ui.hide();
 	}
 };
 


### PR DESCRIPTION
This PR rewrites the ChatBoxSettings component to remove jQuery dependency and adopt the GUIComponent base class with Shadow DOM support.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mrantares/robrowserlegacy/pull/1241" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
