### PR TITLE
fix(inventory): make the Fav tab usable (drag-to-favorite + sale-lock button)

### DIFF
--- a/src/UI/Components/Inventory/InventoryV3/InventoryV3.js
+++ b/src/UI/Components/Inventory/InventoryV3/InventoryV3.js
@@ -109,7 +109,13 @@ InventoryV3.init = function Init() {
 	const tabButtons = root.querySelectorAll('.tabs button');
 	tabButtons.forEach(btn => {
 		btn.addEventListener('mousedown', onSwitchTab);
-		btn.addEventListener('dragover', e => e.stopImmediatePropagation());
+		btn.addEventListener('dragover', e => {
+			// preventDefault is required to mark the tab as a valid drop target;
+			// without it the browser never fires the `drop` event (so dragging an
+			// item onto a tab — e.g. to favorite it — silently did nothing).
+			e.preventDefault();
+			e.stopImmediatePropagation();
+		});
 		btn.addEventListener('drop', onTabDrop);
 	});
 
@@ -185,18 +191,13 @@ InventoryV3.init = function Init() {
 		if (btn) btn.style.backgroundImage = `url(${data})`;
 	});
 
-	const lockSale = _preferences.npcsalelock
-		? root.querySelector('.deallock_on')
-		: root.querySelector('.deallock_off');
-	if (_preferences.tab !== InventoryV3.TAB.FAV) {
-		if (lockSale) lockSale.style.display = 'none';
-		const sortEl = root.querySelector('.sort');
-		if (sortEl) sortEl.style.display = 'none';
-	} else {
-		if (lockSale) lockSale.style.display = '';
-		const sortEl = root.querySelector('.sort');
-		if (sortEl) sortEl.style.display = '';
-	}
+	const dealOn = root.querySelector('.deallock_on');
+	const dealOff = root.querySelector('.deallock_off');
+	const onFavTab = _preferences.tab === InventoryV3.TAB.FAV;
+	if (dealOn) dealOn.classList.toggle('hidden', !(onFavTab && _preferences.npcsalelock));
+	if (dealOff) dealOff.classList.toggle('hidden', !(onFavTab && !_preferences.npcsalelock));
+	const sortEl = root.querySelector('.sort');
+	if (sortEl) sortEl.style.display = onFavTab ? '' : 'none';
 
 	const itemExpansion = root.querySelector('.item_expansion');
 	if (itemExpansion) itemExpansion.addEventListener('click', onInventoryExpand);
@@ -670,38 +671,18 @@ function onSwitchTab() {
 	buttons.forEach(b => b.classList.remove('selected'));
 	this.classList.add('selected');
 
-	if (_preferences.tab !== InventoryV3.TAB.FAV) {
-		const dealOn = root.querySelector('.deallock_on');
-		if (dealOn) dealOn.style.display = 'none';
-		const dealOff = root.querySelector('.deallock_off');
-		if (dealOff) dealOff.style.display = 'none';
-		const lockOverlay = root.querySelector('.lockoverlay');
-		if (lockOverlay) lockOverlay.style.display = 'none';
-		const lockMsg = root.querySelector('.lockoverlaymsg');
-		if (lockMsg) lockMsg.style.display = 'none';
-		const sort = root.querySelector('.sort');
-		if (sort) sort.style.display = 'none';
-	} else {
-		if (_preferences.npcsalelock) {
-			const dealOn = root.querySelector('.deallock_on');
-			if (dealOn) dealOn.style.display = '';
-			const lockOverlay = root.querySelector('.lockoverlay');
-			if (lockOverlay) lockOverlay.style.display = '';
-			const dealOff = root.querySelector('.deallock_off');
-			if (dealOff) dealOff.style.display = 'none';
-		} else {
-			const dealOn = root.querySelector('.deallock_on');
-			if (dealOn) dealOn.style.display = 'none';
-			const lockOverlay = root.querySelector('.lockoverlay');
-			if (lockOverlay) lockOverlay.style.display = 'none';
-			const lockMsg = root.querySelector('.lockoverlaymsg');
-			if (lockMsg) lockMsg.style.display = 'none';
-			const dealOff = root.querySelector('.deallock_off');
-			if (dealOff) dealOff.style.display = '';
-		}
-		const sort = root.querySelector('.sort');
-		if (sort) sort.style.display = '';
-	}
+	const dealOn = root.querySelector('.deallock_on');
+	const dealOff = root.querySelector('.deallock_off');
+	const lockOverlay = root.querySelector('.lockoverlay');
+	const lockMsg = root.querySelector('.lockoverlaymsg');
+	const sort = root.querySelector('.sort');
+	const onFavTab = _preferences.tab === InventoryV3.TAB.FAV;
+
+	if (dealOn) dealOn.classList.toggle('hidden', !(onFavTab && _preferences.npcsalelock));
+	if (dealOff) dealOff.classList.toggle('hidden', !(onFavTab && !_preferences.npcsalelock));
+	if (lockOverlay) lockOverlay.style.display = onFavTab && _preferences.npcsalelock ? '' : 'none';
+	if (lockMsg) lockMsg.style.display = 'none';
+	if (sort) sort.style.display = onFavTab ? '' : 'none';
 }
 
 function onToggleReduction() {
@@ -1123,29 +1104,26 @@ function onNPCLock() {
 	InventoryV3.npcsalelock = _preferences.npcsalelock;
 	const root = InventoryV3.getRoot();
 
+	const dealOn = root.querySelector('.deallock_on');
+	const dealOff = root.querySelector('.deallock_off');
+	if (dealOn) dealOn.classList.toggle('hidden', !_preferences.npcsalelock);
+	if (dealOff) dealOff.classList.toggle('hidden', _preferences.npcsalelock);
+
 	if (_preferences.npcsalelock) {
-		const dealOn = root.querySelector('.deallock_on');
-		if (dealOn) dealOn.style.display = '';
 		const lockOverlay = root.querySelector('.lockoverlay');
 		if (lockOverlay) lockOverlay.style.display = '';
 		const lockMsg = root.querySelector('.lockoverlaymsg');
 		if (lockMsg) lockMsg.style.display = '';
-		const dealOff = root.querySelector('.deallock_off');
-		if (dealOff) dealOff.style.display = 'none';
 
 		lockOverlayTimeout = setTimeout(() => {
 			const msg = root.querySelector('.lockoverlaymsg');
 			if (msg) msg.style.display = 'none';
 		}, 3000);
 	} else {
-		const dealOn = root.querySelector('.deallock_on');
-		if (dealOn) dealOn.style.display = 'none';
 		const lockOverlay = root.querySelector('.lockoverlay');
 		if (lockOverlay) lockOverlay.style.display = 'none';
 		const lockMsg = root.querySelector('.lockoverlaymsg');
 		if (lockMsg) lockMsg.style.display = 'none';
-		const dealOff = root.querySelector('.deallock_off');
-		if (dealOff) dealOff.style.display = '';
 	}
 }
 

--- a/src/UI/Components/Inventory/InventoryV3/InventoryV3.js
+++ b/src/UI/Components/Inventory/InventoryV3/InventoryV3.js
@@ -682,7 +682,7 @@ function onSwitchTab() {
 	if (dealOff) dealOff.classList.toggle('hidden', !(onFavTab && !_preferences.npcsalelock));
 	if (lockOverlay) lockOverlay.style.display = onFavTab && _preferences.npcsalelock ? '' : 'none';
 	if (lockMsg) lockMsg.style.display = 'none';
-	if (sort) sort.style.display = onFavTab ? '' : 'none';
+	if (sort) sort.classList.toggle('hidden', !onFavTab);
 }
 
 function onToggleReduction() {

--- a/src/UI/Components/Inventory/InventoryV3/InventoryV3.js
+++ b/src/UI/Components/Inventory/InventoryV3/InventoryV3.js
@@ -197,7 +197,7 @@ InventoryV3.init = function Init() {
 	if (dealOn) dealOn.classList.toggle('hidden', !(onFavTab && _preferences.npcsalelock));
 	if (dealOff) dealOff.classList.toggle('hidden', !(onFavTab && !_preferences.npcsalelock));
 	const sortEl = root.querySelector('.sort');
-	if (sortEl) sortEl.style.display = onFavTab ? '' : 'none';
+	if (sortEl) sortEl.classList.toggle('hidden', !onFavTab);
 
 	const itemExpansion = root.querySelector('.item_expansion');
 	if (itemExpansion) itemExpansion.addEventListener('click', onInventoryExpand);


### PR DESCRIPTION
Two issues made the InventoryV3 **Fav tab** non-functional. Both are reproducible on current `master`.

### 1. Dragging an item onto a tab does nothing

Favoriting an item is meant to be done by dragging it onto the **Fav** tab (this matches the native client), and the handler `onTabDrop` already exists — but it never runs.

**Root cause:** the tab `dragover` listener only calls `stopImmediatePropagation()`, never `preventDefault()`:

```js
btn.addEventListener("dragover", e => e.stopImmediatePropagation());
```

HTML5 drag-and-drop only fires a `drop` event on an element whose `dragover` handler calls `preventDefault()` (that is what marks it a valid drop target). Without it the browser cancels the drop, so `onTabDrop` is never invoked and dragging an item onto any tab silently does nothing. Dropping an item on the inventory body works because that path *does* prevent default.

**Fix:** add `e.preventDefault()` to the tab `dragover` handler (keeping the existing `stopImmediatePropagation()`).

**Repro:** open the inventory, drag any item onto the Fav tab → nothing happens. With the fix, the item is favorited.

### 2. The NPC sale-lock button never shows on the Fav tab

The Fav tab has a deal-lock (NPC-sale lock) toggle that protects favorited items from being sold to NPCs. It never appears, so the protection can't be enabled.

**Root cause:** the buttons live inside `<div class="deallock_on hidden">` / `<div class="deallock_off hidden">`, and the component CSS has `#InventoryV3 .hidden { display: none }`. The reveal paths try to show them with `element.style.display = ""`, which cannot override an ID-scoped `display: none` rule, so the wrapper stays hidden.

**Fix:** toggle the `.hidden` class (which the rule actually controls) instead of an empty inline `display`, in all three paths that touch these buttons — `init`, `onSwitchTab`, and `onNPCLock`. `onSwitchTab` is the decisive one: `init` runs once before the Fav tab is selected, so the button only becomes visible once the tab-switch handler reveals it correctly.

**Repro:** switch to the Fav tab → no sale-lock button. With the fix, the button shows and toggling it protects favorited items from the NPC sell list.

---

No new behavior or defaults changed — the sale lock remains opt-in and off by default, as before. `prettier --check` passes; ESLint reports no new problems on the changed file (`InventoryV3.js`).