### PR TITLE
Fix inventory storage drops

### DIFF
--- a/src/UI/Components/Inventory/InventoryV2/InventoryV2.js
+++ b/src/UI/Components/Inventory/InventoryV2/InventoryV2.js
@@ -119,7 +119,10 @@ InventoryV2.init = function Init() {
 	}
 
 	this._host.addEventListener('drop', onDrop);
-	this._host.addEventListener('dragover', e => e.stopImmediatePropagation());
+	this._host.addEventListener('dragover', e => {
+		e.stopImmediatePropagation();
+		e.preventDefault();
+	});
 
 	const content = root.querySelector('.container .content');
 	if (content) {

--- a/src/UI/Components/Inventory/InventoryV3/InventoryV3.js
+++ b/src/UI/Components/Inventory/InventoryV3/InventoryV3.js
@@ -124,7 +124,10 @@ InventoryV3.init = function Init() {
 	}
 
 	this._host.addEventListener('drop', onDrop);
-	this._host.addEventListener('dragover', e => e.stopImmediatePropagation());
+	this._host.addEventListener('dragover', e => {
+		e.stopImmediatePropagation();
+		e.preventDefault();
+	});
 
 	const content = root.querySelector('.container .content');
 	if (content) {


### PR DESCRIPTION
This fixes dragging items from the storage to the inventory for me.

Without this, my browser would show a native cursor when trying to drag from storage to inventory. But surprisingly, the other way around has always been working fine.