### PR TITLE
fix(item-info): preserve line breaks in item description

### DIFF
--- a/src/UI/Components/ItemInfo/ItemInfo.css
+++ b/src/UI/Components/ItemInfo/ItemInfo.css
@@ -77,6 +77,7 @@
 }
 .ItemInfo .description .description-inner {
 	width: 150px;
+	white-space: pre-wrap;
 }
 .ItemInfo .extend {
 	position: absolute;


### PR DESCRIPTION
The item description window renders its labelled sections (Class, Effect, Duration, Level Requirement, Jobs, Weight, ...) run together on continuous lines instead of one per line.

The description text carries the section breaks as literal `\n` characters inside the colored spans, but `.description-inner` inherits the default `white-space: normal`, which collapses each `\n` to a single space. Adding `white-space: pre-wrap` preserves the line breaks while still wrapping the long descriptive sentence within the fixed width, matching the native client.

Single-line CSS change scoped to `.description-inner`; no JS touched.

Screenshot before
<img width="568" height="364" alt="ROdescriptions1" src="https://github.com/user-attachments/assets/9dcc3e99-afd9-4c53-b60a-2cf67e99ca07" />

Screenshot after
<img width="612" height="484" alt="ROdescriptions2" src="https://github.com/user-attachments/assets/9de7a362-794e-42ca-b3f6-af8033a25523" />

