### PR TITLE
Fix/gm disguise monster sprite

### DIFF
--- a/src/Renderer/Entity/EntityView.js
+++ b/src/Renderer/Entity/EntityView.js
@@ -220,7 +220,11 @@ function UpdateBody(job) {
 	this.xSize = this.ySize = DB.isBaby(job) ? 4 : 5;
 
 	this.files.shadow.size = job in ShadowTable ? ShadowTable[job] : 1.0;
-	path = this.isAdmin ? DB.getAdminPath(this._sex) : DB.getBodyPath(job, this._sex);
+	// Don't force the GM/admin sprite when the entity is displaying a monster
+	// form (disguise or transformation) - otherwise a GM disguised as a monster
+	// shows the headless admin sprite instead of the monster.
+	const showAdminSprite = this.isAdmin && !shouldSuppressHead.call(this);
+	path = showAdminSprite ? DB.getAdminPath(this._sex) : DB.getBodyPath(job, this._sex);
 	const Entity = this.constructor;
 
 	// Define Object type based on its id


### PR DESCRIPTION
## Problem
A GM character (isAdmin) using `@disguise <mobid>` or `@transform <mobid>`
was being rendered as the **headless GM/admin sprite**, instead of the monster.

## Root Cause
In `EntityView.js`, `UpdateBody()` chose the body like this:
`path = this.isAdmin ? DB.getAdminPath(...) : DB.getBodyPath(job, ...)`
For a GM, `isAdmin` is always true, so it forced the admin sprite **even

when the job was a monster**. At the same time, `shouldSuppressHead()` suppressed a head (job in the monster range) — leaving the headless admin body.

## Correction
Only use the admin sprite when the entity is NOT displaying monstrous form:
`const showAdminSprite = this.isAdmin && !shouldSuppressHead.call(this);`
`shouldSuppressHead()` already covers `@disguise` (isMonster), `@transform` (hasTransformation) and worker forms.

## Impact
- GM disguised/transformed into monstrous now shows the correct sprite.

- Normal GM and non-GM rendering remain unchanged.

## Test
Logged in as GM, `@disguise 1002` → becomes the entire Poring (path resolves to `data/sprite/몬스터/poring` instead of the admin sprite).