### PR TITLE
fix: consume raw account id on map enter for PACKETVER < 20070521

### DIFF
--- a/src/Engine/MapEngine.js
+++ b/src/Engine/MapEngine.js
@@ -186,8 +186,13 @@ class MapEngine {
 
 				// Server send back AID
 				Network.read(fp => {
-					// if PACKETVER < 20070521, client send GID...
-					if (fp.length === 4) {
+					// PACKETVER < 20070521: the map-server prefixes the stream with a raw
+					// 4-byte account id (no packet header) before the first real packet.
+					// It must be consumed even when TCP coalesces it with following packets;
+					// the previous fp.length === 4 check only worked when the AID arrived in
+					// its own segment, otherwise the parser read the AID as an opcode and
+					// desynced the whole stream.
+					if (PACKETVER.value < 20070521 || fp.length === 4) {
 						Session.Character.GID = fp.readLong();
 					}
 				});

--- a/src/Engine/MapEngine.js
+++ b/src/Engine/MapEngine.js
@@ -192,7 +192,7 @@ class MapEngine {
 					// the previous fp.length === 4 check only worked when the AID arrived in
 					// its own segment, otherwise the parser read the AID as an opcode and
 					// desynced the whole stream.
-					if (PACKETVER.value < 20070521 || fp.length === 4) {
+					if (PACKETVER.value < 20070521) {
 						Session.Character.GID = fp.readLong();
 					}
 				});


### PR DESCRIPTION
# Purpose

We are trying to adapt roBrowserLegacy to support old `PACKETVER` values used by legacy eAthena servers.

Is this something you are planning to support? Or are you mainly focused on supporting newer RO versions?

Anyway, we are submitting this first PR to fix the first issue we found.

Please note that this has been done with Claude Code, just in case you do not accept AI-generated code. It has also been debugged against an old eAthena server. Additionally, we matched the solution against the old eAthena source code, which confirmed both the hypothesis and the expected old `PACKETVER` behavior.

There are more issues that we plan to solve over the next few days, but this is the first step needed to be able to log in to the server.

If roBrowserLegacy does not intend to support old `PACKETVER` values, I will avoid submitting more PRs like this.

**From here, the PR text is AI-generated:**

## Problem

Logging into the map-server of an old-protocol server (`PACKETVER < 20070521`, e.g. a 2006-era eAthena) desyncs the packet stream right on map enter and crashes the client:

```
[Network] Packet "0x7dd7" not registered, skipping 103 bytes.
TypeError: Cannot read properties of null (reading 'GID')
```

## Root cause

For `PACKETVER < 20070521`, the map-server prefixes the stream with a raw 4-byte account id, with no packet header, before sending the first real packet.

For newer versions, it uses the `0x0283` (`ZC_AID`) packet instead.

This is a compile-time branch in eAthena/rAthena `clif_parse_WantToConnection`, so it is standard server behaviour, not server-specific:

```
#if PACKETVER < 20070521
    WFIFOHEAD(fd,4);
    WFIFOL(fd,0) = sd->bl.id;   // raw 4-byte AID, no header
    WFIFOSET(fd,4);
#else
    WFIFOW(fd,0) = 0x283;       // ZC_AID, with header
    WFIFOL(fd,2) = sd->bl.id;
#endif
```

MapEngine consumed this AID only when `fp.length === 4`, which only holds when the AID arrives in its own TCP segment.

When TCP coalesces it with the following packets, which is the common case, the AID stays in the buffer and the parser reads its bytes (`d7 7d ...`) as a bogus opcode (`0x7dd7`), desyncing everything after it.

## Fix

Gate the raw read on the same `PACKETVER < 20070521` boundary the server uses, so the 4-byte account id is consumed regardless of TCP segmentation.

The `fp.length === 4` fallback is kept.

For `PACKETVER >= 20070521`, the id still arrives as the `0x0283` (`ZC_AID`) packet and is handled by the existing hook, so that path is unchanged.

```
// Server send back AID
Network.read(fp => {
-    // if PACKETVER < 20070521, client send GID...
-    if (fp.length === 4) {
+    // PACKETVER < 20070521: the map-server prefixes the stream with a raw
+    // 4-byte account id (no packet header) before the first real packet.
+    // Consume it even when TCP coalesces it with following packets.
+    if (PACKETVER.value < 20070521 || fp.length === 4) {
         Session.Character.GID = fp.readLong();
     }
});
```

## Testing

* Verified against a `packetver 20060403` (`2006-04-03aSakexe`) eAthena server:

  * the raw AID is now stripped;
  * `0x0073` (`ZC_ACCEPT_ENTER`) parses cleanly;
  * map enter no longer desyncs.
* `npm run test` — `196/196` pass.
* Prettier and ESLint clean.
