### PR TITLE
Fix AI skill action gate

### DIFF
--- a/src/Core/AIDriver.js
+++ b/src/Core/AIDriver.js
@@ -219,6 +219,20 @@ class AIDriver {
 				return dx * dx + dy * dy;
 			}
 
+			function canUseAISkill(entity) {
+				if (!entity || entity.action === entity.ACTION.DIE || entity.action === entity.ACTION.HURT) {
+					return false;
+				}
+
+				return [
+					entity.ACTION.IDLE,
+					entity.ACTION.WALK,
+					entity.ACTION.ATTACK,
+					entity.ACTION.ATTACK2,
+					entity.ACTION.ATTACK3
+				].some(action => action >= 0 && action === entity.action);
+			}
+
 			ctx.GetActors = function () {
 				AIDriver.exec('status = MyState', isHoAI);
 				const res = [0];
@@ -316,7 +330,7 @@ class AIDriver {
 						);
 						if (range >= dist) {
 							// check if homun is in a valid state to cast skill
-							if (homun && [0, 1, 4].includes(homun.action)) {
+							if (canUseAISkill(homun)) {
 								let pkt;
 								if (PACKETVER.value >= 20180307) {
 									pkt = new PACKET.CZ.USE_SKILL2();


### PR DESCRIPTION
Reason of this change, the homunculus states are:

  0 IDLE
  1 WALK
  2 ATTACK
  3 HURT
  4 DIE
  5 ATTACK2
  6 ATTACK3
  7 ACTION
  
 And it makes to sense to gate the skill usage on IDLE, WALK, DIE. It should be something like all except DIE.
 
 Without modifying this, Vanilmirth never uses its kills. Tested with AzzyAI and CHAI.