### PR TITLE
fix: correct typo preventing PacketCrypt.reset() on connection close

### DIFF
--- a/src/Network/NetworkManager.js
+++ b/src/Network/NetworkManager.js
@@ -389,7 +389,7 @@ function close() {
 
 		s.close();
 
-		if (s.izZone) {
+		if (s.isZone) {
 			PacketCrypt.reset();
 		}
 


### PR DESCRIPTION
## Summary

- **Fixed a typo bug** in `NetworkManager.close()` where the property `isZone` (set at line 107) was checked as `izZone` (line 392), causing the condition to always evaluate to `undefined` (falsy).
- As a result, `PacketCrypt.reset()` was **never called** during manual connection close, potentially leaking encryption state from a previous zone session into subsequent connections.

## Details

In `src/Network/NetworkManager.js`:

```js
// line 107 — property is set as `isZone`
socket.isZone = !!isZone;

// line 392 — but checked as `izZone` (typo!)
if (s.izZone) {        // always undefined → always skipped
    PacketCrypt.reset();
}
```

Since JavaScript silently returns `undefined` for non-existent properties (no compile-time or runtime error), this bug went undetected. The build passes because the project uses vanilla JS without type checking.

### Impact

`PacketCrypt.reset()` is never invoked on `close()`. In practice, `PacketCrypt.init()` is called on each new zone connection which overwrites the stale state, but the reset is still important for correctness — especially in edge cases like rapid reconnections or session transitions where `init()` might not be called immediately after `close()`.

### Fix

Changed `s.izZone` → `s.isZone` (1 character fix).

## Test plan

- [ ] Verify zone server connections still work correctly after the fix
- [ ] Verify server transitions (map change across zones) work without packet corruption
- [ ] Verify logout and re-login flow resets encryption state properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)