### PR TITLE
fix(EntityView): coerce mount-table key to Number in UpdateBody

### DIFF
--- a/src/Renderer/Entity/EntityView.js
+++ b/src/Renderer/Entity/EntityView.js
@@ -189,7 +189,9 @@ function UpdateBody(job) {
 	for (baseJob in MountTable) {
 		if (MountTable[baseJob] === job) {
 			this.costume = job;
-			job = baseJob;
+			// `for...in` yields string keys; coerce back to Number so
+			// downstream `_job` lookups (DB.isX, ===) don't miss.
+			job = +baseJob;
 			break;
 		}
 	}
@@ -197,7 +199,7 @@ function UpdateBody(job) {
 	for (baseJob in AllMountTable) {
 		if (AllMountTable[baseJob] === job) {
 			this.costume = job;
-			job = baseJob;
+			job = +baseJob;
 			break;
 		}
 	}


### PR DESCRIPTION
## Summary
`for (baseJob in MountTable)` (and the same for `AllMountTable`) returns
string keys per JS spec, so the subsequent `job = baseJob` leaves
`this._job` as a string after any mount-sprite remap.

Most consumers tolerate this (loose `==`, object key access, or range
comparisons that coerce), but anywhere using strict `===`, `switch`, or
`Array.includes()` against a numeric job constant silently misses. The
following sites are currently bugged whenever the player rides a mount.

## Concrete bugs

### 1. 4th-class characters lose their AP indicator on any mount
`EntityLife.js:90` does
`if (DB.getJobClass(this.entity._job) === 'Fourth_Class' && ap)` to
decide whether to reserve vertical space for the AP bar. `getJobClass`
([DBManager.js](src/DB/DBManager.js)) is a `switch (job)` over numeric
constants — strict-eq fall-through for a string input → returns
undefined → AP bar height never reserved → the AP gauge clips out of
the entity life box.

This hits **every 4th class on a mount** : Dragon Knight, Imperial
Guard, Arch Mage, Cardinal, Windhawk, Meister, Shadow Cross, Biolo,
Elemental Master, Abyss Chaser, etc. (their `*_RIDING` entries are in
`AllMountTable`).

### 2. Super Novice chant cheer doesn't trigger on a Poring mount
`MapEngine.js:968` checks
`[23, 4045, 4128, 4172, 4190, 4191, 4192, 4193].includes(Session.Entity._job)`
to detect a SuperNovice for the level-up prayer mechanic (the chat-line
sequence that grants a stat bonus). After a Poring costume mount remap
(`AllMountTable[SUPERNOVICE] = PORING_SNOVICE`), `_job = "23"` and the
strict `.includes` returns false — the chant cheer never triggers, so a
mounted SN **doesn't get the stat bonus** even with the correct chat
sequence.

### 3. Wrong spirit-sphere visual for Monk / Sura on Sheep mount
`Skill.js:806` in `onSpiritSphere` does
`[15, 4016, 4038, 4070, 4077, 4106].includes(entity._job)` to pick the
Monk-family `EF_CHOOKGI2` orb effect. After a Sheep costume mount remap
(`AllMountTable[SURA] = SHEEP_SURA`, etc.), `_job` is a string, the
`includes` returns false, and spheres render with the generic
`EF_CHOOKGI` effect. Visible the entire time the player has charged
spheres — Asura prep, Tiger Cannon, Rampage Blast combos, etc.

### 4. Wrong coin visual for Gunslinger / Rebellion on Peco mount
`Skill.js:807`, same pattern as above with
`[24, 4215, 4216, 4228, 4229].includes(entity._job)` for the GS-family
`EF_CHOOKGI3` effect. `AllMountTable[GUNSLINGER] = PECO_GUNNER` and
`[REBELLION] = PECO_REBELLION` trigger the bug — coins render generic
instead of GS-specific.

## Implementation
Two-line change in `EntityView.js` UpdateBody : coerce `baseJob` to
Number with `+baseJob` before reassigning to `job`, in both the
`MountTable` and `AllMountTable` loops. After this, `_job` is
Number-typed unconditionally — callers don't need defensive coerce for
the mount-remap case.

## Test plan
- [ ] **4th class on mount** (Dragon Knight on Dragon, Imperial Guard
  on Grand Peco, etc.) with AP > 0 → AP gauge renders visible above the
  health bar.
- [ ] **SuperNovice on Poring mount** chants the level-up prayer
  sequence → stat bonus triggers.
- [ ] **Sura on Sheep mount** with charged spirit spheres → Monk
  variant `EF_CHOOKGI2` orb effect renders, not the generic
  `EF_CHOOKGI`.
- [ ] **Gunslinger on Peco mount** with charged coins → GS variant
  `EF_CHOOKGI3` renders, not the generic `EF_CHOOKGI`.
- [ ] All four scenarios non-mounted : behavior unchanged.
