### PR TITLE
fix: missing background in WinList server selection window

### DIFF
--- a/src/Engine/LoginEngine.js
+++ b/src/Engine/LoginEngine.js
@@ -33,6 +33,7 @@ import Rijndael from 'Utils/Rijndael.js';
 
 // Version Dependent UIs
 import WinLogin from 'UI/Components/WinLogin/WinLogin.js';
+import WinLoginBackground from 'UI/Components/WinLogin/WinLoginBackground.js';
 
 /**
  * Creating WinLoading
@@ -143,6 +144,7 @@ class LoginEngine {
 
 		// Hooking win_login
 		WinLogin.selectUIVersion();
+		WinLoginBackground.selectUIVersion();
 
 		WinLogin.getUI().onConnectionRequest = onConnectionRequest;
 		WinLogin.getUI().onExitRequest = onExitRequest;
@@ -385,6 +387,7 @@ function onConnectionAccepted(pkt) {
 			WinList.remove();
 			WinLogin.getUI().append();
 		};
+		WinLoginBackground.getUI().append();
 		WinList.append();
 		WinList.setList(list);
 	}

--- a/src/UI/Components/CharSelect/CharSelect/CharSelect.js
+++ b/src/UI/Components/CharSelect/CharSelect/CharSelect.js
@@ -21,6 +21,7 @@ import UIManager from 'UI/UIManager.js';
 import UIComponent from 'UI/UIComponent.js';
 import htmlText from './CharSelect.html?raw';
 import cssText from './CharSelect.css?raw';
+import WinLoginBackground from 'UI/Components/WinLogin/WinLoginBackground.js';
 
 /**
  * Create Chararacter Selection namespace
@@ -122,6 +123,10 @@ CharSelect.init = function Init() {
  * Once append to body
  */
 CharSelect.onAppend = function onAppend() {
+	if (WinLoginBackground) {
+		WinLoginBackground.getUI().append();
+	}
+
 	_index = _preferences.index;
 
 	this.ui.find('.slotinfo .number').text(_list.length + ' / ' + _maxSlots);

--- a/src/UI/Components/CharSelect/CharSelectV2/CharSelectV2.js
+++ b/src/UI/Components/CharSelect/CharSelectV2/CharSelectV2.js
@@ -22,6 +22,7 @@ import UIComponent from 'UI/UIComponent.js';
 import PACKETVER from 'Network/PacketVerManager.js';
 import htmlText from './CharSelectV2.html?raw';
 import cssText from './CharSelectV2.css?raw';
+import WinLoginBackground from 'UI/Components/WinLogin/WinLoginBackground.js';
 
 /**
  * Create Chararacter Selection namespace
@@ -125,6 +126,10 @@ CharSelectV2.init = function Init() {
  * Once append to body
  */
 CharSelectV2.onAppend = function onAppend() {
+	if (WinLoginBackground) {
+		WinLoginBackground.getUI().append();
+	}
+
 	_index = _preferences.index;
 
 	this.ui.find('.slotinfo .number').text(_list.length + ' / ' + _maxSlots);

--- a/src/UI/Components/CharSelect/CharSelectV3/CharSelectV3.js
+++ b/src/UI/Components/CharSelect/CharSelectV3/CharSelectV3.js
@@ -23,6 +23,7 @@ import UIComponent from 'UI/UIComponent.js';
 import PACKETVER from 'Network/PacketVerManager.js';
 import htmlText from './CharSelectV3.html?raw';
 import cssText from './CharSelectV3.css?raw';
+import WinLoginBackground from 'UI/Components/WinLogin/WinLoginBackground.js';
 
 /**
  * Create Chararacter Selection namespace
@@ -139,6 +140,10 @@ CharSelectV3.init = function Init() {
  * Once append to body
  */
 CharSelectV3.onAppend = function onAppend() {
+	if (WinLoginBackground) {
+		WinLoginBackground.getUI().append();
+	}
+
 	_index = _preferences.index;
 
 	this.ui.find('.slotinfo .number').text(_list.length + ' / ' + _maxSlots);

--- a/src/UI/Components/CharSelect/CharSelectV4/CharSelectV4.js
+++ b/src/UI/Components/CharSelect/CharSelectV4/CharSelectV4.js
@@ -23,9 +23,7 @@ import htmlText from './CharSelectV4.html?raw';
 import cssText from './CharSelectV4.css?raw';
 import Client from 'Core/Client.js';
 import jQuery from 'Utils/jquery.js';
-import PACKETVER from 'Network/PacketVerManager.js';
-import WinLoginV2Background from 'UI/Components/WinLogin/WinLoginV2/WinLoginV2Background.js';
-import WinLoginV3Background from 'UI/Components/WinLogin/WinLoginV3/WinLoginV3Background.js';
+import WinLoginBackground from 'UI/Components/WinLogin/WinLoginBackground.js';
 
 /**
  * Create Chararacter Selection namespace
@@ -139,10 +137,8 @@ let _bgInterval = null;
  * Once append to body
  */
 CharSelectV4.onAppend = function onAppend() {
-	if (PACKETVER.value >= 20221207) {
-		WinLoginV3Background.append();
-	} else {
-		WinLoginV2Background.append();
+	if (WinLoginBackground) {
+		WinLoginBackground.getUI().append();
 	}
 
 	//_index = _preferences.index;

--- a/src/UI/Components/WinLogin/WinLogin/WinLogin.js
+++ b/src/UI/Components/WinLogin/WinLogin/WinLogin.js
@@ -11,7 +11,6 @@
 /**
  * Dependencies
  */
-import WinLoginBackground from './WinLoginBackground.js';
 import htmlText from './WinLogin.html?raw';
 import cssText from './WinLogin.css?raw';
 import { createWinLogin } from '../WinLoginCommon.js';
@@ -19,6 +18,5 @@ import { createWinLogin } from '../WinLoginCommon.js';
 export default createWinLogin({
 	name: 'WinLogin',
 	htmlText,
-	cssText,
-	Background: WinLoginBackground
+	cssText
 });

--- a/src/UI/Components/WinLogin/WinLoginBackground.js
+++ b/src/UI/Components/WinLogin/WinLoginBackground.js
@@ -1,0 +1,29 @@
+/**
+ * UI/Components/WinLoginBackground/WinLoginBackground.js
+ *
+ * Login Background Window
+ *
+ * This file is part of ROBrowser, (http://www.robrowser.com/).
+ *
+ */
+
+import WinLoginBackground from './WinLogin/WinLoginBackground.js';
+import WinLoginBackgroundV2 from './WinLoginV2/WinLoginV2Background.js';
+import WinLoginBackgroundV3 from './WinLoginV3/WinLoginV3Background.js';
+import UIVersionManager from 'UI/UIVersionManager.js';
+
+const publicName = 'WinLoginBackground';
+
+const versionInfo = {
+	default: WinLoginBackground,
+	common: {
+		20221207: WinLoginBackgroundV3,
+		20181114: WinLoginBackgroundV2
+	},
+	re: {},
+	prere: {}
+};
+
+const Controller = UIVersionManager.getUIController(publicName, versionInfo);
+
+export default Controller;

--- a/src/UI/Components/WinLogin/WinLoginCommon.js
+++ b/src/UI/Components/WinLogin/WinLoginCommon.js
@@ -14,8 +14,9 @@ import KEYS from 'Controls/KeyEventHandler.js';
 import UIManager from 'UI/UIManager.js';
 import GUIComponent from 'UI/GUIComponent.js';
 import 'UI/Elements/Elements.js';
+import WinLoginBackground from './WinLoginBackground.js';
 
-export function createWinLogin({ name, htmlText, cssText, Background }) {
+export function createWinLogin({ name, htmlText, cssText }) {
 	const Component = new GUIComponent(name, cssText);
 	Component.render = () => htmlText;
 	Component.needFocus = false;
@@ -57,11 +58,10 @@ export function createWinLogin({ name, htmlText, cssText, Background }) {
 		root.querySelector('.signup').addEventListener('click', signup);
 		root.querySelector('.connect').addEventListener('click', connect);
 		root.querySelector('.exit').addEventListener('click', exit);
-		if (Background) Background.init();
 	};
 
 	Component.onAppend = function onAppend() {
-		if (Background) Background.append();
+		WinLoginBackground.getUI().append();
 
 		_inputUsername.value = _preferences.saveID ? _preferences.ID : '';
 		_inputPassword.value = '';

--- a/src/UI/Components/WinLogin/WinLoginV2/WinLoginV2.js
+++ b/src/UI/Components/WinLogin/WinLoginV2/WinLoginV2.js
@@ -13,12 +13,10 @@
  */
 import htmlText from './WinLoginV2.html?raw';
 import cssText from './WinLoginV2.css?raw';
-import WinLoginV2Background from './WinLoginV2Background.js';
 import { createWinLogin } from '../WinLoginCommon.js';
 
 export default createWinLogin({
 	name: 'WinLoginV2',
 	htmlText,
-	cssText,
-	Background: WinLoginV2Background
+	cssText
 });

--- a/src/UI/Components/WinLogin/WinLoginV3/WinLoginV3.js
+++ b/src/UI/Components/WinLogin/WinLoginV3/WinLoginV3.js
@@ -1,11 +1,9 @@
 import htmlText from '../WinLoginV2/WinLoginV2.html?raw';
 import cssText from '../WinLoginV2/WinLoginV2.css?raw';
-import WinLoginV3Background from './WinLoginV3Background.js';
 import { createWinLogin } from '../WinLoginCommon.js';
 
 export default createWinLogin({
 	name: 'WinLoginV3',
 	htmlText,
-	cssText,
-	Background: WinLoginV3Background
+	cssText
 });


### PR DESCRIPTION
This PR refactors how the login background component is selected and instantiated. Previously, each WinLogin variant (V1, V2, V3) imported and passed its own Background component, and CharSelectV4 had manual PACKETVER-based branching. Now:
- A new centralized controller WinLoginBackground.js is introduced, using UIVersionManager to resolve the correct background by packet version.
- The Background parameter is removed from createWinLogin()—WinLoginCommon calls WinLoginBackground.getUI().append() directly.
- LoginEngine calls WinLoginBackground.selectUIVersion() at init time.
- All CharSelect variants (V1–V4) now uniformly use WinLoginBackground.getUI().append() instead of version-specific imports.
- Server Selection screen now uses WinLoginBackground instead of blackscreen or bgi_temp

fix #1246

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mrantares/robrowserlegacy/pull/1253" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->