### PR TITLE
fix(refine-ui): continuous refine shows current level's name and rate

### DIFF
--- a/src/UI/Components/Refine/Refine.js
+++ b/src/UI/Components/Refine/Refine.js
@@ -53,6 +53,8 @@ let refine_no_bsb = 0;
 let refine_item_broken = 0;
 let refine_new_mats = 0;
 let refine_ongoing = 0;
+let refine_current_chance = 0;
+let refine_current_zeny = 0;
 let initialsuccess;
 let currentLoopHandle;
 Refine.imageLoopTimeout = 0;
@@ -251,6 +253,8 @@ function clearRefineStates() {
 	refine_no_zeny = 0;
 	refine_no_bsb = 0;
 	refine_new_mats = 0;
+	refine_current_chance = 0;
+	refine_current_zeny = 0;
 }
 
 /**
@@ -577,6 +581,10 @@ function onPopulateMaterials() {
 				Refine.ui.find('.refine_zeny').text(material.zeny);
 				Refine.ui.find('.refine_zeny_cont').text(material.zeny);
 
+				// Store fresh chance/zeny for re-apply after the result animation
+				refine_current_chance = material.chance;
+				refine_current_zeny = material.zeny;
+
 				// Set the refine_item_mat value to the selected material itemId
 				refine_item_mat = material.itemId;
 				refine_fee = material.zeny;
@@ -694,6 +702,12 @@ function selectMaterial(material, item) {
 	if (onCheckItemBroken()) {
 		refine_can_cont = 0;
 	}
+
+	// Store the fresh chance/zeny so onUpdateRefineUI can re-apply them after the
+	// result animation finishes (server resends REFINING_MATERIAL_LIST with the
+	// recalculated chance for the new refine level after every attempt).
+	refine_current_chance = material.chance;
+	refine_current_zeny = material.zeny;
 
 	Refine.ui.find('.chance_rate').text(DB.getMessage(3285).replace('%d%', material.chance));
 	Refine.ui.find('.refine_zeny_cont').text(material.zeny);
@@ -1073,6 +1087,10 @@ function onUpdateRefineUI(result) {
 	}
 
 	if (refine_can_cont && !refine_new_mats && !refine_item_broken) {
+		// Re-apply the fresh chance/zeny captured from the latest REFINING_MATERIAL_LIST
+		// so the continuous-refine view never shows the previous level's values.
+		Refine.ui.find('.chance_rate').text(DB.getMessage(3285).replace('%d%', refine_current_chance));
+		Refine.ui.find('.refine_zeny_cont').text(refine_current_zeny);
 		Refine.ui.find('.chance_rate').show();
 		Refine.ui.find('.refine_zeny_cont').show();
 	}
@@ -1090,6 +1108,16 @@ function onUpdateRefineUI(result) {
 	// Show again the hidden UIs that has been updated
 	Refine.ui.find('.back_button').show();
 	Refine.ui.find('.refine_cont').show();
+
+	// Re-read the item from inventory (already updated to the new RefiningLevel by
+	// onRefineResult) and repaint the name so the continuous-refine view shows the
+	// real +N instead of the previous iteration's value. Skip if the item broke.
+	if (!refine_item_broken) {
+		const refineditem = Inventory.getUI().getItemByIndex(refine_item_index);
+		if (refineditem) {
+			Refine.ui.find('.item_to_refine_name').text(DB.getItemName(refineditem));
+		}
+	}
 
 	// Hack: Show it here for the surprise
 	Refine.ui.find('.item_to_refine_name').show();


### PR DESCRIPTION
## Summary

During a **continuous refine** (refining again without closing the Refine window), the renewal Refine UI displayed the **previous iteration's** item name and success rate:

- The item name kept the old refine level — e.g. `Ice pick` instead of `+1 Ice pick` — even though the inventory item itself was correctly updated.
- The success rate lagged one step behind. For a level-4 weapon that can break, this means the player sees the **safer** rate of the previous level and may continue refining unaware the real chance has dropped.

## Root cause

The data was correct — it is a pure **render** bug:

- `ZC_ACK_ITEMREFINING` carries the new `RefiningLevel` and `onRefineResult` updates the inventory item correctly.
- The server (rAthena `clif_parse_refineui_refine`) resends `ZC_REFINING_MATERIAL_LIST` with the recalculated chance for the new level after every non-breaking attempt.
- But the item name is only painted in `onRefineUIUpdateMaterials`, which is gated by `Refine.hammer` and skips the repaint in the continuous-refine path; the success rate is only refreshed on material (re)selection. So both labels keep the previous iteration's value.

## Fix

`src/UI/Components/Refine/Refine.js`:

- Capture the fresh chance/zeny whenever a material is selected (`refine_current_chance` / `refine_current_zeny`).
- In `onUpdateRefineUI` (which runs **after** the result animation, when the inventory already holds the new `RefiningLevel`):
  - re-apply `refine_current_chance` / `refine_current_zeny` to `.chance_rate` / `.refine_zeny_cont` before showing them;
  - re-read the item from inventory and repaint `.item_to_refine_name` via `DB.getItemName(...)`, guarded by `!refine_item_broken` so a broken item keeps its `This item has been destroyed.` message.

The diff is scoped to a single file (+28 lines).

## Testing

Verified in-game against rAthena (RENEWAL, PACKETVER 20210406), all three result paths:

- **Success** (`+0 → +1`): name updates to `+1 ...`, rate updates.
- **Variable chance** (`+1 → +5`): rate correctly changed `100% → 60%` at the level where the server lowers the chance (previously it kept showing the old rate).
- **Break** (`+5` failed): item destroyed → `This item has been destroyed.` message preserved, name not overwritten.

`npm run lint` (0 errors) and `npm run format:check` pass.

<!-- TODO: attach before/after screenshots of the Refine window here -->
