### PR TITLE
refactor: Add disconnect callback; handle login disconnects

### DIFF
--- a/src/Engine/LoginEngine.js
+++ b/src/Engine/LoginEngine.js
@@ -148,6 +148,14 @@ class LoginEngine {
 		WinLogin.getUI().onConnectionRequest = onConnectionRequest;
 		WinLogin.getUI().onExitRequest = onExitRequest;
 
+		// Handle unexpected disconnects during login phase
+		Network.onDisconnect = () => {
+			UIManager.showMessageBox(DB.getMessage(1), 'ok', () => {
+				UIManager.removeComponents();
+				WinLogin.getUI().append();
+			}, true);
+		};
+
 		// Autologin features
 		if (autoLogin instanceof Array && autoLogin[0] && autoLogin[1]) {
 			onConnectionRequest.apply(null, autoLogin);
@@ -215,7 +223,10 @@ function onConnectionRequest(username, password) {
 	Network.connect(_server.address, _server.port, success => {
 		// Fail to connect...
 		if (!success) {
-			UIManager.showErrorBox(DB.getMessage(1));
+			UIManager.showMessageBox(DB.getMessage(1), 'ok', () => {
+				UIManager.removeComponents();
+				WinLogin.getUI().append();
+			}, true);
 			return;
 		}
 
@@ -336,6 +347,7 @@ function onCharServerSelected(index) {
 	WinLoading.append();
 
 	Session.ServerName = _charServers[index].name; // Save server name
+	Network.onDisconnect = null; // Let CharEngine handle its own disconnects
 	CharEngine.init(_charServers[index]);
 }
 
@@ -374,6 +386,7 @@ function onConnectionAccepted(pkt) {
 	if (count === 1 && Configs.get('skipServerList')) {
 		WinLoading.append();
 		Session.ServerName = _charServers[0].name; // Save server name
+		Network.onDisconnect = null; // Let CharEngine handle its own disconnects
 		CharEngine.init(_charServers[0]);
 	}
 
@@ -544,7 +557,10 @@ function onServerClosed(pkt) {
 			break; // More than 10 connections sharing the same IP have logged into the game for an hour. (1176)
 	}
 
-	UIManager.showErrorBox(DB.getMessage(msg_id));
+	UIManager.showMessageBox(DB.getMessage(msg_id), 'ok', () => {
+		UIManager.removeComponents();
+		WinLogin.getUI().append();
+	}, true);
 	Network.close();
 }
 

--- a/src/Network/NetworkManager.js
+++ b/src/Network/NetworkManager.js
@@ -62,6 +62,12 @@ let _socket = null;
 let _save_buffer = null;
 
 /**
+ * Custom callback for disconnection
+ * @type {function}
+ */
+let _onDisconnect = null;
+
+/**
  * Defines if dump packets as hex string
  * @const {boolean}
  */
@@ -352,9 +358,13 @@ function onClose() {
 			clearInterval(_socket.ping);
 		}
 
-		import('UI/UIManager.js').then(UIManager => {
-			UIManager.default.showErrorBox('Disconnected from Server.');
-		});
+		if (_onDisconnect) {
+			_onDisconnect();
+		} else {
+			import('UI/UIManager.js').then(UIManager => {
+				UIManager.default.showErrorBox('Disconnected from Server.');
+			});
+		}
 	}
 
 	if (idx !== -1) {
@@ -370,19 +380,20 @@ function close() {
 	let idx;
 
 	if (_socket) {
-		_socket.close();
+		const s = _socket;
+		_socket = null;
 
-		if (_socket.izZone) {
+		s.close();
+
+		if (s.izZone) {
 			PacketCrypt.reset();
 		}
 
-		if (_socket.ping) {
-			clearInterval(_socket.ping);
+		if (s.ping) {
+			clearInterval(s.ping);
 		}
 
-		idx = _sockets.indexOf(_socket);
-		_socket = null;
-
+		idx = _sockets.indexOf(s);
 		if (idx !== -1) {
 			_sockets.splice(idx, 1);
 		}
@@ -476,6 +487,12 @@ const Network = (function network() {
 		hookPacket: hookPacket,
 		close: close,
 		read: read,
+		set onDisconnect(callback) {
+			_onDisconnect = callback;
+		},
+		get onDisconnect() {
+			return _onDisconnect;
+		},
 		setSocketFactory: setSocketFactory,
 		defaultSocketFactory: defaultSocketFactory,
 		registerPacket: registerPacket,


### PR DESCRIPTION
Introduce a Network.onDisconnect callback to allow custom handling of unexpected disconnects. NetworkManager now calls this callback (if set) instead of always showing the default error box, and it exposes getter/setter for onDisconnect. Also refactor close() to avoid referencing _socket after clearing it (store socket in a temporary variable) and ensure proper cleanup of ping/packet crypt and socket lists. LoginEngine registers a disconnect handler during the login flow to show a message box and restore the login UI on disconnect, replaces several showErrorBox calls with showMessageBox + UI cleanup, and clears Network.onDisconnect when handing control to CharEngine so downstream engines can manage disconnects.