### PR TITLE
Add MemoryManager.forceClean, handle STR texture cleanup, migrate ContextMenu to GUIComponent

### DIFF
--- a/.github/workflows/devin_apply_label.yml
+++ b/.github/workflows/devin_apply_label.yml
@@ -40,7 +40,7 @@ jobs:
                         'Devin Check Passed',  
                         'Devin Check Failed - TOFIX',
                         'Devin Check - FIXED',
-                        'Devin Check Failed - WONTFIX'  
+                        'Devin Check - FLAG'  
                       ];  
                       for (const label of allDevinLabels.filter(l => l !== labelToAdd)) {  
                         try {  

--- a/.github/workflows/devin_auto_labeler.yml
+++ b/.github/workflows/devin_auto_labeler.yml
@@ -58,7 +58,7 @@ jobs:
                         const allFlags = unresolved.every(t =>
                           (t.comments.nodes[0]?.body || '').includes('🚩'));
                         labelToAdd = allFlags
-                          ? 'Devin Check Failed - WONTFIX'
+                          ? 'Devin Check - FLAG'
                           : 'Devin Check Failed - TOFIX';
                       }
                       core.info(`total=${total} resolved=${resolved} label=${labelToAdd}`);

--- a/doc/UIComponent_to_GUIComponent.md
+++ b/doc/UIComponent_to_GUIComponent.md
@@ -596,7 +596,7 @@ _bindKeyDown() {
 - `src/UI/Components/Clan/Clan.html` — HTML template using `<ui-button>`, `<ui-text>`
 - `src/UI/Components/Clan/Clan.css` — Styles with `:host` for dimensions/position
 
-> **Note**: The Clan component was the first GUIComponent migration and still uses some `this.ui` proxy calls (`this.ui.hide()`, `this.ui.show()`, `this.ui.is(':visible')`). New components should use native DOM equivalents as described in this guide.
+> **Note**: The Clan component was the first GUIComponent migration and still uses some `this.ui` proxy calls (`this.ui.hide()`, `this.ui.show()`, `this.ui.is(':visible')`). New components should use native DOM equivalents as described in this guide. But use proxy on `this.ui.hide()`, `this.ui.show()` because it calls fix overflow.
 
 ### CSS Pattern
 

--- a/src/Core/MemoryManager.js
+++ b/src/Core/MemoryManager.js
@@ -171,6 +171,36 @@ class MemoryManager {
 	};
 
 	/**
+	 * Force immediate cleanup of memory entries matching an optional regex.
+	 * Useful after bulk loading (e.g., DB.lazyInit) to free parsed file data.
+	 *
+	 * @param {object} gl - WebGL Context (can be null)
+	 * @param {RegExp} [regex] - Optional pattern to match filenames. If omitted, all complete items are removed.
+	 */
+	static forceClean = async (gl, regex) => {
+		const keys = Object.keys(_memory);
+		const removed = [];
+
+		keys.forEach(key => {
+			const item = _memory[key];
+			if (item.complete && (!regex || key.match(regex))) {
+				MemoryManager.remove(gl, key);
+				removed.push(key);
+			}
+		});
+
+		_lastCheckTick = Date.now();
+
+		if (removed.length) {
+			console.log(
+				'%c[MemoryManager] - Force cleaned ' + removed.length + ' elements from memory.',
+				'color:#d35111',
+				{ files: removed }
+			);
+		}
+	};
+
+	/**
 	 * Remove Item from memory
 	 *
 	 * @param {object} gl - WebGL Context

--- a/src/Core/MemoryManager.js
+++ b/src/Core/MemoryManager.js
@@ -189,14 +189,10 @@ class MemoryManager {
 			}
 		});
 
-		_lastCheckTick = Date.now();
-
 		if (removed.length) {
-			console.log(
-				'%c[MemoryManager] - Force cleaned ' + removed.length + ' elements from memory.',
-				'color:#d35111',
-				{ files: removed }
-			);
+			console.log('%c[MemoryManager] - Removed ' + removed.length + ' elements from memory.', 'color:#d35111', {
+				files: removed
+			});
 		}
 	};
 

--- a/src/Core/MemoryManager.js
+++ b/src/Core/MemoryManager.js
@@ -246,6 +246,25 @@ class MemoryManager {
 					}
 					break;
 
+				// Delete GPU textures from STR effects
+				case '.str':
+					if (file.layers) {
+						for (i = 0, count = file.layers.length; i < count; ++i) {
+							if (file.layers[i].materials) {
+								for (let j = 0, matCount = file.layers[i].materials.length; j < matCount; ++j) {
+									if (
+										file.layers[i].materials[j] &&
+										gl != null &&
+										gl.isTexture(file.layers[i].materials[j])
+									) {
+										gl.deleteTexture(file.layers[i].materials[j]);
+									}
+								}
+							}
+						}
+					}
+					break;
+
 				// If file is a blob, remove it (wav, mp3, lua, lub, txt, ...)
 				default:
 					if (file.match && file.match(/^blob:/)) {

--- a/src/DB/DBManager.js
+++ b/src/DB/DBManager.js
@@ -54,6 +54,7 @@ import Network from 'Network/NetworkManager.js';
 import PACKET from 'Network/PacketStructure.js';
 import PACKETVER from 'Network/PacketVerManager.js';
 import wasmUrl from 'Vendors/liblua5.1.wasm?url';
+import MemoryManager from 'Core/MemoryManager.js';
 
 //Pet
 //MapName
@@ -374,6 +375,9 @@ class DB {
 
 				if (DB.index === DB.count) {
 					DB.isLoaded = true;
+					// Force cleanup of DB file data (lua, txt, csv, bson blobs) that are no longer needed
+					// gl is null here because we may not have a WebGL context yet during lazy loading
+					MemoryManager.forceClean(null, /\.(lub|lua|txt|csv|bson|bmp)$/i);
 				}
 			};
 		}

--- a/src/DB/DBManager.js
+++ b/src/DB/DBManager.js
@@ -377,7 +377,7 @@ class DB {
 					DB.isLoaded = true;
 					// Force cleanup of DB file data (lua, txt, csv, bson blobs) that are no longer needed
 					// gl is null here because we may not have a WebGL context yet during lazy loading
-					MemoryManager.forceClean(null, /\.(lub|lua|txt|csv|bson|bmp)$/i);
+					MemoryManager.forceClean(null, /\.(lub|lua|txt|csv|bson)$/i);
 				}
 			};
 		}

--- a/src/Renderer/Renderer.js
+++ b/src/Renderer/Renderer.js
@@ -23,6 +23,7 @@ import Mouse from 'Controls/MouseEventHandler.js';
 import Camera from 'Renderer/Camera.js';
 import Session from 'Engine/SessionStorage.js';
 import PostProcess from 'Renderer/Effects/PostProcess.js';
+import MemoryManager from 'Core/MemoryManager.js';
 
 const { mat4 } = glMatrix;
 
@@ -175,6 +176,10 @@ class Renderer {
 		event.preventDefault(); // Prevent default browser behavior (which is not restoring)
 		this.contextLost = true;
 		console.warn('[Renderer] WebGL Context Lost! Pausing rendering.');
+
+		// Free cached image data — GPU textures are already gone,
+		// clean JS-side cache so assets reload fresh on context restore
+		MemoryManager.forceClean(null, /\.(bmp|jpg|png)$/i);
 
 		this.stop();
 

--- a/src/Renderer/Renderer.js
+++ b/src/Renderer/Renderer.js
@@ -179,7 +179,7 @@ class Renderer {
 
 		// Free cached image data — GPU textures are already gone,
 		// clean JS-side cache so assets reload fresh on context restore
-		MemoryManager.forceClean(null, /\.(bmp|jpg|png)$/i);
+		MemoryManager.forceClean(null, /\.(bmp|jpg|png|spr|pal|str)$/i);
 
 		this.stop();
 

--- a/src/UI/Components/ChatBox/ChatBox.js
+++ b/src/UI/Components/ChatBox/ChatBox.js
@@ -159,6 +159,7 @@ ChatBox.tabs = [];
  * Initialize UI
  */
 ChatBox.init = function init() {
+	if (!ContextMenu.__loaded) ContextMenu.prepare();
 	_heightIndex = _preferences.height - 1;
 	ChatBox.updateHeight();
 	ChatBox.applyFontScale();

--- a/src/UI/Components/ContextMenu/ContextMenu.css
+++ b/src/UI/Components/ContextMenu/ContextMenu.css
@@ -1,5 +1,4 @@
 :host {
-	position: fixed;
 	top: 0;
 	left: 0;
 	width: 100%;

--- a/src/UI/Components/ContextMenu/ContextMenu.css
+++ b/src/UI/Components/ContextMenu/ContextMenu.css
@@ -4,7 +4,6 @@
 	left: 0;
 	width: 100%;
 	height: 100%;
-	z-index: 999;
 }
 
 #ContextMenu {
@@ -13,7 +12,6 @@
 	left: 0;
 	width: 100%;
 	height: 100%;
-	z-index: 999;
 }
 
 #ContextMenu .menu {

--- a/src/UI/Components/ContextMenu/ContextMenu.css
+++ b/src/UI/Components/ContextMenu/ContextMenu.css
@@ -1,11 +1,21 @@
-#ContextMenu {
+:host {
 	position: fixed;
-	top: 0px;
-	left: 0px;
+	top: 0;
+	left: 0;
 	width: 100%;
 	height: 100%;
-	z-index: 1000;
+	z-index: 999;
 }
+
+#ContextMenu {
+	position: fixed;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+	z-index: 999;
+}
+
 #ContextMenu .menu {
 	position: absolute;
 	background-color: white;

--- a/src/UI/Components/ContextMenu/ContextMenu.js
+++ b/src/UI/Components/ContextMenu/ContextMenu.js
@@ -6,58 +6,73 @@
  * This file is part of ROBrowser, (http://www.robrowser.com/).
  */
 
-import jQuery from 'Utils/jquery.js';
 import Renderer from 'Renderer/Renderer.js';
 import Mouse from 'Controls/MouseEventHandler.js';
 import UIManager from 'UI/UIManager.js';
-import UIComponent from 'UI/UIComponent.js';
+import GUIComponent from 'UI/GUIComponent.js';
 import cssText from './ContextMenu.css?raw';
 
 /**
  * Create Component
  */
-const ContextMenu = new UIComponent('ContextMenu', '<div id="ContextMenu"><div class="menu"/></div>', cssText);
+const ContextMenu = new GUIComponent('ContextMenu', cssText);
+
+/**
+ * Render HTML
+ */
+ContextMenu.render = () => '<div id="ContextMenu"><div class="menu"></div></div>';
+
+/**
+ * @var {boolean} focus this UI
+ */
+ContextMenu.needFocus = false;
 
 /**
  * Initialize event handler
  */
 ContextMenu.init = function init() {
-	this.ui.mousedown(function () {
+	const root = this._shadow || this._host;
+
+	// Click anywhere on the overlay → close
+	root.querySelector('#ContextMenu').addEventListener('mousedown', () => {
 		ContextMenu.remove();
 	});
 
-	this.ui.find('.menu').on('mousedown', 'div', function (event) {
+	// Prevent menu item clicks from closing via overlay
+	root.querySelector('.menu').addEventListener('mousedown', event => {
 		event.stopImmediatePropagation();
-		return false;
 	});
 };
 
 /**
- * Initialize UI
+ * Position menu at mouse cursor
  */
 ContextMenu.onAppend = function onAppend() {
-	const menu = this.ui.find('.menu');
-	const width = menu.width();
-	const height = menu.height();
+	const root = this._shadow || this._host;
+	const menu = root.querySelector('.menu');
+	const width = menu.offsetWidth;
+	const height = menu.offsetHeight;
 	let x = Mouse.screen.x;
 	let y = Mouse.screen.y;
 
-	if (Mouse.screen.x + width > Renderer.width) {
-		x = Mouse.screen.x - width;
+	if (x + width > Renderer.width) {
+		x = x - width;
 	}
 
-	if (Mouse.screen.y + height > Renderer.height) {
-		y = Mouse.screen.y - height;
+	if (y + height > Renderer.height) {
+		y = y - height;
 	}
 
-	menu.css({ top: y, left: x });
+	menu.style.top = y + 'px';
+	menu.style.left = x + 'px';
 };
 
 /**
- * Clean UP UI
+ * Clean up menu contents
  */
 ContextMenu.onRemove = function onRemove() {
-	this.ui.find('.menu').empty();
+	const root = this._shadow || this._host;
+	root.querySelector('.menu').innerHTML = '';
 };
 
 /**
@@ -67,25 +82,23 @@ ContextMenu.onRemove = function onRemove() {
  * @param {function} callback once clicked
  */
 ContextMenu.addElement = function addElement(text, callback) {
-	this.ui.find('.menu').append(
-		jQuery('<div/>')
-			.text(text)
-			.click(function () {
-				ContextMenu.remove();
-				callback();
-			})
-	);
+	const root = this._shadow || this._host;
+	const item = document.createElement('div');
+	item.textContent = text;
+	item.addEventListener('click', () => {
+		ContextMenu.remove();
+		callback();
+	});
+	root.querySelector('.menu').appendChild(item);
 };
 
 /**
  * Add a delimiter to the links
  */
 ContextMenu.nextGroup = function nextGroup() {
-	this.ui.find('.menu').append('<hr/>');
+	const root = this._shadow || this._host;
+	root.querySelector('.menu').appendChild(document.createElement('hr'));
 };
-
-// Prepare the context menu to avoid problem
-ContextMenu.prepare();
 
 /**
  * Create component and export it

--- a/src/UI/Components/ContextMenu/ContextMenu.js
+++ b/src/UI/Components/ContextMenu/ContextMenu.js
@@ -25,7 +25,7 @@ ContextMenu.render = () => '<div id="ContextMenu"><div class="menu"></div></div>
 /**
  * @var {boolean} focus this UI
  */
-ContextMenu.needFocus = false;
+ContextMenu.needFocus = true;
 
 /**
  * Initialize event handler

--- a/src/UI/GUIComponent.js
+++ b/src/UI/GUIComponent.js
@@ -1227,6 +1227,33 @@ class GUIComponent {
 							el.style.display = 'none';
 						});
 						return wrapper;
+					},
+					css(prop, value) {
+						if (typeof prop === 'object') {
+							results.forEach(el => {
+								for (const [k, v] of Object.entries(prop)) {
+									el.style[k] = typeof v === 'number' ? v + 'px' : String(v);
+								}
+							});
+							return wrapper;
+						}
+						if (value === undefined) {
+							return results[0]
+								? window
+										.getComputedStyle(results[0])
+										.getPropertyValue(prop.replace(/([A-Z])/g, '-$1').toLowerCase())
+								: '';
+						}
+						results.forEach(el => {
+							el.style[prop] = typeof v === 'number' ? value + 'px' : String(value);
+						});
+						return wrapper;
+					},
+					height() {
+						return results[0] ? results[0].getBoundingClientRect().height : 0;
+					},
+					width() {
+						return results[0] ? results[0].getBoundingClientRect().width : 0;
 					}
 				};
 				return wrapper;

--- a/src/UI/GUIComponent.js
+++ b/src/UI/GUIComponent.js
@@ -1232,7 +1232,7 @@ class GUIComponent {
 						if (typeof prop === 'object') {
 							results.forEach(el => {
 								for (const [k, v] of Object.entries(prop)) {
-									el.style[k] = typeof v === 'number' ? v + 'px' : String(v);
+									el.style[k] = typeof v === 'number' && !CSS_NUMBER[k] ? v + 'px' : String(v);
 								}
 							});
 							return wrapper;
@@ -1245,7 +1245,8 @@ class GUIComponent {
 								: '';
 						}
 						results.forEach(el => {
-							el.style[prop] = typeof v === 'number' ? value + 'px' : String(value);
+							el.style[prop] =
+								typeof value === 'number' && !CSS_NUMBER[prop] ? value + 'px' : String(value);
 						});
 						return wrapper;
 					},


### PR DESCRIPTION
This PR introduces memory management improvements, proper GPU texture cleanup for STR effects, and migrates the ContextMenu component from the legacy jQuery-based `UIComponent` to the native DOM `GUIComponent`.

### Memory Management
- **`MemoryManager.forceClean(gl, regex)`** — New static method that immediately removes all completed memory entries matching an optional regex pattern, bypassing the default 30-second idle cleanup interval.
- **Post-DB cleanup** — After `DB.lazyInit()` finishes loading all database files, `forceClean` is called to free cached file data (`.lub`, `.lua`, `.txt`, `.csv`, `.bson`) that is no longer needed once parsed into JS tables.
- **Context loss cleanup** — On WebGL context loss, `forceClean` is called to purge cached image and sprite data (`.bmp`, `.jpg`, `.png`, `.spr`, `.pal`, `.str`) since all GPU texture handles become invalid. This ensures assets reload cleanly when the context is restored.
- **STR texture cleanup** — Added `case '.str'` to `MemoryManager.remove()` to properly delete GPU textures stored in `layers[i].materials[j]`. Previously, STR files fell through to the `default` case, leaking GPU texture memory.

### ContextMenu Migration
- Migrated `ContextMenu` from `UIComponent` (jQuery) to `GUIComponent` (native DOM APIs).
- Replaced jQuery selectors and methods (`this.ui.find()`, `jQuery('<div/>')`, `.css()`, `.empty()`, `.append()`) with native equivalents (`querySelector`, `createElement`, `addEventListener`, `style`, `innerHTML`).
- Added `render()` method and `:host` CSS selector for shadow DOM support.
- Removed the eager `ContextMenu.prepare()` call at module load time. Instead, added a guard in `ChatBox.init()` to ensure ContextMenu is prepared before ChatBox accesses `ContextMenu.ui`, preventing a null reference crash when the ChatBox filter/PM menu is the first ContextMenu interaction in a session.

### GUIComponent Proxy Enhancements

- Added `css()`, `height()`, and `width()` methods to the `find()` wrapper returned by the `this.ui` compatibility proxy. These are required by `ChatBox.js` which positions the ContextMenu via `ContextMenu.ui.find('.menu').css(...)`.

### Documentation

- Updated `UIComponent_to_GUIComponent.md` to clarify that `this.ui.hide()` / `this.ui.show()` proxy calls should still be used because they trigger overflow fix logic.
