### PR TITLE
feat: Render on-map 3D mobs, NPCs and guild flags as Granny3D (.gr2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
 	},
 	"dependencies": {
 		"bson": "^7.2.0",
+		"granny-ro-js": "^1.4.1",
 		"lodash-es": "^4.18.1",
 		"rijndael-js": "^2.0.0",
 		"ws": "^8.18.0"

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
 	},
 	"dependencies": {
 		"bson": "^7.2.0",
-		"granny-ro-js": "^1.4.1",
+		"granny-ro-js": "~1.5.0",
 		"lodash-es": "^4.18.1",
 		"rijndael-js": "^2.0.0",
 		"ws": "^8.18.0"

--- a/src/Loaders/GR2Loader.js
+++ b/src/Loaders/GR2Loader.js
@@ -13,18 +13,7 @@
  */
 
 import { parseTextured, parseAnimated, parseGR2File, loadGR2, extractModels, ready } from 'granny-ro-js/wasm';
-
-/**
- * Action clip indices (mirrors the client 3dmob SetAction state machine).
- * Used to graft external animation banks at their action slot.
- */
-const ACTION = {
-	stand: 0,
-	move: 1,
-	attack: 2,
-	dead: 3,
-	damage: 4
-};
+import { mul, trans, IDENTITY_ROW } from 'Renderer/GR2/gr2Math.js';
 
 /**
  * granny TRANSFORM_FLAGS bits gating which InitialPlacement components are live.
@@ -32,26 +21,6 @@ const ACTION = {
 const HAS_POSITION = 1;
 const HAS_ORIENTATION = 2;
 const HAS_SCALESHEAR = 4;
-
-const IDENTITY_ROW = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
-
-// Row-vector 4x4 multiply (D3D convention v' = v.M). granny-ro-js hands back
-// row-major matrices; the flat array goes straight to GL column-major (its transpose).
-function _mul(a, b) {
-	const o = new Array(16);
-	for (let r = 0; r < 4; r++) {
-		for (let c = 0; c < 4; c++) {
-			let s = 0;
-			for (let k = 0; k < 4; k++) {
-				s += a[r * 4 + k] * b[k * 4 + c];
-			}
-			o[r * 4 + c] = s;
-		}
-	}
-	return o;
-}
-
-const _trans = (x, y, z) => [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, x, y, z, 1];
 
 // Quaternion (x,y,z,w) to a row-vector rotation matrix (transpose of the column-vector form).
 function _quatToRow(x, y, z, w) {
@@ -121,22 +90,6 @@ class GR2Loader {
 	}
 
 	/**
-	 * Graft external animation banks into this.parsed.animations at their action slot.
-	 * bankBuffers is a map { dead: ArrayBuffer, damage: ArrayBuffer, ... }; a bank is
-	 * animation-only and joins the model skeleton by bone name at pose time (no index remap).
-	 */
-	graftBanks(bankBuffers) {
-		for (const name in bankBuffers) {
-			const slot = ACTION[name];
-			if (slot == null) {
-				continue;
-			}
-			const bank = parseAnimated(new Uint8Array(bankBuffers[name]));
-			this.parsed.animations[slot] = bank.animations[0];
-		}
-	}
-
-	/**
 	 * packModel(parsed) -> { meshes:[{ name, vcount, indices, bind, bidx, bw, uv, nrm, texFile, emblem }], boneCount }.
 	 * Per-vertex attribute arrays: bind pos(3), GLOBAL bone indices(4), normalized top-4 weights(4),
 	 * uv(2), bind normals(3). Matless proxy submeshes are dropped (the client binds no shader for them).
@@ -200,7 +153,8 @@ class GR2Loader {
 				}
 			}
 
-			const texFile = (m.materials && m.materials[0] && m.materials[0].textureFile) || '';
+			const mat0 = m.materials && m.materials[0];
+			const texFile = (mat0 && mat0.textureFile) || '';
 			return {
 				name: m.name,
 				vcount: N,
@@ -238,22 +192,22 @@ class GR2Loader {
 		let M = IDENTITY_ROW.slice();
 		if (t.flags & HAS_SCALESHEAR) {
 			const s = t.scaleShear;
-			M = _mul(M, [s[0], s[1], s[2], 0, s[3], s[4], s[5], 0, s[6], s[7], s[8], 0, 0, 0, 0, 1]);
+			M = mul(M, [s[0], s[1], s[2], 0, s[3], s[4], s[5], 0, s[6], s[7], s[8], 0, 0, 0, 0, 1]);
 		}
 		if (t.flags & HAS_ORIENTATION) {
 			const q = t.orientation;
-			M = _mul(M, _quatToRow(q[0], q[1], q[2], q[3]));
+			M = mul(M, _quatToRow(q[0], q[1], q[2], q[3]));
 		}
 		if (t.flags & HAS_POSITION) {
 			const p = t.position;
-			M = _mul(M, _trans(-p[0], -p[1], -p[2]));
+			M = mul(M, trans(-p[0], -p[1], -p[2]));
 		}
 		return M;
 	}
 
 	/**
 	 * Initialize the granny-ro-js WASM (texture pixel decode only). The geometry / skeleton /
-	 * animation decode is WASM-independent; call this before decoding textures (session 5).
+	 * animation decode is WASM-independent; call this before decoding textures.
 	 */
 	static ready() {
 		return ready();

--- a/src/Loaders/GR2Loader.js
+++ b/src/Loaders/GR2Loader.js
@@ -222,6 +222,14 @@ class GR2Loader {
 	 * ipRowFromTransform(t) -> row-vector mat4 for a granny Transform { flags, position,
 	 * orientation, scaleShear }, applying ONLY the flag-marked components (S.R.T order).
 	 * Identity when the transform is absent or flags is 0.
+	 *
+	 * POSITION is applied INVERTED (`-p`). The granny InitialPlacement records where the
+	 * model sat in its authoring scene; rendering at the actor's cell origin must UNDO that
+	 * placement, not re-apply it. A model authored off-origin (e.g. Kguardian90_7, whose mesh
+	 * lives entirely forward of origin with an IP `[0.045,-7.253,0]`) otherwise draws ~1.45
+	 * cells too far forward — verified against mars-26/data.grf: `-p` re-centers its world-Z
+	 * onto its identity-IP siblings. Orientation/scale stay as-authored (translation-free IPs
+	 * like the treasurebox Rx+90 are unaffected).
 	 */
 	static ipRowFromTransform(t) {
 		if (!t || !t.flags) {
@@ -238,7 +246,7 @@ class GR2Loader {
 		}
 		if (t.flags & HAS_POSITION) {
 			const p = t.position;
-			M = _mul(M, _trans(p[0], p[1], p[2]));
+			M = _mul(M, _trans(-p[0], -p[1], -p[2]));
 		}
 		return M;
 	}

--- a/src/Loaders/GR2Loader.js
+++ b/src/Loaders/GR2Loader.js
@@ -1,0 +1,255 @@
+/**
+ * Loaders/GR2Loader.js
+ *
+ * Decodes a Granny3D .gr2 buffer into roBrowser model structures via granny-ro-js
+ *
+ * This file is part of ROBrowser, (http://www.robrowser.com/).
+ *
+ * The legacy Loaders/GrannyModel.js hand-rolled parser is left untouched (its load()
+ * bails before decompression); the actual decode is delegated to the granny-ro-js
+ * package (Oodle0 + type-tree + skeleton + skinning + animation, verified vs granny2.dll).
+ * This loader is the thin adapter: parse the bytes, then pack the meshes into per-vertex
+ * attribute arrays and read the model InitialPlacement transform.
+ */
+
+import { parseTextured, parseAnimated, parseGR2File, loadGR2, extractModels, ready } from 'granny-ro-js/wasm';
+
+/**
+ * Action clip indices (mirrors the client 3dmob SetAction state machine).
+ * Used to graft external animation banks at their action slot.
+ */
+const ACTION = {
+	stand: 0,
+	move: 1,
+	attack: 2,
+	dead: 3,
+	damage: 4
+};
+
+/**
+ * granny TRANSFORM_FLAGS bits gating which InitialPlacement components are live.
+ */
+const HAS_POSITION = 1;
+const HAS_ORIENTATION = 2;
+const HAS_SCALESHEAR = 4;
+
+const IDENTITY_ROW = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+
+// Row-vector 4x4 multiply (D3D convention v' = v.M). granny-ro-js hands back
+// row-major matrices; the flat array goes straight to GL column-major (its transpose).
+function _mul(a, b) {
+	const o = new Array(16);
+	for (let r = 0; r < 4; r++) {
+		for (let c = 0; c < 4; c++) {
+			let s = 0;
+			for (let k = 0; k < 4; k++) {
+				s += a[r * 4 + k] * b[k * 4 + c];
+			}
+			o[r * 4 + c] = s;
+		}
+	}
+	return o;
+}
+
+const _trans = (x, y, z) => [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, x, y, z, 1];
+
+// Quaternion (x,y,z,w) to a row-vector rotation matrix (transpose of the column-vector form).
+function _quatToRow(x, y, z, w) {
+	const xx = x * x;
+	const yy = y * y;
+	const zz = z * z;
+	const xy = x * y;
+	const xz = x * z;
+	const yz = y * z;
+	const wx = w * x;
+	const wy = w * y;
+	const wz = w * z;
+	return [
+		1 - 2 * (yy + zz),
+		2 * (xy + wz),
+		2 * (xz - wy),
+		0,
+		2 * (xy - wz),
+		1 - 2 * (xx + zz),
+		2 * (yz + wx),
+		0,
+		2 * (xz + wy),
+		2 * (yz - wx),
+		1 - 2 * (xx + yy),
+		0,
+		0,
+		0,
+		0,
+		1
+	];
+}
+
+const _isEmblemMesh = name => /Plane/i.test(name);
+
+/**
+ * GR2Loader — decode a .gr2 buffer. Parse-in-constructor like Loaders/Model.js:
+ *   const model = new GR2Loader(buffer);
+ *   model.meshes / model.boneCount / model.parsed / model.ipRow
+ */
+class GR2Loader {
+	constructor(buffer) {
+		if (buffer) {
+			this.load(buffer);
+		}
+	}
+
+	/**
+	 * Parse the .gr2 bytes into { parsed, meshes, boneCount, animIndex, duration, ipRow }.
+	 * parseTextured and parseAnimated each re-parse the same bytes; we merge the animations
+	 * onto the textured model. The InitialPlacement is only reachable through the low-level
+	 * graph (the parse* wrappers do not expose the loaded object), so we re-walk for it.
+	 */
+	load(buffer) {
+		const u8 = new Uint8Array(buffer);
+		this.parsed = { ...parseTextured(u8), animations: parseAnimated(u8).animations };
+
+		const packed = GR2Loader.packModel(this.parsed);
+		this.meshes = packed.meshes;
+		this.boneCount = packed.boneCount;
+
+		this.animIndex = 0;
+		const anim = this.parsed.animations[0];
+		this.duration = anim ? anim.duration : 1;
+
+		const model = extractModels(loadGR2(parseGR2File(u8)))[0];
+		this.ipRow = model ? GR2Loader.ipRowFromTransform(model.initialPlacement) : undefined;
+	}
+
+	/**
+	 * Graft external animation banks into this.parsed.animations at their action slot.
+	 * bankBuffers is a map { dead: ArrayBuffer, damage: ArrayBuffer, ... }; a bank is
+	 * animation-only and joins the model skeleton by bone name at pose time (no index remap).
+	 */
+	graftBanks(bankBuffers) {
+		for (const name in bankBuffers) {
+			const slot = ACTION[name];
+			if (slot == null) {
+				continue;
+			}
+			const bank = parseAnimated(new Uint8Array(bankBuffers[name]));
+			this.parsed.animations[slot] = bank.animations[0];
+		}
+	}
+
+	/**
+	 * packModel(parsed) -> { meshes:[{ name, vcount, indices, bind, bidx, bw, uv, nrm, texFile, emblem }], boneCount }.
+	 * Per-vertex attribute arrays: bind pos(3), GLOBAL bone indices(4), normalized top-4 weights(4),
+	 * uv(2), bind normals(3). Matless proxy submeshes are dropped (the client binds no shader for them).
+	 */
+	static packModel(parsed) {
+		const skel = parsed.skeletons[0];
+		if (!skel) {
+			throw new Error('GR2Loader: model has no skeleton');
+		}
+
+		const bones = skel.bones;
+		const byName = {};
+		for (let i = 0; i < bones.length; i++) {
+			byName[bones[i].name] = i;
+		}
+		const boneCount = bones.length;
+
+		const textured = parsed.meshes.filter(m => m.materials && m.materials[0] && m.materials[0].textureFile);
+		const meshes = textured.map(m => {
+			const l2g = m.boneBindings.map(b => (byName[b.name] != null ? byName[b.name] : 0));
+			const N = m.vertexCount;
+			const bind = new Float32Array(N * 3);
+			const bidx = new Float32Array(N * 4);
+			const bw = new Float32Array(N * 4);
+			const uv = new Float32Array(N * 2);
+			const nrm = new Float32Array(N * 3);
+
+			for (let i = 0; i < N; i++) {
+				const p = m.positions[i];
+				bind[i * 3] = p[0];
+				bind[i * 3 + 1] = p[1];
+				bind[i * 3 + 2] = p[2];
+
+				const nn = (m.normals && m.normals[i]) || [0, 0, 1];
+				nrm[i * 3] = nn[0];
+				nrm[i * 3 + 1] = nn[1];
+				nrm[i * 3 + 2] = nn[2];
+
+				const t = m.uvs[i] || [0, 0];
+				uv[i * 2] = t[0];
+				uv[i * 2 + 1] = t[1];
+
+				const vw = m.vertexWeights[i] || [];
+				let s = 0;
+				for (let j = 0; j < 4; j++) {
+					const e = vw[j];
+					if (e) {
+						bidx[i * 4 + j] = l2g[e.boneIndex] | 0;
+						bw[i * 4 + j] = e.weight;
+						s += e.weight;
+					}
+				}
+				// Rigid vertex (no weights) binds fully to the first bound bone.
+				if (s < 1e-6) {
+					bidx[i * 4] = l2g.length ? l2g[0] | 0 : 0;
+					bw[i * 4] = 1;
+					s = 1;
+				}
+				for (let j = 0; j < 4; j++) {
+					bw[i * 4 + j] /= s;
+				}
+			}
+
+			const texFile = (m.materials && m.materials[0] && m.materials[0].textureFile) || '';
+			return {
+				name: m.name,
+				vcount: N,
+				indices: new Uint16Array(m.indices),
+				bind: bind,
+				bidx: bidx,
+				bw: bw,
+				uv: uv,
+				nrm: nrm,
+				texFile: texFile,
+				emblem: _isEmblemMesh(m.name)
+			};
+		});
+
+		return { meshes: meshes, boneCount: boneCount };
+	}
+
+	/**
+	 * ipRowFromTransform(t) -> row-vector mat4 for a granny Transform { flags, position,
+	 * orientation, scaleShear }, applying ONLY the flag-marked components (S.R.T order).
+	 * Identity when the transform is absent or flags is 0.
+	 */
+	static ipRowFromTransform(t) {
+		if (!t || !t.flags) {
+			return IDENTITY_ROW.slice();
+		}
+		let M = IDENTITY_ROW.slice();
+		if (t.flags & HAS_SCALESHEAR) {
+			const s = t.scaleShear;
+			M = _mul(M, [s[0], s[1], s[2], 0, s[3], s[4], s[5], 0, s[6], s[7], s[8], 0, 0, 0, 0, 1]);
+		}
+		if (t.flags & HAS_ORIENTATION) {
+			const q = t.orientation;
+			M = _mul(M, _quatToRow(q[0], q[1], q[2], q[3]));
+		}
+		if (t.flags & HAS_POSITION) {
+			const p = t.position;
+			M = _mul(M, _trans(p[0], p[1], p[2]));
+		}
+		return M;
+	}
+
+	/**
+	 * Initialize the granny-ro-js WASM (texture pixel decode only). The geometry / skeleton /
+	 * animation decode is WASM-independent; call this before decoding textures (session 5).
+	 */
+	static ready() {
+		return ready();
+	}
+}
+
+export default GR2Loader;

--- a/src/Loaders/GR2Loader.js
+++ b/src/Loaders/GR2Loader.js
@@ -12,7 +12,7 @@
  * attribute arrays and read the model InitialPlacement transform.
  */
 
-import { parseTextured, parseAnimated, parseGR2File, loadGR2, extractModels, ready } from 'granny-ro-js/wasm';
+import { parseAll, ready } from 'granny-ro-js/wasm';
 import { mul, trans, IDENTITY_ROW } from 'Renderer/GR2/gr2Math.js';
 
 /**
@@ -69,23 +69,24 @@ class GR2Loader {
 
 	/**
 	 * Parse the .gr2 bytes into { parsed, meshes, boneCount, animIndex, duration, ipRow }.
-	 * parseTextured and parseAnimated each re-parse the same bytes; we merge the animations
-	 * onto the textured model. The InitialPlacement is only reachable through the low-level
-	 * graph (the parse* wrappers do not expose the loaded object), so we re-walk for it.
+	 * A single parseAll decompresses the buffer once and runs every extractor on that one
+	 * graph: parsed carries the textured meshes/skeletons, the animations, and models[] —
+	 * models[0].initialPlacement is the InitialPlacement transform that grounds the actor.
 	 */
 	load(buffer) {
 		const u8 = new Uint8Array(buffer);
-		this.parsed = { ...parseTextured(u8), animations: parseAnimated(u8).animations };
+		const parsed = parseAll(u8);
+		this.parsed = parsed;
 
-		const packed = GR2Loader.packModel(this.parsed);
+		const packed = GR2Loader.packModel(parsed);
 		this.meshes = packed.meshes;
 		this.boneCount = packed.boneCount;
 
 		this.animIndex = 0;
-		const anim = this.parsed.animations[0];
+		const anim = parsed.animations[0];
 		this.duration = anim ? anim.duration : 1;
 
-		const model = extractModels(loadGR2(parseGR2File(u8)))[0];
+		const model = parsed.models[0];
 		this.ipRow = model ? GR2Loader.ipRowFromTransform(model.initialPlacement) : undefined;
 	}
 

--- a/src/Renderer/Entity/Entity.js
+++ b/src/Renderer/Entity/Entity.js
@@ -126,6 +126,11 @@ class Entity {
 		this.matrix = mat4.create();
 		this.position = vec3.create();
 
+		// GR2 3D body: resolved model path (EntityView) + the renderer instance
+		// handle (EntityRender attaches, EntityManager detaches on removal).
+		this.gr2 = null;
+		this.gr2Model = null;
+
 		// Apply mixins (adds methods from each module)
 		entityControl.call(this);
 		entityAction.call(this);

--- a/src/Renderer/Entity/Entity.js
+++ b/src/Renderer/Entity/Entity.js
@@ -127,7 +127,8 @@ class Entity {
 		this.position = vec3.create();
 
 		// GR2 3D body: resolved model path (EntityView) + the renderer instance
-		// handle (EntityRender attaches, EntityManager detaches on removal).
+		// handle (EntityRender attaches, EntityManager detaches on removal). Set
+		// here, before the mixins below run, so every mixin method sees them defined.
 		this.gr2 = null;
 		this.gr2Model = null;
 

--- a/src/Renderer/Entity/EntityRender.js
+++ b/src/Renderer/Entity/EntityRender.js
@@ -52,6 +52,16 @@ function render(modelView, projection) {
 	if (this.gr2 && !this.gr2Model) {
 		this.gr2Model = GR2ModelRenderer.attach(this);
 	}
+	// A supported model whose file 404'd or decode threw is now flagged missing: drop the (invisible)
+	// 3D path and re-resolve the body, which falls back to the Poring sprite via isMissing in
+	// UpdateBody. Runs once -- UpdateBody clears this.gr2, so the guard is false next frame.
+	if (this.gr2 && GR2ModelRenderer.isMissing(this.gr2)) {
+		if (this.gr2Model) {
+			GR2ModelRenderer.detach(this.gr2Model);
+			this.gr2Model = null;
+		}
+		this.job = this._job;
+	}
 
 	// Process action
 	this.animations.process();

--- a/src/Renderer/Entity/EntityRender.js
+++ b/src/Renderer/Entity/EntityRender.js
@@ -268,6 +268,9 @@ const renderEntity = (function renderEntityClosure() {
 		// GR2 3D body: the model is drawn by GR2ModelRenderer in the map pass. Suppress the 2D
 		// billboard body AND the shadow blob (Phase 0: no blob under a GR2). Name / lifebar /
 		// emblem overlays render in renderGUI (called separately) and are kept.
+		// Returning here also skips attachments.renderBefore() below -- intentional: the current
+		// GR2 set (guardians/emperium/flag/treasure) carries no sprite attachments. attachments.render()
+		// (the always-behind pass, called from the map-pass entry above) still runs on the parent.
 		if (this.gr2) {
 			return;
 		}

--- a/src/Renderer/Entity/EntityRender.js
+++ b/src/Renderer/Entity/EntityRender.js
@@ -19,6 +19,7 @@ import Session from 'Engine/SessionStorage.js';
 import JobId from 'DB/Jobs/JobConst.js';
 import DB from 'DB/DBManager.js';
 import GraphicsSettings from 'Preferences/Graphics.js';
+import GR2ModelRenderer from 'Renderer/GR2/GR2ModelRenderer.js';
 
 /**
  * Load dependencies
@@ -42,6 +43,16 @@ const WALK_DIST_TO_MOTION = WALK_STEP_SIZE * 0.37 * 4 * 25; // ≈ 170.2
  * @param {mat4} projection
  */
 function render(modelView, projection) {
+	// GR2 3D body: attach (or re-attach on a body change) an instance the renderer draws in
+	// the map pass. The billboard body + shadow are suppressed below while this.gr2 is set.
+	if (this.gr2Model && this.gr2Model.path !== this.gr2) {
+		GR2ModelRenderer.detach(this.gr2Model);
+		this.gr2Model = null;
+	}
+	if (this.gr2 && !this.gr2Model) {
+		this.gr2Model = GR2ModelRenderer.attach(this);
+	}
+
 	// Process action
 	this.animations.process();
 
@@ -170,6 +181,27 @@ const calculateBoundingRect = (function calculateBoundingRectClosure() {
 		const rect = entity.boundingRect;
 		const minSize = entity.objecttype === entity.constructor.TYPE_ITEM ? 30 : 60;
 
+		// GR2 3D body: renderEntity early-returns for GR2, so no sprite body accumulates a rect.
+		// Use the screen-space box the GR2 renderer projected from the model AABB this frame so the
+		// hover/click test matches the visible model instead of the tiny default sprite box.
+		const gr2Model = entity.gr2Model;
+		if (gr2Model && gr2Model.screenRect) {
+			const sr = gr2Model.screenRect;
+			rect.x1 = sr.x1;
+			rect.y1 = sr.y1;
+			rect.x2 = sr.x2;
+			rect.y2 = sr.y2;
+			if (rect.x2 - rect.x1 < minSize) {
+				rect.x1 = (rect.x1 + rect.x2) * 0.5 - minSize * 0.5;
+				rect.x2 = rect.x1 + minSize;
+			}
+			if (rect.y2 - rect.y1 < minSize) {
+				rect.y1 = (rect.y1 + rect.y2) * 0.5 - minSize * 0.5;
+				rect.y2 = rect.y1 + minSize;
+			}
+			return;
+		}
+
 		// No body ? Default picking (sprite 110 for example)
 		if (rect.x1 === Infinity || rect.x2 === -Infinity || rect.y1 === -Infinity || rect.y2 === Infinity) {
 			rect.x1 = -25;
@@ -231,6 +263,13 @@ const renderEntity = (function renderEntityClosure() {
 		// Animation change ! Get it now
 		if (animation.save && animation.delay < Date.now()) {
 			this.setAction(animation.save);
+		}
+
+		// GR2 3D body: the model is drawn by GR2ModelRenderer in the map pass. Suppress the 2D
+		// billboard body AND the shadow blob (Phase 0: no blob under a GR2). Name / lifebar /
+		// emblem overlays render in renderGUI (called separately) and are kept.
+		if (this.gr2) {
+			return;
 		}
 
 		// Avoid look up, render as IDLE all not supported frames

--- a/src/Renderer/Entity/EntityRender.js
+++ b/src/Renderer/Entity/EntityRender.js
@@ -45,6 +45,9 @@ const WALK_DIST_TO_MOTION = WALK_STEP_SIZE * 0.37 * 4 * 25; // ≈ 170.2
 function render(modelView, projection) {
 	// GR2 3D body: attach (or re-attach on a body change) an instance the renderer draws in
 	// the map pass. The billboard body + shadow are suppressed below while this.gr2 is set.
+	// `path` and `this.gr2` are both path strings; JS `!==` on strings is value equality
+	// (string interning is irrelevant), so this correctly fires only when the model file
+	// actually changed -- detach the old instance and let the block below attach the new one.
 	if (this.gr2Model && this.gr2Model.path !== this.gr2) {
 		GR2ModelRenderer.detach(this.gr2Model);
 		this.gr2Model = null;

--- a/src/Renderer/Entity/EntityView.js
+++ b/src/Renderer/Entity/EntityView.js
@@ -17,6 +17,9 @@ import EntityAction from './EntityAction.js';
 import PACKETVER from 'Network/PacketVerManager.js';
 import JobConst from 'DB/Jobs/JobConst.js';
 
+// Client directory the GR2 3D-mob models resolve against (GR2ModelRenderer fetches from here).
+const GR2_MODEL_ROOT = 'data/model/3dmob/';
+
 /**
  * Files to display a view
  *
@@ -292,7 +295,7 @@ function UpdateBody(job) {
 	// attaches an instance on this.gr2). No 2D substitute sprite -- mirror the invisible
 	// branch above: record the model path, null the body sprite, return before the load.
 	if (path === null || path.match(/\.gr2$/i)) {
-		this.gr2 = path ? 'data/model/3dmob/' + path.replace(/^.*\//, '') : null;
+		this.gr2 = path ? GR2_MODEL_ROOT + path.replace(/^.*\//, '') : null;
 		this.files.body.spr = null;
 		this.files.body.act = null;
 		return;

--- a/src/Renderer/Entity/EntityView.js
+++ b/src/Renderer/Entity/EntityView.js
@@ -309,6 +309,12 @@ function UpdateBody(job) {
 	// set is monsters/NPCs with no PC attachments. Revisit if a player-class GR2 model
 	// (e.g. a mount) is ever added.
 	if (path.match(/\.gr2$/i)) {
+		// Tripwire: the current GR2 set is monsters/NPCs, so this never fires. If a player-class
+		// GR2 (e.g. a mount) is ever added, its weapon/shield/bodypalette refresh would be silently
+		// dropped by the early return -- make that loud instead of a hard-to-trace visual gap.
+		if (this.objecttype === Entity.TYPE_PC && (this._weapon || this._shield)) {
+			console.warn('[GR2] Player-class GR2 body (' + path + '): weapon/shield/bodypalette refresh is skipped -- see UpdateBody.');
+		}
 		this.gr2 = GR2_MODEL_ROOT + path.replace(/^.*\//, '');
 		this.files.body.spr = null;
 		this.files.body.act = null;

--- a/src/Renderer/Entity/EntityView.js
+++ b/src/Renderer/Entity/EntityView.js
@@ -16,9 +16,14 @@ import AllMountTable from 'DB/Jobs/AllMountTable.js';
 import EntityAction from './EntityAction.js';
 import PACKETVER from 'Network/PacketVerManager.js';
 import JobConst from 'DB/Jobs/JobConst.js';
+import GR2ModelRenderer from 'Renderer/GR2/GR2ModelRenderer.js';
 
 // Client directory the GR2 3D-mob models resolve against (GR2ModelRenderer fetches from here).
 const GR2_MODEL_ROOT = 'data/model/3dmob/';
+
+// Stand-in when a .gr2 model is absent from the GRF: render the Poring sprite instead of nothing
+// (job 1002). Consumed only after GR2ModelRenderer.isMissing flags the path (see UpdateBody).
+const GR2_FALLBACK_JOB = 1002;
 
 /**
  * Files to display a view
@@ -229,7 +234,7 @@ function UpdateBody(job) {
 	// form (disguise or transformation) - otherwise a GM disguised as a monster
 	// shows the headless admin sprite instead of the monster.
 	const showAdminSprite = this.isAdmin && !shouldSuppressHead.call(this);
-	const path = showAdminSprite ? DB.getAdminPath(this._sex) : DB.getBodyPath(job, this._sex);
+	let path = showAdminSprite ? DB.getAdminPath(this._sex) : DB.getBodyPath(job, this._sex);
 	const Entity = this.constructor;
 
 	// Define Object type based on its id
@@ -302,25 +307,40 @@ function UpdateBody(job) {
 		return;
 	}
 
-	// GR2 3D body: rendered by GR2ModelRenderer through the Entity path (EntityRender
-	// attaches an instance on this.gr2). No 2D substitute sprite -- record the model
-	// path, null the body sprite, return before the load. Returning here also skips the
+	// GR2 3D body: a supported model is rendered by GR2ModelRenderer through the Entity path
+	// (EntityRender attaches an instance on this.gr2) -- record the model path, null the body
+	// sprite, return before the load. Unsupported or failed models fall through to a 2D Poring
+	// substitute instead (see the inner branch). The supported return also skips the
 	// bodypalette/weapon/shield refresh in the load callback below -- intentional: the GR2
 	// set is monsters/NPCs with no PC attachments. Revisit if a player-class GR2 model
 	// (e.g. a mount) is ever added.
 	if (path.match(/\.gr2$/i)) {
-		// Tripwire: the current GR2 set is monsters/NPCs, so this never fires. If a player-class
-		// GR2 (e.g. a mount) is ever added, its weapon/shield/bodypalette refresh would be silently
-		// dropped by the early return -- make that loud instead of a hard-to-trace visual gap.
-		if (this.objecttype === Entity.TYPE_PC && (this._weapon || this._shield)) {
-			console.warn('[GR2] Player-class GR2 body (' + path + '): weapon/shield/bodypalette refresh is skipped -- see UpdateBody.');
+		const gr2Path = GR2_MODEL_ROOT + path.replace(/^.*\//, '');
+		// Enter the 3D path only for the supported roster whose file/decode hasn't failed. Everything
+		// else -- an unsupported model (dragon_5, Hugeling90_6, any future .gr2: rejected synchronously
+		// by isSupported, no I/O) or a supported model that later 404'd / failed to decode (isMissing) --
+		// falls through to the 2D Poring substitute below instead of rendering an invisible actor.
+		if (GR2ModelRenderer.isSupported(gr2Path) && !GR2ModelRenderer.isMissing(gr2Path)) {
+			// Tripwire: the current GR2 set is monsters/NPCs, so this never fires. If a player-class
+			// GR2 (e.g. a mount) is ever added, its weapon/shield/bodypalette refresh would be silently
+			// dropped by the early return -- make that loud instead of a hard-to-trace visual gap.
+			if (this.objecttype === Entity.TYPE_PC && (this._weapon || this._shield)) {
+				console.warn(
+					'[GR2] Player-class GR2 body (' +
+						path +
+						'): weapon/shield/bodypalette refresh is skipped -- see UpdateBody.'
+				);
+			}
+			this.gr2 = gr2Path;
+			this.files.body.spr = null;
+			this.files.body.act = null;
+			return;
 		}
-		this.gr2 = GR2_MODEL_ROOT + path.replace(/^.*\//, '');
-		this.files.body.spr = null;
-		this.files.body.act = null;
-		return;
+		this.gr2 = null;
+		path = DB.getBodyPath(GR2_FALLBACK_JOB, this._sex);
+	} else {
+		this.gr2 = null;
 	}
-	this.gr2 = null;
 
 	// Loading
 	Client.loadFile(path + '.act');

--- a/src/Renderer/Entity/EntityView.js
+++ b/src/Renderer/Entity/EntityView.js
@@ -183,6 +183,10 @@ function UpdateBody(job) {
 	// Capture sequence number for stale callback detection
 	const transformationSeq = this._transformationSeq || 0;
 
+	// job < 0 is a "no body update" sentinel: keep the current body state untouched, including
+	// this.gr2. Intentionally not cleared here -- same as the invisible-sprite branch below
+	// (job 111/139/45), which also retains this.gr2. Only the "no body at all" path === null
+	// branch clears this.gr2, because that path means the entity genuinely has no body sprite.
 	if (job < 0) {
 		return;
 	}

--- a/src/Renderer/Entity/EntityView.js
+++ b/src/Renderer/Entity/EntityView.js
@@ -291,11 +291,25 @@ function UpdateBody(job) {
 		return;
 	}
 
+	// getBodyPath returned null -> the entity has no body sprite at all (DBManager's
+	// "Not visible sprite" list: ANOPHELES 2337, ...). Not a GR2 case -- mirror the
+	// invisible branch above and return before the load. Keeps the .gr2 branch below
+	// strictly about genuine 3D models (no null.match() fall-through).
+	if (path === null) {
+		this.gr2 = null;
+		this.files.body.spr = null;
+		this.files.body.act = null;
+		return;
+	}
+
 	// GR2 3D body: rendered by GR2ModelRenderer through the Entity path (EntityRender
-	// attaches an instance on this.gr2). No 2D substitute sprite -- mirror the invisible
-	// branch above: record the model path, null the body sprite, return before the load.
-	if (path === null || path.match(/\.gr2$/i)) {
-		this.gr2 = path ? GR2_MODEL_ROOT + path.replace(/^.*\//, '') : null;
+	// attaches an instance on this.gr2). No 2D substitute sprite -- record the model
+	// path, null the body sprite, return before the load. Returning here also skips the
+	// bodypalette/weapon/shield refresh in the load callback below -- intentional: the GR2
+	// set is monsters/NPCs with no PC attachments. Revisit if a player-class GR2 model
+	// (e.g. a mount) is ever added.
+	if (path.match(/\.gr2$/i)) {
+		this.gr2 = GR2_MODEL_ROOT + path.replace(/^.*\//, '');
 		this.files.body.spr = null;
 		this.files.body.act = null;
 		return;

--- a/src/Renderer/Entity/EntityView.js
+++ b/src/Renderer/Entity/EntityView.js
@@ -315,6 +315,8 @@ function UpdateBody(job) {
 	// set is monsters/NPCs with no PC attachments. Revisit if a player-class GR2 model
 	// (e.g. a mount) is ever added.
 	if (path.match(/\.gr2$/i)) {
+		// Re-root the model under GR2_MODEL_ROOT: DB.getBodyPath always returns a directory-qualified
+		// path (data/sprite/<...>/name.gr2), so stripping to the basename and re-prefixing is safe.
 		const gr2Path = GR2_MODEL_ROOT + path.replace(/^.*\//, '');
 		// Enter the 3D path only for the supported roster whose file/decode hasn't failed. Everything
 		// else -- an unsupported model (dragon_5, Hugeling90_6, any future .gr2: rejected synchronously

--- a/src/Renderer/Entity/EntityView.js
+++ b/src/Renderer/Entity/EntityView.js
@@ -171,7 +171,7 @@ function refreshHeadState() {
  * @param {number} job id
  */
 function UpdateBody(job) {
-	let baseJob, path;
+	let baseJob;
 	// Capture sequence number for stale callback detection
 	const transformationSeq = this._transformationSeq || 0;
 
@@ -226,7 +226,7 @@ function UpdateBody(job) {
 	// form (disguise or transformation) - otherwise a GM disguised as a monster
 	// shows the headless admin sprite instead of the monster.
 	const showAdminSprite = this.isAdmin && !shouldSuppressHead.call(this);
-	path = showAdminSprite ? DB.getAdminPath(this._sex) : DB.getBodyPath(job, this._sex);
+	const path = showAdminSprite ? DB.getAdminPath(this._sex) : DB.getBodyPath(job, this._sex);
 	const Entity = this.constructor;
 
 	// Define Object type based on its id
@@ -288,25 +288,16 @@ function UpdateBody(job) {
 		return;
 	}
 
-	// granny model not supported yet :(
-	// Display a poring instead
+	// GR2 3D body: rendered by GR2ModelRenderer through the Entity path (EntityRender
+	// attaches an instance on this.gr2). No 2D substitute sprite -- mirror the invisible
+	// branch above: record the model path, null the body sprite, return before the load.
 	if (path === null || path.match(/\.gr2$/i)) {
-		if (path.match(/aguardian90_8\.gr2$/i)) {
-			path = DB.getBodyPath(1276, this._sex);
-		} else if (path.match(/empelium90_0\.gr2$/i)) {
-			path = DB.getBodyPath(2080, this._sex);
-		} else if (path.match(/guildflag90_1\.gr2$/i)) {
-			path = DB.getBodyPath(1911, this._sex);
-		} else if (path.match(/kguardian90_7\.gr2$/i)) {
-			path = DB.getBodyPath(2691, this._sex);
-		} else if (path.match(/sguardian90_9\.gr2$/i)) {
-			path = DB.getBodyPath(1163, this._sex);
-		} else if (path.match(/treasurebox_2\.gr2$/i)) {
-			path = DB.getBodyPath(1191, this._sex);
-		} else {
-			path = DB.getBodyPath(1002, this._sex);
-		}
+		this.gr2 = path ? 'data/model/3dmob/' + path.replace(/^.*\//, '') : null;
+		this.files.body.spr = null;
+		this.files.body.act = null;
+		return;
 	}
+	this.gr2 = null;
 
 	// Loading
 	Client.loadFile(path + '.act');

--- a/src/Renderer/EntityManager.js
+++ b/src/Renderer/EntityManager.js
@@ -17,7 +17,20 @@ import KEYS from 'Controls/KeyEventHandler.js';
 import PathFinding from 'Utils/PathFinding.js';
 import GraphicsSettings from 'Preferences/Graphics.js';
 import Altitude from 'Renderer/Map/Altitude.js';
+import GR2ModelRenderer from 'Renderer/GR2/GR2ModelRenderer.js';
 const _list = [];
+
+/**
+ * Release an entity's GR2 model instance (if any) at the true-removal sites, so a
+ * removed mob leaves no ghost in the renderer's instance list. Idempotent.
+ * @param {Entity} entity
+ */
+function releaseGr2(entity) {
+	if (entity.gr2Model) {
+		GR2ModelRenderer.detach(entity.gr2Model);
+		entity.gr2Model = null;
+	}
+}
 
 // O(1) GID lookup map
 const _gidMap = new Map();
@@ -156,7 +169,10 @@ function addEntity(entity) {
  * Clean up entities from list
  */
 function free() {
-	_list.forEach(entity => entity.clean());
+	_list.forEach(entity => {
+		releaseGr2(entity);
+		entity.clean();
+	});
 
 	_list.length = 0;
 	_gidMap.clear();
@@ -183,6 +199,7 @@ function removeEntity(gid) {
 	const entity = _gidMap.get(gid);
 
 	if (entity) {
+		releaseGr2(entity);
 		entity.clean();
 		_gidMap.delete(gid);
 		const index = _list.indexOf(entity);
@@ -356,6 +373,7 @@ function render(gl, modelView, projection, fog, renderEffects) {
 				}
 
 				_gidMap.delete(_list[i].GID);
+				releaseGr2(_list[i]);
 				_list[i].clean();
 				_list.splice(i, 1);
 				i--;

--- a/src/Renderer/GR2/GR2Model.fs
+++ b/src/Renderer/GR2/GR2Model.fs
@@ -1,0 +1,43 @@
+#version 300 es
+precision highp float;
+
+in vec2 vTextureCoord;
+in float vLightWeighting;
+out vec4 fragColor;
+
+uniform sampler2D uDiffuse;
+uniform float uAlphaRef;      // client HARD alpha-test (207/255), not roBrowser's a == 0.0
+
+uniform bool uFogUse;
+uniform float uFogNear;
+uniform float uFogFar;
+uniform vec3 uFogColor;
+
+uniform vec3 uLightAmbient;
+uniform vec3 uLightDiffuse;
+uniform vec3 uLightEnv;
+
+void main(void) {
+	vec4 textureSample = texture(uDiffuse, vTextureCoord.st);
+
+	// Client hard alpha-test (fcn.005384e0.c:32-34, ALPHAREF 0xCF): discard alpha < 207/255,
+	// keep the rest OPAQUE. Clips the linear alpha ramp to a tight 1-texel edge.
+	if (textureSample.a < uAlphaRef) {
+		discard;
+	}
+
+	// Phase-0 grayscale directional light: uLightDiffuse / uLightAmbient are fed grayscale
+	// (R=G=B) so the shade is the RE directional gradient MODULATE'd with the texel.
+	vec3 color = (vLightWeighting * uLightDiffuse + uLightAmbient);
+	textureSample.rgb *= clamp(color, 0.0, 1.0);
+	textureSample.rgb *= clamp(uLightEnv, 0.0, 1.0);
+	textureSample.a = 1.0;
+
+	fragColor = textureSample;
+
+	if (uFogUse) {
+		float depth = gl_FragCoord.z / gl_FragCoord.w;
+		float fogFactor = smoothstep(uFogNear, uFogFar, depth);
+		fragColor = mix(fragColor, vec4(uFogColor, fragColor.w), fogFactor);
+	}
+}

--- a/src/Renderer/GR2/GR2Model.fs
+++ b/src/Renderer/GR2/GR2Model.fs
@@ -7,6 +7,7 @@ out vec4 fragColor;
 
 uniform sampler2D uDiffuse;
 uniform float uAlphaRef;      // client HARD alpha-test (207/255), not roBrowser's a == 0.0
+uniform float uAlpha;         // per-instance entity alpha (removal fade); 1.0 = opaque
 
 uniform bool uFogUse;
 uniform float uFogNear;
@@ -31,7 +32,9 @@ void main(void) {
 	vec3 color = (vLightWeighting * uLightDiffuse + uLightAmbient);
 	textureSample.rgb *= clamp(color, 0.0, 1.0);
 	textureSample.rgb *= clamp(uLightEnv, 0.0, 1.0);
-	textureSample.a = 1.0;
+	// Kept fragments are opaque except during a removal fade, where uAlpha ramps the FINAL alpha
+	// down (the discard above already cut the texture edge). uAlpha = 1.0 -> unchanged.
+	textureSample.a = uAlpha;
 
 	fragColor = textureSample;
 

--- a/src/Renderer/GR2/GR2Model.vs
+++ b/src/Renderer/GR2/GR2Model.vs
@@ -14,7 +14,8 @@ uniform mat4 uModelViewMat;   // Camera view * instance world
 uniform mat4 uProjectionMat;
 uniform mat3 uNormalMat;      // normal-matrix of (view * world) -> VIEW space
 
-uniform mat4 uBones[48];      // GPU skin, BONE_CAP = 48
+uniform mat4 uBones[48];      // GPU skin. MUST equal gr2Pack.js BONE_CAP (48) — GLSL can't import
+                              // it, so this literal is the hand-synced mirror; change both together.
 
 uniform vec3 uLightDirection; // scene light direction, VIEW space
 uniform float uLightOpacity;

--- a/src/Renderer/GR2/GR2Model.vs
+++ b/src/Renderer/GR2/GR2Model.vs
@@ -1,0 +1,39 @@
+#version 300 es
+precision highp float;
+
+in vec3 aPosition;
+in vec3 aNormal;
+in vec2 aTextureCoord;
+in vec4 aBoneIndex;
+in vec4 aBoneWeight;
+
+out vec2 vTextureCoord;
+out float vLightWeighting;
+
+uniform mat4 uModelViewMat;   // Camera view * instance world
+uniform mat4 uProjectionMat;
+uniform mat3 uNormalMat;      // normal-matrix of (view * world) -> VIEW space
+
+uniform mat4 uBones[48];      // GPU skin, BONE_CAP = 48
+
+uniform vec3 uLightDirection; // scene light direction, VIEW space
+uniform float uLightOpacity;
+
+void main(void) {
+	mat4 skin = aBoneWeight.x * uBones[int(aBoneIndex.x)]
+	          + aBoneWeight.y * uBones[int(aBoneIndex.y)]
+	          + aBoneWeight.z * uBones[int(aBoneIndex.z)]
+	          + aBoneWeight.w * uBones[int(aBoneIndex.w)];
+
+	vec4 skinned = skin * vec4(aPosition, 1.0);
+	gl_Position = uProjectionMat * uModelViewMat * skinned;
+
+	vTextureCoord = aTextureCoord;
+
+	// Skin the normal, then carry it to view space (uNormalMat = normal-matrix of view*world);
+	// uLightDirection is handed in already in view space, so N.L shares a frame and stays
+	// world-fixed as the orbit camera moves.
+	vec3 normal = normalize(uNormalMat * (mat3(skin) * aNormal));
+	float lightWeight = max(dot(normal, uLightDirection), 0.0);
+	vLightWeighting = (1.0 - uLightOpacity) + lightWeight * uLightOpacity;
+}

--- a/src/Renderer/GR2/GR2ModelRenderer.js
+++ b/src/Renderer/GR2/GR2ModelRenderer.js
@@ -104,13 +104,26 @@ let _instances = [];
 let _poseCache = {};
 
 // Debug aid: highlight each instance's anchor CELL with a flat tile. The tile marks the cell
-// CENTER (its shader adds +0.5); the model straddles the cell's -0.4 corner, so the offset between
-// tile and pole shows which junction the model sits on (NE/NW diagnosis). Toggle from the dev
-// console (`mod.debugCell = true`); off by default, no gameplay effect.
+// CENTER (its shader adds +0.5) — the SAME cell centre the model's origin now lands on (flagCore
+// adds RB_PLACEMENT_OFS = +0.5), so tile and pole should COINCIDE; a visible offset between them
+// means a placement regression. Toggle from the dev console (`mod.debugCell = true`); off by
+// default, no gameplay effect.
 const _dbgCellTile = FlatColorTile('gr2_debug_cell', { r: 0.0, g: 1.0, b: 1.0, a: 0.45 });
 const _dbgTileInst = new _dbgCellTile([0, 0, 0]);
 let _dbgCellInited = false;
 let _debugCell = false;
+
+// GR2 pick-box geometry — TWO modes, switched at the call site in render() by commenting (no
+// runtime flag). The client hit-tests a base bounding-SPHERE, NOT the model AABB (fcn.006852e0):
+//   sphere centre (0,0,0) = model base, radius 10.0 client-u (fcn.006800d0.c:202-206).
+//   10 client-u ÷ 5 (roBrowser /5 referential, gr2World.RB_UNIT_SCALE) = 2.0 world-u (cells).
+//   Half-extent = √(r²·0.5) — the client's projected corner offset (fcn.006852e0.c:70-71).
+// These constants feed computeBaseSphereRect (the "sphere" mode), which is the shipped DEFAULT.
+// The alternative is the full model AABB ("tout le drapeau" — whole model hoverable, more generous
+// than the client), switched in at the pick site by commenting.
+// VISUAL-UNVERIFIED: the world-unit radius is a single-constant calibration point (visual gate).
+const BASE_SPHERE_RADIUS = 2.0;
+const BASE_SPHERE_HALF_EXTENT = Math.sqrt(BASE_SPHERE_RADIUS * BASE_SPHERE_RADIUS * 0.5);
 
 // granny-ro-js WASM init (texture pixel decode); shared across all types.
 let _readyPromise = null;
@@ -478,7 +491,11 @@ function computeLocalAABB(meshes) {
  * rect (window pixels, y-down: x1/y1 = min, x2/y2 = max), written into `out`. Returns false when
  * every corner is behind the camera. Mirrors EntityRender.calculateBoundingRect's NDC->pixel map
  * so the projected box lines up with EntityManager's mouse-space pick test.
+ *
+ * Intentionally kept even though the shipped default calls computeBaseSphereRect: it is the
+ * "tout le drapeau" mode (A) at the pick site, activated by commenting there. See render().
  */
+// eslint-disable-next-line no-unused-vars
 function computeScreenRect(aabb, mvp, out) {
 	const min = aabb.min;
 	const max = aabb.max;
@@ -513,6 +530,42 @@ function computeScreenRect(aabb, mvp, out) {
 	out.y1 = minY;
 	out.x2 = maxX;
 	out.y2 = maxY;
+	return true;
+}
+
+/**
+ * computeBaseSphereRect(mvp, projection, out) -> the client's GR2 pick box: the screen rect of a
+ * base bounding-sphere (fcn.006852e0), written into `out` (same {x1,y1,x2,y2} shape and
+ * window-pixel/y-down convention computeScreenRect produces, so EntityRender consumes it
+ * unchanged). Returns false when the base is behind the camera.
+ *
+ * Centre = the model origin (0,0,0) projected through the FULL model→clip matrix = the mvp
+ * translation column (mvp[12], mvp[13], w = mvp[15]). This is the model's base exactly as drawn —
+ * it carries the cell-centre +0.5, the groundOffset and the ipRow — matching fcn.006852e0.c:50-57,
+ * which transforms the stored centre (sub+0x394 = (0,0,0)) by the model's own matrices. Do NOT use
+ * the raw cell anchor (worldAnchorToClip): it misses the +0.5/ground and lands half a cell off.
+ *
+ * Half-extent = √(r²·0.5) world-u (BASE_SPHERE_HALF_EXTENT), projected `·focal·(1/w)` symmetrically
+ * around the centre (fcn.006852e0.c:70-71,75-81), where roBrowser's `focal` is `halfW·projection[0]`
+ * / `halfH·projection[5]` (the viewport scales). The radius is a world/view extent, independent of
+ * the model's own geometry scale — same as the client, which adds the raw radius in view space.
+ */
+function computeBaseSphereRect(mvp, projection, out) {
+	const cw = mvp[15];
+	if (cw <= 1e-6) {
+		return false;
+	}
+	const inv = 1 / cw;
+	const halfW = window.innerWidth * 0.5;
+	const halfH = window.innerHeight * 0.5;
+	const cx = halfW * (1 + mvp[12] * inv);
+	const cy = halfH * (1 - mvp[13] * inv);
+	const ex = halfW * projection[0] * BASE_SPHERE_HALF_EXTENT * inv;
+	const ey = halfH * projection[5] * BASE_SPHERE_HALF_EXTENT * inv;
+	out.x1 = cx - ex;
+	out.x2 = cx + ex;
+	out.y1 = cy - ey;
+	out.y2 = cy + ey;
 	return true;
 }
 
@@ -669,13 +722,22 @@ function render(gl, modelView, projection, normalMat, fog, light, tick) {
 				gl.uniform3fv(uniform.uLightAmbient, light.ambient || _phaseAmbient);
 			}
 
-			// Project the model AABB to a screen-space pick box for EntityManager's hover/click
-			// test. Stashed on the instance (not entity.boundingRect) because Entity.render()
-			// resets that rect after this map pass; EntityRender.calculateBoundingRect copies it.
+			// Project a screen-space pick box for EntityManager's hover/click test. Stashed on the
+			// instance (not entity.boundingRect) because Entity.render() resets that rect after this
+			// map pass; EntityRender.calculateBoundingRect copies it.
+			//
+			// TWO faithful-to-different-things modes — switch by commenting (no runtime flag):
+			//  (A) "tout le drapeau": the full model AABB projected. The WHOLE model is hoverable —
+			//      more generous (better UX) than the client, but a divergence.
+			//  (B) DEFAULT — "sphere", client-faithful (fcn.006852e0): a coarse square at the model
+			//      base only (computeBaseSphereRect). On the tall flag just the lower ~46% is
+			//      clickable. To use (A) instead, comment (B) and uncomment (A).
 			if (inst.entity && type.aabb) {
-				mat4.multiply(_mvp, projection, _mv);
 				const box = inst.screenRect || (inst.screenRect = { x1: 0, y1: 0, x2: 0, y2: 0 });
-				if (!computeScreenRect(type.aabb, _mvp, box)) {
+				mat4.multiply(_mvp, projection, _mv);
+				// const ok = computeScreenRect(type.aabb, _mvp, box); // (A) full model AABB
+				const ok = computeBaseSphereRect(_mvp, projection, box); // (B) client base sphere
+				if (!ok) {
 					inst.screenRect = null;
 				}
 			}

--- a/src/Renderer/GR2/GR2ModelRenderer.js
+++ b/src/Renderer/GR2/GR2ModelRenderer.js
@@ -950,6 +950,9 @@ function syncFromEntity(inst, type, tick) {
 	const e = inst.entity;
 	const p = e.position;
 	const dir = e.direction;
+	// Rebuild the world matrix on any pose change. p[2] IS the terrain cell height
+	// (position[2] = Altitude.getCellHeight, see attach), so a terrain-height change is
+	// already covered here -- it's part of the position tuple, not a missing trigger.
 	if (inst.pos[0] !== p[0] || inst.pos[1] !== p[1] || inst.pos[2] !== p[2] || inst.dir !== dir) {
 		inst.pos[0] = p[0];
 		inst.pos[1] = p[1];

--- a/src/Renderer/GR2/GR2ModelRenderer.js
+++ b/src/Renderer/GR2/GR2ModelRenderer.js
@@ -349,6 +349,7 @@ function acquire(path) {
 		return type;
 	}
 
+	const declaredBanks = bankPathsFor(path); // [{ name, path }]
 	type = {
 		path: path,
 		refcount: 1,
@@ -364,8 +365,8 @@ function acquire(path) {
 		// External animation banks (data/model/3dmob_bone/<setId>_<suffix>.gr2) loaded
 		// lazily, prioritised by the current action (see pumpBanks). The main .gr2 gives
 		// the mesh + embedded standby; move/attack/dead/damage stream in on demand.
-		declaredBanks: bankPathsFor(path), // [{ name, path }]
-		bankQueue: bankPathsFor(path).map(b => b.name),
+		declaredBanks: declaredBanks,
+		bankQueue: declaredBanks.map(b => b.name),
 		bankState: {}, // name -> 'loading' | 'loaded'
 		bankLoading: false
 	};
@@ -763,7 +764,8 @@ function render(gl, modelView, projection, normalMat, fog, light, tick) {
 			// remove_tick ramp, the SAME fade a 2D body applies (EntityRender.renderLayer) — so a
 			// GR2 mob/NPC fades out on death/vanish instead of hard-popping. Opaque instances
 			// (alpha 1) stay on the no-blend fast path; only a fading instance flips blend on and
-			// back off (the outer save/restore only guards the BLEND enable bit).
+			// back off. The outer save/restore guards the BLEND enable bit; the blend func it may
+			// switch is reset to the resting default at pass end (see below).
 			let alpha = 1.0;
 			const e = inst.entity;
 			if (e) {
@@ -811,6 +813,9 @@ function render(gl, modelView, projection, normalMat, fog, light, tick) {
 	if (blendWasEnabled) {
 		gl.enable(gl.BLEND);
 	}
+	// House convention: leave the blend func at roBrowser's resting default (every effect
+	// restores this on exit) — a fading instance above may have switched it.
+	gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
 	_poseCache = seen;
 
 	// Debug: paint the anchor cell of every instance (see _debugCell above).

--- a/src/Renderer/GR2/GR2ModelRenderer.js
+++ b/src/Renderer/GR2/GR2ModelRenderer.js
@@ -43,6 +43,12 @@ import {
 import { buildWorld, computeGroundOffset } from './gr2World.js';
 import { createActor, setAction, actorPose, ACTION } from './actorAction.js';
 import { bankPathsFor } from './gr2Banks.js';
+// The `?raw` shader imports and the `granny-ro-js/wasm` subpath (line 33) resolve in
+// production too: the builder (applications/tools/builder-web.mjs) drives Vite's `build()`,
+// so it runs the same Rollup pipeline as dev -- `?raw` is a first-class transform (already
+// used pervasively for UI .css/.html) and the wasm entry is a plain ESM module with the
+// binary base64-inlined (atob + WebAssembly.instantiate, no separate .wasm / fetch). Verified
+// via `npm run build`: poseAt + WebAssembly.instantiate land in dist/Web/Online.js.
 import _vertexShader from './GR2Model.vs?raw';
 import _fragmentShader from './GR2Model.fs?raw';
 

--- a/src/Renderer/GR2/GR2ModelRenderer.js
+++ b/src/Renderer/GR2/GR2ModelRenderer.js
@@ -364,9 +364,12 @@ function acquire(path) {
 					const loader = new GR2Loader(buffer);
 					type.parsed = loader.parsed;
 					type.meshes = loader.meshes;
-					type.groundOffset = computeGroundOffset(type.meshes); // drop the base onto the terrain
-					type.aabb = computeLocalAABB(type.meshes); // local bounds for the screen-space pick box
+					// ipRow BEFORE groundOffset: grounding must run in the model's real draw frame
+					// (v . ipRow . flagCore) — a non-identity IP (treasurebox 90deg rot, guardian Y
+					// translation) else grounds in the wrong frame and the model floats/sinks/lies flat.
 					type.ipRow = loader.ipRow;
+					type.groundOffset = computeGroundOffset(type.meshes, type.ipRow); // drop the base onto the terrain
+					type.aabb = computeLocalAABB(type.meshes); // local bounds for the screen-space pick box
 					type.boneCount = loader.boneCount;
 					type.duration = loader.duration;
 					type.cpuReady = true;

--- a/src/Renderer/GR2/GR2ModelRenderer.js
+++ b/src/Renderer/GR2/GR2ModelRenderer.js
@@ -1066,7 +1066,13 @@ function spawnMany(path, n, opts) {
  * unload frees them via free(gl)).
  */
 function clear() {
-	_instances = [];
+	// Route every instance through detach() so per-guild emblem textures are freed and the type
+	// refcount is decremented (a bare `_instances = []` orphaned both). detach() mutates _instances,
+	// so iterate over a copy. Type GL resources stay cached for re-spawn (freed at map unload).
+	const insts = _instances.slice();
+	for (let i = 0; i < insts.length; i++) {
+		detach(insts[i]);
+	}
 	_poseCache = {};
 }
 

--- a/src/Renderer/GR2/GR2ModelRenderer.js
+++ b/src/Renderer/GR2/GR2ModelRenderer.js
@@ -1,0 +1,506 @@
+/**
+ * Renderer/GR2/GR2ModelRenderer.js
+ *
+ * GPU-skinned Granny3D (.gr2) model renderer for on-map 3dmob actors (guild flag,
+ * Emperium, guardians). Ported from the sandbox robrowser render path
+ * (re-ro-clients-asm/sandbox/src/subsystems/gr2/draw-gpu-robrowser.js) to roBrowser
+ * conventions, consuming Loaders/GR2Loader.js.
+ *
+ * Architecture:
+ *   - Per-TYPE resource cache (key = gr2 path): one VBO/IBO/VAO/textures/skeleton/parsed
+ *     per type, refcounted. N instances carry only { world, actor, animIndex, t }.
+ *   - 40 Hz pose cache: poseAt is recomputed on the rag tick, keyed
+ *     (path, animIndex, quantize(t, 1/40)). Same-type / same-phase instances collapse to
+ *     one poseAt; culled/absent instances never pose.
+ *   - Bones: mat4 uBones[48] uniform + one draw per submesh per instance.
+ *
+ * Wired at the AnimatedModels seam of MapRenderer.onRender, wrapped in
+ * SpriteRenderer.runWithDepth(true, true, true). Frustum/distance culling is deferred to the
+ * Entity-integration pass (needs the populated EntityManager). Drive it from the /api.html
+ * console via window.RO.load('Renderer/GR2/GR2ModelRenderer'): RO.spawn(path, {pos, dir, action}).
+ *
+ * This file is part of ROBrowser, (http://www.robrowser.com/).
+ */
+
+import Client from 'Core/Client.js';
+import glMatrix from 'Utils/gl-matrix.js';
+import WebGL from 'Utils/WebGL.js';
+import SpriteRenderer from 'Renderer/SpriteRenderer.js';
+import Session from 'Engine/SessionStorage.js';
+import Altitude from 'Renderer/Map/Altitude.js';
+import GR2Loader from 'Loaders/GR2Loader.js';
+import { poseAt } from 'granny-ro-js/wasm';
+import { packRobrowserInterleave, flattenPose, poseCacheKey, quantizePoseTime, recenterEmblem } from './gr2Pack.js';
+import { buildWorld, computeGroundOffset } from './gr2World.js';
+import { createActor, setAction, actorPose } from './actorAction.js';
+import _vertexShader from './GR2Model.vs?raw';
+import _fragmentShader from './GR2Model.fs?raw';
+
+const mat3 = glMatrix.mat3;
+const mat4 = glMatrix.mat4;
+
+/**
+ * Phase-0 grayscale directional lighting (gr2-lighting-shadow-mars26.md): intensity
+ * 128/255, ambient floor 127/255, no env tint, full directional opacity. No uShadow cell
+ * scalar, no shadow blob.
+ */
+const ALPHA_REF = 207 / 255;
+const _phaseDiffuse = new Float32Array([128 / 255, 128 / 255, 128 / 255]);
+const _phaseAmbient = new Float32Array([127 / 255, 127 / 255, 127 / 255]);
+const _phaseEnv = new Float32Array([1, 1, 1]);
+
+let _program = null;
+
+// Per-type resource cache (key = gr2 path).
+let _types = {};
+
+// Live instances: { path, world, worldBuilt, actor, dir, pos, standbyIdx, animIndex, t }.
+let _instances = [];
+
+// Pose cache — set each frame to only the poses used that frame (bounds memory, keeps the
+// 40 Hz reuse across rAF frames when the quantized bucket is unchanged).
+let _poseCache = {};
+
+// granny-ro-js WASM init (texture pixel decode); shared across all types.
+let _readyPromise = null;
+
+// Scratchpads to evade the GC.
+const _mv = mat4.create();
+const _nmat = mat3.create();
+const _lightView = new Float32Array(3);
+
+/**
+ * Initialize the shader program.
+ */
+function init(gl) {
+	_program = WebGL.createShaderProgram(gl, _vertexShader, _fragmentShader);
+
+	_program.uniform = {
+		uModelViewMat: gl.getUniformLocation(_program, 'uModelViewMat'),
+		uProjectionMat: gl.getUniformLocation(_program, 'uProjectionMat'),
+		uNormalMat: gl.getUniformLocation(_program, 'uNormalMat'),
+		uBones: gl.getUniformLocation(_program, 'uBones[0]'),
+		uLightDirection: gl.getUniformLocation(_program, 'uLightDirection'),
+		uLightOpacity: gl.getUniformLocation(_program, 'uLightOpacity'),
+		uLightAmbient: gl.getUniformLocation(_program, 'uLightAmbient'),
+		uLightDiffuse: gl.getUniformLocation(_program, 'uLightDiffuse'),
+		uLightEnv: gl.getUniformLocation(_program, 'uLightEnv'),
+		uAlphaRef: gl.getUniformLocation(_program, 'uAlphaRef'),
+		uFogUse: gl.getUniformLocation(_program, 'uFogUse'),
+		uFogNear: gl.getUniformLocation(_program, 'uFogNear'),
+		uFogFar: gl.getUniformLocation(_program, 'uFogFar'),
+		uFogColor: gl.getUniformLocation(_program, 'uFogColor'),
+		uDiffuse: gl.getUniformLocation(_program, 'uDiffuse')
+	};
+
+	_program.attribute = {
+		aPosition: gl.getAttribLocation(_program, 'aPosition'),
+		aNormal: gl.getAttribLocation(_program, 'aNormal'),
+		aTextureCoord: gl.getAttribLocation(_program, 'aTextureCoord'),
+		aBoneIndex: gl.getAttribLocation(_program, 'aBoneIndex'),
+		aBoneWeight: gl.getAttribLocation(_program, 'aBoneWeight')
+	};
+}
+
+/**
+ * Free all type GL resources and drop every instance (MapRenderer calls this on map unload).
+ */
+function free(gl) {
+	for (const path in _types) {
+		const type = _types[path];
+		if (type.submeshes) {
+			for (let s = 0; s < type.submeshes.length; s++) {
+				const sm = type.submeshes[s];
+				gl.deleteVertexArray(sm.vao);
+				gl.deleteBuffer(sm.vbo);
+				gl.deleteBuffer(sm.ibo);
+			}
+		}
+		if (type.textures) {
+			for (const file in type.textures.byFile) {
+				gl.deleteTexture(type.textures.byFile[file]);
+			}
+		}
+	}
+	_types = {};
+	_instances = [];
+	_poseCache = {};
+}
+
+/**
+ * keyGr2Magenta(px) — ASM-faithful gr2 texture transparency. The client keys MAGENTA
+ * 0xFF00FF by zeroing the whole pixel to black + alpha 0 (mars26 fcn.0054e950 / ver12
+ * fcn.00417550). Discarded before the RGB contributes (opaque + hard alpha-test at 207).
+ * A 32-bit source with its own alpha is honoured verbatim.
+ */
+function keyGr2Magenta(px) {
+	for (let i = 3; i < px.length; i += 4) {
+		if (px[i] < 255) {
+			return px;
+		}
+	}
+	const out = new Uint8Array(px);
+	for (let i = 0; i < out.length; i += 4) {
+		if (out[i] >= 248 && out[i + 1] < 8 && out[i + 2] >= 248) {
+			out[i] = out[i + 1] = out[i + 2] = out[i + 3] = 0;
+		}
+	}
+	return out;
+}
+
+/**
+ * makeTypeTextures(gl, parsed) -> { byFile:{ textureFile -> GLTexture } }. One texture per
+ * embedded granny texture, keyed by its file name (the string a packed mesh carries in
+ * texFile). LINEAR + CLAMP = the client's active sampler 0 (byte-cited).
+ */
+function makeTypeTextures(gl, parsed) {
+	const byFile = {};
+	const list = parsed.textures || [];
+	for (let i = 0; i < list.length; i++) {
+		const t = list[i];
+		const tex = gl.createTexture();
+		gl.bindTexture(gl.TEXTURE_2D, tex);
+		if (t && t.pixels) {
+			gl.texImage2D(
+				gl.TEXTURE_2D,
+				0,
+				gl.RGBA,
+				t.width,
+				t.height,
+				0,
+				gl.RGBA,
+				gl.UNSIGNED_BYTE,
+				keyGr2Magenta(t.pixels)
+			);
+		} else {
+			gl.texImage2D(
+				gl.TEXTURE_2D,
+				0,
+				gl.RGBA,
+				1,
+				1,
+				0,
+				gl.RGBA,
+				gl.UNSIGNED_BYTE,
+				new Uint8Array([200, 200, 200, 255])
+			);
+		}
+		gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+		gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+		gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+		gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+		byFile[t.name] = tex;
+	}
+	const grey = gl.createTexture();
+	gl.bindTexture(gl.TEXTURE_2D, grey);
+	gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 1, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, new Uint8Array([180, 180, 185, 255]));
+	byFile.__grey = grey;
+	gl.bindTexture(gl.TEXTURE_2D, null);
+	return { byFile: byFile };
+}
+
+/**
+ * acquire(path) — refcount a type; on first acquire fetch the .gr2 (worker Thread ->
+ * cyro source) and decode it on the CPU (GL upload is deferred to the first render that
+ * has a gl context). Returns the type entry immediately (empty until decode completes).
+ */
+function acquire(path) {
+	let type = _types[path];
+	if (type) {
+		type.refcount++;
+		return type;
+	}
+
+	type = {
+		path: path,
+		refcount: 1,
+		cpuReady: false,
+		glReady: false,
+		parsed: null,
+		meshes: null,
+		ipRow: undefined,
+		boneCount: 0,
+		duration: 1,
+		submeshes: null,
+		textures: null
+	};
+	_types[path] = type;
+
+	if (!_readyPromise) {
+		_readyPromise = GR2Loader.ready();
+	}
+	Client.getFile(
+		path,
+		function (buffer) {
+			_readyPromise.then(function () {
+				// The type may have been freed before the async decode returned.
+				if (_types[path] !== type) {
+					return;
+				}
+				const loader = new GR2Loader(buffer);
+				type.parsed = loader.parsed;
+				type.meshes = loader.meshes;
+				recenterEmblem(type.meshes); // render-only: centre the off-baked emblem on the banner
+				type.groundOffset = computeGroundOffset(type.meshes); // drop the base onto the terrain
+				type.ipRow = loader.ipRow;
+				type.boneCount = loader.boneCount;
+				type.duration = loader.duration;
+				type.cpuReady = true;
+			});
+		},
+		function () {
+			console.warn('[GR2ModelRenderer] failed to fetch', path);
+		}
+	);
+	return type;
+}
+
+/**
+ * buildTypeGL(gl, type) — upload the type's VBO/IBO/VAO per submesh + textures, once the
+ * CPU decode is done. One VAO per submesh, 16-float interleave (stride 64).
+ */
+function buildTypeGL(gl, type) {
+	type.textures = makeTypeTextures(gl, type.parsed);
+	const attr = _program.attribute;
+	type.submeshes = type.meshes.map(function (mesh) {
+		const vao = gl.createVertexArray();
+		gl.bindVertexArray(vao);
+
+		const vbo = gl.createBuffer();
+		gl.bindBuffer(gl.ARRAY_BUFFER, vbo);
+		gl.bufferData(gl.ARRAY_BUFFER, packRobrowserInterleave(mesh), gl.STATIC_DRAW);
+
+		const stride = 64;
+		gl.enableVertexAttribArray(attr.aPosition);
+		gl.vertexAttribPointer(attr.aPosition, 3, gl.FLOAT, false, stride, 0);
+		gl.enableVertexAttribArray(attr.aNormal);
+		gl.vertexAttribPointer(attr.aNormal, 3, gl.FLOAT, false, stride, 12);
+		gl.enableVertexAttribArray(attr.aTextureCoord);
+		gl.vertexAttribPointer(attr.aTextureCoord, 2, gl.FLOAT, false, stride, 24);
+		gl.enableVertexAttribArray(attr.aBoneIndex);
+		gl.vertexAttribPointer(attr.aBoneIndex, 4, gl.FLOAT, false, stride, 32);
+		gl.enableVertexAttribArray(attr.aBoneWeight);
+		gl.vertexAttribPointer(attr.aBoneWeight, 4, gl.FLOAT, false, stride, 48);
+
+		const ibo = gl.createBuffer();
+		gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, ibo);
+		gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, mesh.indices, gl.STATIC_DRAW);
+
+		gl.bindVertexArray(null);
+		return {
+			vao: vao,
+			vbo: vbo,
+			ibo: ibo,
+			count: mesh.indices.length,
+			tex: type.textures.byFile[mesh.texFile] || type.textures.byFile.__grey
+		};
+	});
+	type.glReady = true;
+}
+
+function mat3MulVec3(m, v, out) {
+	out[0] = m[0] * v[0] + m[4] * v[1] + m[8] * v[2];
+	out[1] = m[1] * v[0] + m[5] * v[1] + m[9] * v[2];
+	out[2] = m[2] * v[0] + m[6] * v[1] + m[10] * v[2];
+}
+
+function normalize3(v) {
+	const len = Math.hypot(v[0], v[1], v[2]) || 1;
+	v[0] /= len;
+	v[1] /= len;
+	v[2] /= len;
+}
+
+/**
+ * Render every live GR2 instance. Signature mirrors AnimatedModels.render (the seam it
+ * sits next to): (gl, modelView, projection, normalMat, fog, light, tick). modelView is
+ * Camera.modelView (the view matrix); the per-instance world is composed on top.
+ */
+function render(gl, modelView, projection, normalMat, fog, light, tick) {
+	if (_instances.length === 0 || !light) {
+		return;
+	}
+	if (!_program) {
+		init(gl);
+	}
+
+	// Build GL resources for any type whose CPU decode has finished.
+	for (const path in _types) {
+		const type = _types[path];
+		if (type.cpuReady && !type.glReady) {
+			buildTypeGL(gl, type);
+		}
+	}
+
+	const uniform = _program.uniform;
+	gl.useProgram(_program);
+
+	// Per-frame constant uniforms.
+	gl.uniformMatrix4fv(uniform.uProjectionMat, false, projection);
+	gl.uniform1f(uniform.uLightOpacity, 1.0);
+	gl.uniform3fv(uniform.uLightDiffuse, _phaseDiffuse);
+	gl.uniform3fv(uniform.uLightAmbient, _phaseAmbient);
+	gl.uniform3fv(uniform.uLightEnv, _phaseEnv);
+	gl.uniform1f(uniform.uAlphaRef, ALPHA_REF);
+	gl.uniform1i(uniform.uFogUse, fog.use && fog.exist);
+	gl.uniform1f(uniform.uFogNear, fog.near);
+	gl.uniform1f(uniform.uFogFar, fog.far);
+	gl.uniform3fv(uniform.uFogColor, fog.color);
+	gl.activeTexture(gl.TEXTURE0);
+	gl.uniform1i(uniform.uDiffuse, 0);
+
+	// Opaque device state — no blend (client draws the GR2 opaque with a hard alpha-test). Saved
+	// and restored so the later transparent passes (entity shadow, water, effects) keep their blend.
+	const blendWasEnabled = gl.isEnabled(gl.BLEND);
+	gl.disable(gl.BLEND);
+
+	// Scene light direction (world) -> view space, so N.L shares the normal's frame.
+	mat3MulVec3(modelView, light.direction, _lightView);
+	normalize3(_lightView);
+	gl.uniform3fv(uniform.uLightDirection, _lightView);
+
+	const seen = {};
+	SpriteRenderer.runWithDepth(true, true, true, function () {
+		for (let i = 0; i < _instances.length; i++) {
+			const inst = _instances[i];
+			const type = _types[inst.path];
+			if (!type || !type.glReady) {
+				continue;
+			}
+
+			// Build the instance world matrix once the type (its ipRow) is known. Entity
+			// positions are [cellX, cellY, height]; roBrowser's world axes are X=cellX,
+			// Y=height (up), Z=cellY — so swap Y/Z into buildWorld's ground-plane frame (the
+			// same swap Camera.update does: _position[1]=pos[2], _position[2]=pos[1]).
+			if (!inst.worldBuilt) {
+				const p = inst.pos;
+				// RO direction is an 8-way index (0-7); the world yaw wants degrees (45 deg/step).
+				inst.world = buildWorld(inst.dir * 45, [p[0], p[2], p[1]], type.ipRow, {
+					heightOffset: type.groundOffset
+				});
+				inst.worldBuilt = true;
+			}
+
+			// Advance the action clock, then resolve/cache the pose at 40 Hz.
+			const pose = actorPose(inst.actor, type, tick, inst.standbyIdx, null);
+			inst.animIndex = pose.animIndex;
+			inst.t = pose.t;
+
+			const key = poseCacheKey(inst.path, pose.animIndex, quantizePoseTime(pose.t));
+			let bones = seen[key] || _poseCache[key];
+			if (!bones) {
+				const idx = pose.animIndex < 0 ? -1 : pose.animIndex;
+				const sampleT = pose.animIndex < 0 ? 0 : pose.t;
+				bones = flattenPose(poseAt(type.parsed, idx, sampleT), type.boneCount);
+			}
+			seen[key] = bones;
+
+			// Per-instance matrices: modelView = view * world, normalMat = inv-transpose of its 3x3.
+			mat4.multiply(_mv, modelView, inst.world);
+			mat4.toInverseMat3(_mv, _nmat);
+			mat3.transpose(_nmat, _nmat);
+			gl.uniformMatrix4fv(uniform.uModelViewMat, false, _mv);
+			gl.uniformMatrix3fv(uniform.uNormalMat, false, _nmat);
+			gl.uniformMatrix4fv(uniform.uBones, false, bones);
+
+			for (let s = 0; s < type.submeshes.length; s++) {
+				const sm = type.submeshes[s];
+				gl.bindTexture(gl.TEXTURE_2D, sm.tex);
+				gl.bindVertexArray(sm.vao);
+				gl.drawElements(gl.TRIANGLES, sm.count, gl.UNSIGNED_SHORT, 0);
+			}
+		}
+	});
+	gl.bindVertexArray(null);
+	if (blendWasEnabled) {
+		gl.enable(gl.BLEND);
+	}
+	_poseCache = seen;
+}
+
+/**
+ * spawn(path, opts) — dev harness: place a GR2 instance. opts = { pos, dir, action,
+ * standbyIdx }; pos/dir default to the player's position/facing. Returns the instance.
+ */
+function spawn(path, opts) {
+	const o = opts || {};
+	const ent = Session.Entity;
+	const pos = o.pos || (ent ? [ent.position[0], ent.position[1], ent.position[2]] : [0, 0, 0]);
+	const dir = o.dir != null ? o.dir : ent ? ent.direction : 0;
+	// Ground the base on the REAL terrain height at the target cell (what a real entity carries in
+	// position[2]) — so an offset dev spawn sits on the local ground, not the player's height.
+	pos[2] = Altitude.getCellHeight(pos[0], pos[1]);
+
+	acquire(path);
+
+	const actor = createActor();
+	if (o.action && o.action !== 'stand') {
+		setAction(actor, o.action, 0);
+		if (o.action === 'move') {
+			actor.loop = true;
+		}
+	}
+
+	const inst = {
+		path: path,
+		world: null,
+		worldBuilt: false,
+		actor: actor,
+		dir: dir,
+		pos: pos,
+		standbyIdx: o.standbyIdx != null ? o.standbyIdx : 0,
+		animIndex: 0,
+		t: 0
+	};
+	_instances.push(inst);
+	return inst;
+}
+
+/**
+ * spawnMany(path, n, opts) — dev stress path: spawn n instances of one type in a sunflower
+ * (phyllotaxis) spiral radiating out around the player, to prove same-type mobs collapse to one
+ * geometry upload + one poseAt per phase. opts.spacing scales the disk radius.
+ */
+function spawnMany(path, n, opts) {
+	const o = opts || {};
+	const ent = Session.Entity;
+	const base = o.pos || (ent ? [ent.position[0], ent.position[1], ent.position[2]] : [0, 0, 0]);
+	const spacing = o.spacing || 1.2;
+	const golden = Math.PI * (3 - Math.sqrt(5)); // ~137.5 deg — even phyllotaxis fill
+	const out = [];
+	for (let i = 0; i < n; i++) {
+		const r = spacing * Math.sqrt(i + 0.5); // radius grows outward, dense near the centre
+		const a = i * golden;
+		const inst = spawn(path, {
+			pos: [base[0] + r * Math.cos(a), base[1] + r * Math.sin(a), base[2]],
+			dir: o.dir,
+			action: o.action,
+			standbyIdx: o.standbyIdx
+		});
+		// decorrelate: phase-shift each instance by one 40 Hz tick so they land in distinct pose
+		// buckets (realistic non-synchronized load — poseAt count then caps at duration*40, not N).
+		if (o.decorrelate) {
+			inst.actor.startT = -i * 25;
+		}
+		out.push(inst);
+	}
+	return out;
+}
+
+/**
+ * clear() — dev: drop every instance (GL type resources stay cached for re-spawn; the map
+ * unload frees them via free(gl)).
+ */
+function clear() {
+	_instances = [];
+	_poseCache = {};
+}
+
+export default {
+	init: init,
+	free: free,
+	render: render,
+	spawn: spawn,
+	spawnMany: spawnMany,
+	clear: clear
+};

--- a/src/Renderer/GR2/GR2ModelRenderer.js
+++ b/src/Renderer/GR2/GR2ModelRenderer.js
@@ -124,6 +124,8 @@ let _types = {};
 // onError; consumed by isMissing() so the Entity path falls back to a Poring sprite instead of
 // rendering nothing. Session-lifetime on purpose -- a missing model stays missing across maps,
 // so free() deliberately does NOT clear it (no re-request, no re-attempt of the dead 3D path).
+// Bounded, not a growing leak: acquire() only ever receives ROSTERED paths (UpdateBody gates on
+// isSupported before this.gr2 is set), so this holds at most one key per roster entry.
 const _missing = {};
 
 // Live instances: { path, world, worldBuilt, actor, dir, pos, standbyIdx, animIndex, t,
@@ -250,6 +252,11 @@ function free(gl) {
 	_types = {};
 	_instances = [];
 	_poseCache = {};
+	// _program and _gl are intentionally kept (not deleted/nulled): roBrowser uses one persistent
+	// WebGL context across map loads, so the compiled program stays valid and render() reuses it via
+	// the `if (!_program)` guard -- re-init only on a genuinely fresh context. Same pattern as
+	// AnimatedModels.js free(). If context loss/restore ever recreates the GL context, both would
+	// need to reset _program here.
 }
 
 /**

--- a/src/Renderer/GR2/GR2ModelRenderer.js
+++ b/src/Renderer/GR2/GR2ModelRenderer.js
@@ -90,6 +90,9 @@ function grayBroadcast(src, out) {
 
 let _program = null;
 
+// GL context cached from render() so detach() can free per-instance emblem textures off-frame.
+let _gl = null;
+
 // Per-type resource cache (key = gr2 path).
 let _types = {};
 
@@ -187,6 +190,12 @@ function free(gl) {
 			}
 		}
 	}
+	// Per-instance (per-guild) emblem textures live on the instance, not the type cache.
+	for (let i = 0; i < _instances.length; i++) {
+		if (_instances[i].emblemTex) {
+			gl.deleteTexture(_instances[i].emblemTex);
+		}
+	}
 	_types = {};
 	_instances = [];
 	_poseCache = {};
@@ -260,35 +269,50 @@ function makeTypeTextures(gl, parsed) {
 	gl.bindTexture(gl.TEXTURE_2D, grey);
 	gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 1, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, new Uint8Array([180, 180, 185, 255]));
 	byFile.__grey = grey;
-	// Emblem placeholder — a 24x24 magenta patch painted into the top-left corner of a 32x32 POT
-	// (the real guild emblem is a 24px request rounded up to the next power-of-two; UV 0..1 sample
-	// the whole 32x32 so the emblem reads at the top-left 75% of the quad). The [24..31] border is
-	// left transparent (killed by the shader's hard alpha-test). Stands in for the dynamic guild
-	// emblem (ZC_GUILD_EMBLEM_IMG, wired later); the asymmetric corner also reads out the flag
-	// orientation. NEAREST + CLAMP because a non-mip 32x32 with the default min-filter would be
-	// incomplete/black.
-	const magenta = gl.createTexture();
-	gl.bindTexture(gl.TEXTURE_2D, magenta);
-	const mpx = new Uint8Array(32 * 32 * 4);
-	for (let y = 0; y < 32; y++) {
-		for (let x = 0; x < 32; x++) {
-			if (x < 24 && y < 24) {
-				const o = (y * 32 + x) * 4;
-				mpx[o] = 255;
-				mpx[o + 1] = 0;
-				mpx[o + 2] = 255;
-				mpx[o + 3] = 255;
-			}
-		}
-	}
-	gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 32, 32, 0, gl.RGBA, gl.UNSIGNED_BYTE, mpx);
-	gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
-	gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
-	gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
-	gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-	byFile.__magenta = magenta;
 	gl.bindTexture(gl.TEXTURE_2D, null);
 	return { byFile: byFile };
+}
+
+// A4R4G4B4 4-bit quantize — the client's on-load emblem format (byte-cited fcn.0054e1d0 class-1).
+function quantize4bit(px) {
+	for (let i = 0; i < px.length; i++) {
+		px[i] = (px[i] >> 4) * 0x11;
+	}
+}
+
+/**
+ * buildEmblemTexture(gl, img, prevTex) — the live per-guild emblem, POT-padded the way the client
+ * does it. The client requests the emblem 24x24 then rounds it up to the next power-of-two
+ * (32x32, fcn.00529000) with the pixels in the TOP-LEFT corner and the rest transparent, so
+ * UV 0..1 sample the whole 32x32 and the emblem reads at 75% top-left of the Plane01 quad
+ * (~centered, upper third of the banner). The placement IS the POT padding — no geometry recentre.
+ * The transparent [24..31] border is discarded by the shader's hard alpha-test (ALPHA_REF). The
+ * source already passed Texture.load (magenta keyed) in Guild.js, so only the A4R4G4B4 quantize is
+ * applied here. Reuses prevTex on a guild/version change so a re-bind never leaks. LINEAR + CLAMP
+ * = the client's sampler (byte-cited).
+ */
+function buildEmblemTexture(gl, img, prevTex) {
+	const POT = 32,
+		SRC = 24;
+	const cv = document.createElement('canvas');
+	cv.width = POT;
+	cv.height = POT;
+	const ctx = cv.getContext('2d', { willReadFrequently: true });
+	ctx.imageSmoothingEnabled = false;
+	ctx.drawImage(img, 0, 0, SRC, SRC);
+	const im = ctx.getImageData(0, 0, POT, POT);
+	quantize4bit(im.data);
+
+	const tex = prevTex || gl.createTexture();
+	gl.bindTexture(gl.TEXTURE_2D, tex);
+	gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
+	gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, im);
+	gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+	gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+	gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+	gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+	gl.bindTexture(gl.TEXTURE_2D, null);
+	return tex;
 }
 
 /**
@@ -396,8 +420,13 @@ function buildTypeGL(gl, type) {
 			ibo: ibo,
 			count: mesh.indices.length,
 			tex: type.textures.byFile[mesh.texFile] || type.textures.byFile.__grey,
-			emblem: mesh.emblem // route the emblem submesh (Plane01) to the placeholder texture
+			emblem: mesh.emblem // the emblem submesh (Plane01) binds the live per-instance guild emblem
 		};
+	});
+	// Whether this type carries an emblem submesh (guild flag) — gates the per-instance emblem
+	// rebuild in render() so non-flag types skip it.
+	type.hasEmblem = type.submeshes.some(function (sm) {
+		return sm.emblem;
 	});
 	type.glReady = true;
 }
@@ -497,6 +526,7 @@ function normalize3(v) {
  * Camera.modelView (the view matrix); the per-instance world is composed on top.
  */
 function render(gl, modelView, projection, normalMat, fog, light, tick) {
+	_gl = gl;
 	if (_instances.length === 0 || !light) {
 		return;
 	}
@@ -554,6 +584,24 @@ function render(gl, modelView, projection, normalMat, fog, light, tick) {
 			// this pass runs before EntityManager.render) and prioritise its bank load.
 			if (inst.entity) {
 				syncFromEntity(inst, type, tick);
+
+				// Live guild emblem: bind the entity's fetched emblem image (Guild.requestGuildEmblem,
+				// triggered on spawn for any GUID) as a per-instance POT texture. Per-instance, not
+				// per-type — two flags of different guilds must show different emblems. Rebuild only when
+				// the image reference changes (new guild / GEmblemVer → new image object), so the identity
+				// compare is the whole per-frame cost.
+				if (type.hasEmblem) {
+					const emblemImg = inst.entity.emblem && inst.entity.emblem.emblem;
+					if (emblemImg !== inst._emblemImg) {
+						inst._emblemImg = emblemImg;
+						if (emblemImg) {
+							inst.emblemTex = buildEmblemTexture(gl, emblemImg, inst.emblemTex);
+						} else if (inst.emblemTex) {
+							gl.deleteTexture(inst.emblemTex);
+							inst.emblemTex = null;
+						}
+					}
+				}
 			}
 
 			// Frustum cull BEFORE posing — a culled instance neither poses nor draws. The anchor
@@ -655,9 +703,10 @@ function render(gl, modelView, projection, normalMat, fog, light, tick) {
 
 			for (let s = 0; s < type.submeshes.length; s++) {
 				const sm = type.submeshes[s];
-				// The emblem submesh (Plane01) draws the magenta placeholder until the dynamic guild
-				// emblem is wired; every other submesh uses its baked texture.
-				gl.bindTexture(gl.TEXTURE_2D, sm.emblem ? type.textures.byFile.__magenta : sm.tex);
+				// The emblem submesh (Plane01) binds this instance's live guild emblem; before it is
+				// fetched (or on a dev spawn with no entity) it falls back to the baked emblem.tif from
+				// the .gr2. Every other submesh uses its baked texture.
+				gl.bindTexture(gl.TEXTURE_2D, sm.emblem ? inst.emblemTex || sm.tex : sm.tex);
 				gl.bindVertexArray(sm.vao);
 				gl.drawElements(gl.TRIANGLES, sm.count, gl.UNSIGNED_SHORT, 0);
 			}
@@ -822,7 +871,10 @@ function attach(entity) {
 		t: 0,
 		_lastAction: 'stand',
 		_lastTick: 0,
-		screenRect: null
+		screenRect: null,
+		// Per-instance (per-guild) emblem texture + the image it was built from, for change detection.
+		emblemTex: null,
+		_emblemImg: null
 	};
 	_instances.push(inst);
 	return inst;
@@ -840,6 +892,11 @@ function detach(inst) {
 	const type = _types[inst.path];
 	if (type && type.refcount > 0) {
 		type.refcount--;
+	}
+	// Free this instance's per-guild emblem texture (the per-type cache is freed at map unload).
+	if (inst.emblemTex && _gl) {
+		_gl.deleteTexture(inst.emblemTex);
+		inst.emblemTex = null;
 	}
 	inst.entity = null;
 }

--- a/src/Renderer/GR2/GR2ModelRenderer.js
+++ b/src/Renderer/GR2/GR2ModelRenderer.js
@@ -29,10 +29,19 @@ import SpriteRenderer from 'Renderer/SpriteRenderer.js';
 import Session from 'Engine/SessionStorage.js';
 import Altitude from 'Renderer/Map/Altitude.js';
 import GR2Loader from 'Loaders/GR2Loader.js';
-import { poseAt } from 'granny-ro-js/wasm';
-import { packRobrowserInterleave, flattenPose, poseCacheKey, quantizePoseTime, recenterEmblem } from './gr2Pack.js';
+import { poseAt, parseAnimated } from 'granny-ro-js/wasm';
+import {
+	packRobrowserInterleave,
+	flattenPose,
+	poseCacheKey,
+	quantizePoseTime,
+	recenterEmblem,
+	gr2ActionFor,
+	frustumCullClip
+} from './gr2Pack.js';
 import { buildWorld, computeGroundOffset } from './gr2World.js';
-import { createActor, setAction, actorPose } from './actorAction.js';
+import { createActor, setAction, actorPose, ACTION } from './actorAction.js';
+import { bankPathsFor } from './gr2Banks.js';
 import _vertexShader from './GR2Model.vs?raw';
 import _fragmentShader from './GR2Model.fs?raw';
 
@@ -66,8 +75,24 @@ let _readyPromise = null;
 
 // Scratchpads to evade the GC.
 const _mv = mat4.create();
+const _mvp = mat4.create();
 const _nmat = mat3.create();
 const _lightView = new Float32Array(3);
+const _clip = new Float32Array(4);
+
+// Frustum-cull margin (NDC), padded so a model straddling the screen edge is not clipped
+// by its ground anchor alone.
+const CULL_MARGIN = 0.2;
+
+// Removal-fade toggles — both OFF by default = FAITHFUL. For a genuine 3D (.gr2) actor the
+// official mars26 client instantiates NEITHER the out-of-sight alpha fade NOR the death corpse
+// (CCorpse) — both are 2D-sprite-only; a genuine 3D actor hard-POPS on removal (verified by RE
+// on mars26; no alpha fade-in on spawn either). Our GR2 roster (guardians, Emperium, guild
+// flag, treasure box) IS that 3D set, so popping is correct. Set a toggle true to A/B a
+// roBrowser-parity fade over remove_delay instead (NON-authentic). Exported -> runtime-mutable:
+// RO.load('Renderer/GR2/GR2ModelRenderer').FADE.death.
+//   death  -> the DIE removal        vanish -> the out-of-sight removal
+const FADE = { death: false, vanish: false };
 
 /**
  * Initialize the shader program.
@@ -86,6 +111,7 @@ function init(gl) {
 		uLightDiffuse: gl.getUniformLocation(_program, 'uLightDiffuse'),
 		uLightEnv: gl.getUniformLocation(_program, 'uLightEnv'),
 		uAlphaRef: gl.getUniformLocation(_program, 'uAlphaRef'),
+		uAlpha: gl.getUniformLocation(_program, 'uAlpha'),
 		uFogUse: gl.getUniformLocation(_program, 'uFogUse'),
 		uFogNear: gl.getUniformLocation(_program, 'uFogNear'),
 		uFogFar: gl.getUniformLocation(_program, 'uFogFar'),
@@ -222,7 +248,14 @@ function acquire(path) {
 		boneCount: 0,
 		duration: 1,
 		submeshes: null,
-		textures: null
+		textures: null,
+		// External animation banks (data/model/3dmob_bone/<setId>_<suffix>.gr2) loaded
+		// lazily, prioritised by the current action (see pumpBanks). The main .gr2 gives
+		// the mesh + embedded standby; move/attack/dead/damage stream in on demand.
+		declaredBanks: bankPathsFor(path), // [{ name, path }]
+		bankQueue: bankPathsFor(path).map(b => b.name),
+		bankState: {}, // name -> 'loading' | 'loaded'
+		bankLoading: false
 	};
 	_types[path] = type;
 
@@ -237,15 +270,20 @@ function acquire(path) {
 				if (_types[path] !== type) {
 					return;
 				}
-				const loader = new GR2Loader(buffer);
-				type.parsed = loader.parsed;
-				type.meshes = loader.meshes;
-				recenterEmblem(type.meshes); // render-only: centre the off-baked emblem on the banner
-				type.groundOffset = computeGroundOffset(type.meshes); // drop the base onto the terrain
-				type.ipRow = loader.ipRow;
-				type.boneCount = loader.boneCount;
-				type.duration = loader.duration;
-				type.cpuReady = true;
+				try {
+					const loader = new GR2Loader(buffer);
+					type.parsed = loader.parsed;
+					type.meshes = loader.meshes;
+					recenterEmblem(type.meshes); // render-only: centre the off-baked emblem on the banner
+					type.groundOffset = computeGroundOffset(type.meshes); // drop the base onto the terrain
+					type.aabb = computeLocalAABB(type.meshes); // local bounds for the screen-space pick box
+					type.ipRow = loader.ipRow;
+					type.boneCount = loader.boneCount;
+					type.duration = loader.duration;
+					type.cpuReady = true;
+				} catch (e) {
+					console.error('[GR2ModelRenderer] decode failed', path, e);
+				}
 			});
 		},
 		function () {
@@ -304,6 +342,82 @@ function mat3MulVec3(m, v, out) {
 	out[2] = m[2] * v[0] + m[6] * v[1] + m[10] * v[2];
 }
 
+/**
+ * computeLocalAABB(meshes) -> the model's local bind-pose axis-aligned bounds { min, max }, or
+ * null if empty. Used to project a screen-space pick box (see computeScreenRect) — the GR2 path
+ * suppresses the 2D sprite body, which is what normally fills entity.boundingRect.
+ */
+function computeLocalAABB(meshes) {
+	let minX = Infinity,
+		minY = Infinity,
+		minZ = Infinity;
+	let maxX = -Infinity,
+		maxY = -Infinity,
+		maxZ = -Infinity;
+	for (let k = 0; k < meshes.length; k++) {
+		const bind = meshes[k].bind;
+		const vc = meshes[k].vcount;
+		for (let i = 0; i < vc; i++) {
+			const x = bind[i * 3];
+			const y = bind[i * 3 + 1];
+			const z = bind[i * 3 + 2];
+			if (x < minX) minX = x;
+			if (x > maxX) maxX = x;
+			if (y < minY) minY = y;
+			if (y > maxY) maxY = y;
+			if (z < minZ) minZ = z;
+			if (z > maxZ) maxZ = z;
+		}
+	}
+	if (minX === Infinity) {
+		return null;
+	}
+	return { min: [minX, minY, minZ], max: [maxX, maxY, maxZ] };
+}
+
+/**
+ * computeScreenRect(aabb, mvp, out) -> project the 8 AABB corners through mvp to a screen-space
+ * rect (window pixels, y-down: x1/y1 = min, x2/y2 = max), written into `out`. Returns false when
+ * every corner is behind the camera. Mirrors EntityRender.calculateBoundingRect's NDC->pixel map
+ * so the projected box lines up with EntityManager's mouse-space pick test.
+ */
+function computeScreenRect(aabb, mvp, out) {
+	const min = aabb.min;
+	const max = aabb.max;
+	const halfW = window.innerWidth * 0.5;
+	const halfH = window.innerHeight * 0.5;
+	let minX = Infinity,
+		minY = Infinity,
+		maxX = -Infinity,
+		maxY = -Infinity;
+	let any = false;
+	for (let i = 0; i < 8; i++) {
+		const x = i & 1 ? max[0] : min[0];
+		const y = i & 2 ? max[1] : min[1];
+		const z = i & 4 ? max[2] : min[2];
+		const cw = mvp[3] * x + mvp[7] * y + mvp[11] * z + mvp[15];
+		if (cw <= 1e-6) {
+			continue;
+		}
+		const inv = 1 / cw;
+		const sx = halfW * (1 + (mvp[0] * x + mvp[4] * y + mvp[8] * z + mvp[12]) * inv);
+		const sy = halfH * (1 - (mvp[1] * x + mvp[5] * y + mvp[9] * z + mvp[13]) * inv);
+		if (sx < minX) minX = sx;
+		if (sx > maxX) maxX = sx;
+		if (sy < minY) minY = sy;
+		if (sy > maxY) maxY = sy;
+		any = true;
+	}
+	if (!any) {
+		return false;
+	}
+	out.x1 = minX;
+	out.y1 = minY;
+	out.x2 = maxX;
+	out.y2 = maxY;
+	return true;
+}
+
 function normalize3(v) {
 	const len = Math.hypot(v[0], v[1], v[2]) || 1;
 	v[0] /= len;
@@ -337,10 +451,16 @@ function render(gl, modelView, projection, normalMat, fog, light, tick) {
 
 	// Per-frame constant uniforms.
 	gl.uniformMatrix4fv(uniform.uProjectionMat, false, projection);
-	gl.uniform1f(uniform.uLightOpacity, 1.0);
-	gl.uniform3fv(uniform.uLightDiffuse, _phaseDiffuse);
-	gl.uniform3fv(uniform.uLightAmbient, _phaseAmbient);
-	gl.uniform3fv(uniform.uLightEnv, _phaseEnv);
+	// Drive the GR2 shade from the map's own light (parity with Models.js / AnimatedModels.js
+	// — the GR2 .fs math is byte-identical). Falls back to the Phase-0 baked grays if a map
+	// somehow omits a field (dev spawn always has light; the render early-returns without it).
+	// Drive the GR2 shade from the map's own light (parity with Models.js / AnimatedModels.js
+	// — the GR2 .fs math is byte-identical). Falls back to the Phase-0 baked grays if a map
+	// omits a field (dev spawn always has light; the render early-returns without it).
+	gl.uniform1f(uniform.uLightOpacity, light.opacity != null ? light.opacity : 1.0);
+	gl.uniform3fv(uniform.uLightDiffuse, light.diffuse || _phaseDiffuse);
+	gl.uniform3fv(uniform.uLightAmbient, light.ambient || _phaseAmbient);
+	gl.uniform3fv(uniform.uLightEnv, light.env || _phaseEnv);
 	gl.uniform1f(uniform.uAlphaRef, ALPHA_REF);
 	gl.uniform1i(uniform.uFogUse, fog.use && fog.exist);
 	gl.uniform1f(uniform.uFogNear, fog.near);
@@ -368,14 +488,31 @@ function render(gl, modelView, projection, normalMat, fog, light, tick) {
 				continue;
 			}
 
+			// Entity-backed instance: pull pos/dir/action from the live entity (1-frame lag —
+			// this pass runs before EntityManager.render) and prioritise its bank load.
+			if (inst.entity) {
+				syncFromEntity(inst, type, tick);
+			}
+
+			// Frustum cull BEFORE posing — a culled instance neither poses nor draws. The anchor
+			// negates the height to match buildWorld's world-Y (-position[2]).
+			worldAnchorToClip(inst.pos, modelView, projection, _clip);
+			if (frustumCullClip(_clip[0], _clip[1], _clip[3], CULL_MARGIN)) {
+				// Off-screen: drop the stale pick box so the hover test can't match it (the entity
+				// falls back to EntityRender's default box, which is off-screen anyway).
+				inst.screenRect = null;
+				continue;
+			}
+
 			// Build the instance world matrix once the type (its ipRow) is known. Entity
-			// positions are [cellX, cellY, height]; roBrowser's world axes are X=cellX,
-			// Y=height (up), Z=cellY — so swap Y/Z into buildWorld's ground-plane frame (the
-			// same swap Camera.update does: _position[1]=pos[2], _position[2]=pos[1]).
+			// positions are [cellX, cellY, position[2]] where position[2] = getCellHeight (a
+			// NEGATED terrain height). roBrowser's world-Y (up) is -position[2] (see the 2D sprite
+			// Project(): `y = -pos.z`), so negate p[2] into buildWorld's up axis — else the
+			// placement error is proportional to the terrain height (flat OK, hills sink/vanish).
 			if (!inst.worldBuilt) {
 				const p = inst.pos;
 				// RO direction is an 8-way index (0-7); the world yaw wants degrees (45 deg/step).
-				inst.world = buildWorld(inst.dir * 45, [p[0], p[2], p[1]], type.ipRow, {
+				inst.world = buildWorld(inst.dir * 45, [p[0], -p[2], p[1]], type.ipRow, {
 					heightOffset: type.groundOffset
 				});
 				inst.worldBuilt = true;
@@ -403,11 +540,50 @@ function render(gl, modelView, projection, normalMat, fog, light, tick) {
 			gl.uniformMatrix3fv(uniform.uNormalMat, false, _nmat);
 			gl.uniformMatrix4fv(uniform.uBones, false, bones);
 
+			// Project the model AABB to a screen-space pick box for EntityManager's hover/click
+			// test. Stashed on the instance (not entity.boundingRect) because Entity.render()
+			// resets that rect after this map pass; EntityRender.calculateBoundingRect copies it.
+			if (inst.entity && type.aabb) {
+				mat4.multiply(_mvp, projection, _mv);
+				const box = inst.screenRect || (inst.screenRect = { x1: 0, y1: 0, x2: 0, y2: 0 });
+				if (!computeScreenRect(type.aabb, _mvp, box)) {
+					inst.screenRect = null;
+				}
+			}
+
+			// Removal fade: honour the entity's current alpha — effectColor[3] scaled by the
+			// remove_tick ramp, the SAME fade a 2D body applies (EntityRender.renderLayer) — so a
+			// GR2 mob/NPC fades out on death/vanish instead of hard-popping. Opaque instances
+			// (alpha 1) stay on the no-blend fast path; only a fading instance flips blend on and
+			// back off (the outer save/restore only guards the BLEND enable bit).
+			let alpha = 1.0;
+			const e = inst.entity;
+			if (e) {
+				alpha = e.effectColor[3];
+				if (e.remove_tick && e.remove_delay) {
+					const isDeath = e.action === e.ACTION.DIE;
+					if (isDeath ? FADE.death : FADE.vanish) {
+						alpha *= 1 - (Date.now() - e.remove_tick) / e.remove_delay;
+					}
+				}
+				alpha = alpha < 0 ? 0 : alpha > 1 ? 1 : alpha;
+			}
+			gl.uniform1f(uniform.uAlpha, alpha);
+			const fading = alpha < 1;
+			if (fading) {
+				gl.enable(gl.BLEND);
+				gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
+			}
+
 			for (let s = 0; s < type.submeshes.length; s++) {
 				const sm = type.submeshes[s];
 				gl.bindTexture(gl.TEXTURE_2D, sm.tex);
 				gl.bindVertexArray(sm.vao);
 				gl.drawElements(gl.TRIANGLES, sm.count, gl.UNSIGNED_SHORT, 0);
+			}
+
+			if (fading) {
+				gl.disable(gl.BLEND);
 			}
 		}
 	});
@@ -416,6 +592,151 @@ function render(gl, modelView, projection, normalMat, fog, light, tick) {
 		gl.enable(gl.BLEND);
 	}
 	_poseCache = seen;
+}
+
+// worldAnchorToClip(pos, modelView, projection, out4): project the instance ground anchor to
+// clip space for the frustum cull. Mirrors buildWorld's frame: world-X = cellX, world-Y (up) =
+// -position[2] (the negated terrain height), world-Z = cellY.
+function worldAnchorToClip(pos, modelView, projection, out) {
+	const x = pos[0];
+	const y = -pos[2];
+	const z = pos[1];
+	const vx = modelView[0] * x + modelView[4] * y + modelView[8] * z + modelView[12];
+	const vy = modelView[1] * x + modelView[5] * y + modelView[9] * z + modelView[13];
+	const vz = modelView[2] * x + modelView[6] * y + modelView[10] * z + modelView[14];
+	const vw = modelView[3] * x + modelView[7] * y + modelView[11] * z + modelView[15];
+	out[0] = projection[0] * vx + projection[4] * vy + projection[8] * vz + projection[12] * vw;
+	out[1] = projection[1] * vx + projection[5] * vy + projection[9] * vz + projection[13] * vw;
+	out[2] = projection[2] * vx + projection[6] * vy + projection[10] * vz + projection[14] * vw;
+	out[3] = projection[3] * vx + projection[7] * vy + projection[11] * vz + projection[15] * vw;
+}
+
+/**
+ * pumpBanks(type, priorityName): per-type sequential loader for the external animation
+ * banks. The current action's bank (priorityName) jumps to the front of the queue; one bank
+ * is fetched at a time and grafted into the shared type.parsed.animations at its action slot
+ * (loaded once for every instance of that type). A 404 drops the name (stays bind pose).
+ */
+function pumpBanks(type, priorityName) {
+	const queue = type.bankQueue;
+
+	// Re-prioritise: the current action's bank jumps the queue ("change la priorité au besoin").
+	if (priorityName) {
+		const at = queue.indexOf(priorityName);
+		if (at > 0) {
+			queue.splice(at, 1);
+			queue.unshift(priorityName);
+		}
+	}
+
+	if (type.bankLoading || queue.length === 0) {
+		return;
+	}
+
+	const name = queue.shift();
+	const entry = type.declaredBanks.find(b => b.name === name);
+	if (!entry) {
+		return;
+	}
+	type.bankLoading = true;
+	type.bankState[name] = 'loading';
+	Client.getFile(
+		entry.path,
+		function (buffer) {
+			type.bankLoading = false;
+			// The type may have been freed during the async fetch.
+			if (_types[type.path] === type && type.parsed) {
+				const bank = parseAnimated(new Uint8Array(buffer));
+				type.parsed.animations[ACTION[name].idx] = bank.animations[0];
+				type.bankState[name] = 'loaded';
+			}
+			pumpBanks(type);
+		},
+		function () {
+			type.bankLoading = false;
+			delete type.bankState[name];
+			pumpBanks(type);
+		}
+	);
+}
+
+// syncFromEntity(inst, type, tick): pull the live entity's pos/dir/action onto the instance
+// each frame. NPC instances (standbyIdx < 0) are never action-driven (static bind pose); MOB
+// instances map their action enum to a GR2 action and priority-load that bank.
+function syncFromEntity(inst, type, tick) {
+	const e = inst.entity;
+	const p = e.position;
+	const dir = e.direction;
+	if (inst.pos[0] !== p[0] || inst.pos[1] !== p[1] || inst.pos[2] !== p[2] || inst.dir !== dir) {
+		inst.pos[0] = p[0];
+		inst.pos[1] = p[1];
+		inst.pos[2] = p[2];
+		inst.dir = dir;
+		inst.worldBuilt = false;
+	}
+
+	if (inst.standbyIdx < 0) {
+		return;
+	}
+
+	const name = gr2ActionFor(e);
+	pumpBanks(type, name);
+	// Re-cut on a name change OR a re-issued action with the same name. The client restarts the
+	// clip on every ZC_NOTIFY_ACT (SetAction = hard clock reset, no same-action dedup); a name-only
+	// guard latched one-shot actions — an immobile plant re-hit stays entity.action=HURT, so the
+	// hurt clip plays once and never replays. The entity bumps animation.tick on every setAction()
+	// (EntityAction), so a changed tick is the faithful "re-issued this frame" signal.
+	const animTick = e.animation.tick;
+	if (name !== inst._lastAction || animTick !== inst._lastTick) {
+		setAction(inst.actor, name, tick);
+		inst.actor.loop = name === 'move';
+		inst._lastAction = name;
+		inst._lastTick = animTick;
+	}
+}
+
+/**
+ * attach(entity): create a GR2 instance bound to a mob/NPC entity. standbyIdx is classified
+ * by objecttype — NPC -> -1 (static poseAt(-1); SetAction never fires) vs MOB -> 0 (animated
+ * idx-0 standby). The renderer pulls pos/dir/action from the entity each frame (syncFromEntity).
+ */
+function attach(entity) {
+	acquire(entity.gr2);
+	const p = entity.position;
+	const isNpc = entity.objecttype === entity.constructor.TYPE_NPC;
+	const inst = {
+		entity: entity,
+		path: entity.gr2,
+		world: null,
+		worldBuilt: false,
+		actor: createActor(),
+		dir: entity.direction,
+		pos: [p[0], p[1], p[2]],
+		standbyIdx: isNpc ? -1 : 0,
+		animIndex: 0,
+		t: 0,
+		_lastAction: 'stand',
+		_lastTick: 0,
+		screenRect: null
+	};
+	_instances.push(inst);
+	return inst;
+}
+
+/**
+ * detach(inst): drop an entity's GR2 instance (called from EntityManager on removal). The type
+ * GL resources stay cached until map unload (free); the type set is bounded, so no leak.
+ */
+function detach(inst) {
+	const idx = _instances.indexOf(inst);
+	if (idx !== -1) {
+		_instances.splice(idx, 1);
+	}
+	const type = _types[inst.path];
+	if (type && type.refcount > 0) {
+		type.refcount--;
+	}
+	inst.entity = null;
 }
 
 /**
@@ -500,7 +821,10 @@ export default {
 	init: init,
 	free: free,
 	render: render,
+	attach: attach,
+	detach: detach,
 	spawn: spawn,
 	spawnMany: spawnMany,
-	clear: clear
+	clear: clear,
+	FADE: FADE
 };

--- a/src/Renderer/GR2/GR2ModelRenderer.js
+++ b/src/Renderer/GR2/GR2ModelRenderer.js
@@ -71,10 +71,26 @@ const _gr2FlagDiffuse = new Float32Array([100 / 255, 100 / 255, 100 / 255]); // 
 const _gr2EmpDiffuse = new Float32Array([128 / 255, 128 / 255, 128 / 255]); // 0.502
 const _gr2EmpAmbient = new Float32Array([127 / 255, 127 / 255, 127 / 255]); // 0.498
 const _gr2FlagAmbient = new Float32Array(3); // scratch: per-frame grayscale of the map ambient
-// Per-model lighting dispatch keys (.gr2 basenames). The guild flag runtime-tints its ambient off
-// the map light; the Emperium set uses the fixed byte-decided grays.
-const GR2_MODEL_GUILDFLAG = 'guildflag90_1';
-const GR2_EMP_MODELS = { empelium90_0: 1, kguardian90_7: 1, aguardian90_8: 1, sguardian90_9: 1, treasurebox_2: 1 };
+// ── Supported GR2 3D roster ──────────────────────────────────────────────────────────────────
+// The complete set of .gr2 models the client renders in 3D, keyed by lowercase basename. This is
+// the single source of truth: it drives BOTH isSupported() (below) and the per-model lighting
+// dispatch in render(). A monster/NPC whose body resolves to a .gr2 NOT listed here (dragon_5,
+// Hugeling90_6, or any future model) has no decode/lighting path, so the Entity layer substitutes
+// a 2D Poring sprite instead of an invisible actor (see EntityView.UpdateBody -> isSupported).
+//
+// To add a model: add ONE line below with its lighting profile. That single edit enrols it in the
+// 3D path (isSupported turns true) AND selects its shading (render() reads the profile value).
+//   'flag' -> ambient runtime-tinted off the map light (guild flag only)
+//   'emp'  -> fixed byte-decided grayscale diffuse/ambient (gr2-lighting-shadow-mars26.md §6)
+//   'map'  -> plain map light (default profile; no model uses it yet)
+const GR2_ROSTER = {
+	guildflag90_1: 'flag', // Guild flag
+	empelium90_0: 'emp', // Emperium
+	kguardian90_7: 'emp', // Knight guardian
+	aguardian90_8: 'emp', // Archer guardian
+	sguardian90_9: 'emp', // Soldier guardian
+	treasurebox_2: 'emp' // Treasure box
+};
 
 // Lowercased .gr2 basename (no dir, no extension) — the per-model lighting key.
 function gr2Basename(path) {
@@ -95,10 +111,20 @@ function grayBroadcast(src, out) {
 let _program = null;
 
 // GL context cached from render() so detach() can free per-instance emblem textures off-frame.
+// Safe to cache: roBrowser uses one persistent WebGL context, _gl is re-assigned every render()
+// (never nulled), and if the context is ever lost the engine pauses rendering (Renderer.onContextLost)
+// -- a deleteTexture on a lost context is a spec no-op and the GPU has already freed everything, so
+// a "stale" _gl can neither crash nor leak. Not a dangling-context hazard.
 let _gl = null;
 
 // Per-type resource cache (key = gr2 path).
 let _types = {};
+
+// Negative cache: gr2 paths that 404'd on fetch (absent from the GRF). Populated in acquire's
+// onError; consumed by isMissing() so the Entity path falls back to a Poring sprite instead of
+// rendering nothing. Session-lifetime on purpose -- a missing model stays missing across maps,
+// so free() deliberately does NOT clear it (no re-request, no re-attempt of the dead 3D path).
+const _missing = {};
 
 // Live instances: { path, world, worldBuilt, actor, dir, pos, standbyIdx, animIndex, t,
 // _lastAction, _lastTick, screenRect, emblemTex, _emblemImg } (+ entity, attached on bind).
@@ -397,11 +423,18 @@ function acquire(path) {
 					type.duration = loader.duration;
 					type.cpuReady = true;
 				} catch (e) {
+					// Decode threw (unexpected/corrupt buffer): same fate as a 404 -- flag missing so the
+					// Entity path reverts to a Poring sprite instead of an invisible actor, and no re-attempt.
+					// A defensive net only; the rostered models are expected to decode cleanly.
+					_missing[path] = true;
 					console.error('[GR2ModelRenderer] decode failed', path, e);
 				}
 			});
 		},
 		function () {
+			// Absent from the GRF -> flag it so the Entity path substitutes a Poring sprite
+			// (see EntityView.UpdateBody / EntityRender.render). No retry: the flag is permanent.
+			_missing[path] = true;
 			console.warn('[GR2ModelRenderer] failed to fetch', path);
 		}
 	);
@@ -728,11 +761,11 @@ function render(gl, modelView, projection, normalMat, fog, light, tick) {
 			// GR2 by a byte-decided grayscale diffuse/ambient, not the map light. Re-issued every
 			// iteration because GL uniforms are stateful — a fixed-constant model must not leak its
 			// diffuse/ambient onto the next instance.
-			const base = gr2Basename(inst.path);
-			if (base === GR2_MODEL_GUILDFLAG) {
+			const profile = GR2_ROSTER[gr2Basename(inst.path)];
+			if (profile === 'flag') {
 				gl.uniform3fv(uniform.uLightDiffuse, _gr2FlagDiffuse);
 				gl.uniform3fv(uniform.uLightAmbient, grayBroadcast(light.ambient || _phaseAmbient, _gr2FlagAmbient));
-			} else if (GR2_EMP_MODELS[base]) {
+			} else if (profile === 'emp') {
 				gl.uniform3fv(uniform.uLightDiffuse, _gr2EmpDiffuse);
 				gl.uniform3fv(uniform.uLightAmbient, _gr2EmpAmbient);
 			} else {
@@ -990,6 +1023,10 @@ function detach(inst) {
 		type.refcount--;
 	}
 	// Free this instance's per-guild emblem texture (the per-type cache is freed at map unload).
+	// Invariant (no leak on early detach): emblemTex is assigned ONLY inside render(), after _gl is
+	// set, and _gl is never nulled -- so emblemTex != null implies _gl != null. A spawn-then-detach
+	// before the first render leaves emblemTex null (nothing allocated), so the guard frees exactly
+	// what was created. The `&& _gl` is defensive, never the reason a real texture is skipped.
 	if (inst.emblemTex && _gl) {
 		_gl.deleteTexture(inst.emblemTex);
 		inst.emblemTex = null;
@@ -1087,6 +1124,16 @@ export default {
 	render: render,
 	attach: attach,
 	detach: detach,
+	// True once a gr2 path has 404'd on fetch or thrown on decode; the Entity path falls back to Poring.
+	isMissing: function (path) {
+		return _missing[path] === true;
+	},
+	// True only for a model in GR2_ROSTER (has a working 3D decode + lighting path). Unsupported .gr2
+	// (dragon_5, Hugeling90_6, future models) return false so the Entity path substitutes a Poring
+	// sprite synchronously -- no I/O, no invisible-actor frame.
+	isSupported: function (path) {
+		return GR2_ROSTER[gr2Basename(path)] !== undefined;
+	},
 	spawn: spawn,
 	spawnMany: spawnMany,
 	clear: clear,

--- a/src/Renderer/GR2/GR2ModelRenderer.js
+++ b/src/Renderer/GR2/GR2ModelRenderer.js
@@ -15,9 +15,9 @@
  *   - Bones: mat4 uBones[48] uniform + one draw per submesh per instance.
  *
  * Wired at the AnimatedModels seam of MapRenderer.onRender, wrapped in
- * SpriteRenderer.runWithDepth(true, true, true). Frustum/distance culling is deferred to the
- * Entity-integration pass (needs the populated EntityManager). Drive it from the /api.html
- * console via window.RO.load('Renderer/GR2/GR2ModelRenderer'): RO.spawn(path, {pos, dir, action}).
+ * SpriteRenderer.runWithDepth(true, true, true). Each instance frustum-culls on its ground anchor
+ * before posing (see frustumCullClip in render()). Drive it from the /api.html console via
+ * window.RO.load('Renderer/GR2/GR2ModelRenderer'): RO.spawn(path, {pos, dir, action}).
  *
  * This file is part of ROBrowser, (http://www.robrowser.com/).
  */
@@ -37,7 +37,8 @@ import {
 	poseCacheKey,
 	quantizePoseTime,
 	gr2ActionFor,
-	frustumCullClip
+	frustumCullClip,
+	POSE_HZ
 } from './gr2Pack.js';
 import { buildWorld, computeGroundOffset } from './gr2World.js';
 import { createActor, setAction, actorPose, ACTION } from './actorAction.js';
@@ -70,7 +71,10 @@ const _gr2FlagDiffuse = new Float32Array([100 / 255, 100 / 255, 100 / 255]); // 
 const _gr2EmpDiffuse = new Float32Array([128 / 255, 128 / 255, 128 / 255]); // 0.502
 const _gr2EmpAmbient = new Float32Array([127 / 255, 127 / 255, 127 / 255]); // 0.498
 const _gr2FlagAmbient = new Float32Array(3); // scratch: per-frame grayscale of the map ambient
-const _gr2EmpSet = { empelium90_0: 1, kguardian90_7: 1, aguardian90_8: 1, sguardian90_9: 1, treasurebox_2: 1 };
+// Per-model lighting dispatch keys (.gr2 basenames). The guild flag runtime-tints its ambient off
+// the map light; the Emperium set uses the fixed byte-decided grays.
+const GR2_MODEL_GUILDFLAG = 'guildflag90_1';
+const GR2_EMP_MODELS = { empelium90_0: 1, kguardian90_7: 1, aguardian90_8: 1, sguardian90_9: 1, treasurebox_2: 1 };
 
 // Lowercased .gr2 basename (no dir, no extension) — the per-model lighting key.
 function gr2Basename(path) {
@@ -96,7 +100,8 @@ let _gl = null;
 // Per-type resource cache (key = gr2 path).
 let _types = {};
 
-// Live instances: { path, world, worldBuilt, actor, dir, pos, standbyIdx, animIndex, t }.
+// Live instances: { path, world, worldBuilt, actor, dir, pos, standbyIdx, animIndex, t,
+// _lastAction, _lastTick, screenRect, emblemTex, _emblemImg } (+ entity, attached on bind).
 let _instances = [];
 
 // Pose cache — set each frame to only the poses used that frame (bounds memory, keeps the
@@ -104,7 +109,7 @@ let _instances = [];
 let _poseCache = {};
 
 // Debug aid: highlight each instance's anchor CELL with a flat tile. The tile marks the cell
-// CENTER (its shader adds +0.5) — the SAME cell centre the model's origin now lands on (flagCore
+// CENTER (its shader adds +0.5) — the SAME cell centre the model's origin now lands on (worldCore
 // adds RB_PLACEMENT_OFS = +0.5), so tile and pole should COINCIDE; a visible offset between them
 // means a placement regression. Toggle from the dev console (`mod.debugCell = true`); off by
 // default, no gameplay effect.
@@ -138,6 +143,12 @@ const _clip = new Float32Array(4);
 // Frustum-cull margin (NDC), padded so a model straddling the screen edge is not clipped
 // by its ground anchor alone.
 const CULL_MARGIN = 0.2;
+
+// Clip-w floor: a projected point with w <= this is on/behind the camera plane, skip it.
+const CLIP_W_EPS = 1e-6;
+
+// RO direction is an 8-way index (0-7); the world yaw wants degrees (45 deg per step).
+const DIR_STEP_DEG = 45;
 
 // Removal-fade toggles — both OFF by default = FAITHFUL. For a genuine 3D (.gr2) actor the
 // official mars26 client instantiates NEITHER the out-of-sight alpha fade NOR the death corpse
@@ -189,9 +200,10 @@ function init(gl) {
 function free(gl) {
 	for (const path in _types) {
 		const type = _types[path];
-		if (type.submeshes) {
-			for (let s = 0; s < type.submeshes.length; s++) {
-				const sm = type.submeshes[s];
+		const submeshes = type.submeshes;
+		if (submeshes) {
+			for (let s = 0; s < submeshes.length; s++) {
+				const sm = submeshes[s];
 				gl.deleteVertexArray(sm.vao);
 				gl.deleteBuffer(sm.vbo);
 				gl.deleteBuffer(sm.ibo);
@@ -235,6 +247,11 @@ function keyGr2Magenta(px) {
 	return out;
 }
 
+// 1x1 fallback pixels. A granny texture that decoded no pixels -> a neutral grey placeholder;
+// a submesh whose texFile matches no embedded texture -> the shared __grey stand-in.
+const TEX_MISSING_PX = new Uint8Array([200, 200, 200, 255]);
+const TEX_GREY_PX = new Uint8Array([180, 180, 185, 255]);
+
 /**
  * makeTypeTextures(gl, parsed) -> { byFile:{ textureFile -> GLTexture } }. One texture per
  * embedded granny texture, keyed by its file name (the string a packed mesh carries in
@@ -260,17 +277,7 @@ function makeTypeTextures(gl, parsed) {
 				keyGr2Magenta(t.pixels)
 			);
 		} else {
-			gl.texImage2D(
-				gl.TEXTURE_2D,
-				0,
-				gl.RGBA,
-				1,
-				1,
-				0,
-				gl.RGBA,
-				gl.UNSIGNED_BYTE,
-				new Uint8Array([200, 200, 200, 255])
-			);
+			gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 1, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, TEX_MISSING_PX);
 		}
 		gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
 		gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
@@ -280,16 +287,18 @@ function makeTypeTextures(gl, parsed) {
 	}
 	const grey = gl.createTexture();
 	gl.bindTexture(gl.TEXTURE_2D, grey);
-	gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 1, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, new Uint8Array([180, 180, 185, 255]));
+	gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 1, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, TEX_GREY_PX);
 	byFile.__grey = grey;
 	gl.bindTexture(gl.TEXTURE_2D, null);
 	return { byFile: byFile };
 }
 
 // A4R4G4B4 4-bit quantize — the client's on-load emblem format (byte-cited fcn.0054e1d0 class-1).
+// Drop each channel to 4 bits then replicate the nibble across the byte (nibble ×0x11: 0..15 -> 0..255).
+const A4_NIBBLE_EXPAND = 0x11;
 function quantize4bit(px) {
 	for (let i = 0; i < px.length; i++) {
-		px[i] = (px[i] >> 4) * 0x11;
+		px[i] = (px[i] >> 4) * A4_NIBBLE_EXPAND;
 	}
 }
 
@@ -378,7 +387,7 @@ function acquire(path) {
 					type.parsed = loader.parsed;
 					type.meshes = loader.meshes;
 					// ipRow BEFORE groundOffset: grounding must run in the model's real draw frame
-					// (v . ipRow . flagCore) — a non-identity IP (treasurebox 90deg rot, guardian Y
+					// (v . ipRow . worldCore) — a non-identity IP (treasurebox 90deg rot, guardian Y
 					// translation) else grounds in the wrong frame and the model floats/sinks/lies flat.
 					type.ipRow = loader.ipRow;
 					type.groundOffset = computeGroundOffset(type.meshes, type.ipRow); // drop the base onto the terrain
@@ -398,9 +407,21 @@ function acquire(path) {
 	return type;
 }
 
+// Interleaved vertex layout — MUST mirror gr2Pack.js packRobrowserInterleave (16 floats/vertex,
+// 64-byte stride): position(3), normal(3), uv(2), boneIndex(4), boneWeight(4). Byte offsets are the
+// float offsets (0/3/6/8/12) x4.
+const GR2_VERTEX_STRIDE = 64;
+const GR2_VERTEX_LAYOUT = [
+	{ attr: 'aPosition', size: 3, offset: 0 },
+	{ attr: 'aNormal', size: 3, offset: 12 },
+	{ attr: 'aTextureCoord', size: 2, offset: 24 },
+	{ attr: 'aBoneIndex', size: 4, offset: 32 },
+	{ attr: 'aBoneWeight', size: 4, offset: 48 }
+];
+
 /**
  * buildTypeGL(gl, type) — upload the type's VBO/IBO/VAO per submesh + textures, once the
- * CPU decode is done. One VAO per submesh, 16-float interleave (stride 64).
+ * CPU decode is done. One VAO per submesh, 16-float interleave (see GR2_VERTEX_LAYOUT).
  */
 function buildTypeGL(gl, type) {
 	type.textures = makeTypeTextures(gl, type.parsed);
@@ -413,17 +434,12 @@ function buildTypeGL(gl, type) {
 		gl.bindBuffer(gl.ARRAY_BUFFER, vbo);
 		gl.bufferData(gl.ARRAY_BUFFER, packRobrowserInterleave(mesh), gl.STATIC_DRAW);
 
-		const stride = 64;
-		gl.enableVertexAttribArray(attr.aPosition);
-		gl.vertexAttribPointer(attr.aPosition, 3, gl.FLOAT, false, stride, 0);
-		gl.enableVertexAttribArray(attr.aNormal);
-		gl.vertexAttribPointer(attr.aNormal, 3, gl.FLOAT, false, stride, 12);
-		gl.enableVertexAttribArray(attr.aTextureCoord);
-		gl.vertexAttribPointer(attr.aTextureCoord, 2, gl.FLOAT, false, stride, 24);
-		gl.enableVertexAttribArray(attr.aBoneIndex);
-		gl.vertexAttribPointer(attr.aBoneIndex, 4, gl.FLOAT, false, stride, 32);
-		gl.enableVertexAttribArray(attr.aBoneWeight);
-		gl.vertexAttribPointer(attr.aBoneWeight, 4, gl.FLOAT, false, stride, 48);
+		for (let a = 0; a < GR2_VERTEX_LAYOUT.length; a++) {
+			const layout = GR2_VERTEX_LAYOUT[a];
+			const loc = attr[layout.attr];
+			gl.enableVertexAttribArray(loc);
+			gl.vertexAttribPointer(loc, layout.size, gl.FLOAT, false, GR2_VERTEX_STRIDE, layout.offset);
+		}
 
 		const ibo = gl.createBuffer();
 		gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, ibo);
@@ -511,7 +527,7 @@ function computeScreenRect(aabb, mvp, out) {
 		const y = i & 2 ? max[1] : min[1];
 		const z = i & 4 ? max[2] : min[2];
 		const cw = mvp[3] * x + mvp[7] * y + mvp[11] * z + mvp[15];
-		if (cw <= 1e-6) {
+		if (cw <= CLIP_W_EPS) {
 			continue;
 		}
 		const inv = 1 / cw;
@@ -552,7 +568,7 @@ function computeScreenRect(aabb, mvp, out) {
  */
 function computeBaseSphereRect(mvp, projection, out) {
 	const cw = mvp[15];
-	if (cw <= 1e-6) {
+	if (cw <= CLIP_W_EPS) {
 		return false;
 	}
 	const inv = 1 / cw;
@@ -677,8 +693,7 @@ function render(gl, modelView, projection, normalMat, fog, light, tick) {
 			// placement error is proportional to the terrain height (flat OK, hills sink/vanish).
 			if (!inst.worldBuilt) {
 				const p = inst.pos;
-				// RO direction is an 8-way index (0-7); the world yaw wants degrees (45 deg/step).
-				inst.world = buildWorld(inst.dir * 45, [p[0], -p[2], p[1]], type.ipRow, {
+				inst.world = buildWorld(inst.dir * DIR_STEP_DEG, [p[0], -p[2], p[1]], type.ipRow, {
 					heightOffset: type.groundOffset
 				});
 				inst.worldBuilt = true;
@@ -686,14 +701,16 @@ function render(gl, modelView, projection, normalMat, fog, light, tick) {
 
 			// Advance the action clock, then resolve/cache the pose at 40 Hz.
 			const pose = actorPose(inst.actor, type, tick, inst.standbyIdx, null);
-			inst.animIndex = pose.animIndex;
-			inst.t = pose.t;
+			const animIndex = pose.animIndex;
+			const t = pose.t;
+			inst.animIndex = animIndex;
+			inst.t = t;
 
-			const key = poseCacheKey(inst.path, pose.animIndex, quantizePoseTime(pose.t));
+			const key = poseCacheKey(inst.path, animIndex, quantizePoseTime(t));
 			let bones = seen[key] || _poseCache[key];
 			if (!bones) {
-				const idx = pose.animIndex < 0 ? -1 : pose.animIndex;
-				const sampleT = pose.animIndex < 0 ? 0 : pose.t;
+				const idx = animIndex < 0 ? -1 : animIndex;
+				const sampleT = animIndex < 0 ? 0 : t;
 				bones = flattenPose(poseAt(type.parsed, idx, sampleT), type.boneCount);
 			}
 			seen[key] = bones;
@@ -711,10 +728,10 @@ function render(gl, modelView, projection, normalMat, fog, light, tick) {
 			// iteration because GL uniforms are stateful — a fixed-constant model must not leak its
 			// diffuse/ambient onto the next instance.
 			const base = gr2Basename(inst.path);
-			if (base === 'guildflag90_1') {
+			if (base === GR2_MODEL_GUILDFLAG) {
 				gl.uniform3fv(uniform.uLightDiffuse, _gr2FlagDiffuse);
 				gl.uniform3fv(uniform.uLightAmbient, grayBroadcast(light.ambient || _phaseAmbient, _gr2FlagAmbient));
-			} else if (_gr2EmpSet[base]) {
+			} else if (GR2_EMP_MODELS[base]) {
 				gl.uniform3fv(uniform.uLightDiffuse, _gr2EmpDiffuse);
 				gl.uniform3fv(uniform.uLightAmbient, _gr2EmpAmbient);
 			} else {
@@ -766,12 +783,21 @@ function render(gl, modelView, projection, normalMat, fog, light, tick) {
 				gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
 			}
 
-			for (let s = 0; s < type.submeshes.length; s++) {
-				const sm = type.submeshes[s];
-				// The emblem submesh (Plane01) binds this instance's live guild emblem; before it is
-				// fetched (or on a dev spawn with no entity) it falls back to the baked emblem.tif from
-				// the .gr2. Every other submesh uses its baked texture.
-				gl.bindTexture(gl.TEXTURE_2D, sm.emblem ? inst.emblemTex || sm.tex : sm.tex);
+			const submeshes = type.submeshes;
+			for (let s = 0; s < submeshes.length; s++) {
+				const sm = submeshes[s];
+				// The emblem submesh (Plane01) stays empty until the live guild emblem loads
+				// (Guild.requestGuildEmblem): skip it when there is no per-instance emblem texture —
+				// a dev spawn with no entity, or a flag whose emblem hasn't arrived. Every other
+				// submesh uses its baked texture.
+				if (sm.emblem) {
+					if (!inst.emblemTex) {
+						continue;
+					}
+					gl.bindTexture(gl.TEXTURE_2D, inst.emblemTex);
+				} else {
+					gl.bindTexture(gl.TEXTURE_2D, sm.tex);
+				}
 				gl.bindVertexArray(sm.vao);
 				gl.drawElements(gl.TRIANGLES, sm.count, gl.UNSIGNED_SHORT, 0);
 			}
@@ -1028,7 +1054,7 @@ function spawnMany(path, n, opts) {
 		// decorrelate: phase-shift each instance by one 40 Hz tick so they land in distinct pose
 		// buckets (realistic non-synchronized load — poseAt count then caps at duration*40, not N).
 		if (o.decorrelate) {
-			inst.actor.startT = -i * 25;
+			inst.actor.startT = -i * (1000 / POSE_HZ);
 		}
 		out.push(inst);
 	}

--- a/src/Renderer/GR2/GR2ModelRenderer.js
+++ b/src/Renderer/GR2/GR2ModelRenderer.js
@@ -58,6 +58,36 @@ const _phaseDiffuse = new Float32Array([128 / 255, 128 / 255, 128 / 255]);
 const _phaseAmbient = new Float32Array([127 / 255, 127 / 255, 127 / 255]);
 const _phaseEnv = new Float32Array([1, 1, 1]);
 
+/**
+ * Byte-decided per-model lighting (gr2-lighting-shadow-mars26.md §6): the client shades each GR2
+ * with a fixed grayscale diffuse/ambient keyed on the model, NOT the map light. Two constant sets
+ * (dispatch is exhaustive — flag vs. everything else). Values ÷255 from the client bytes; the
+ * Emperium set numerically equals the Phase-0 grays but encodes a distinct byte fact, so it is
+ * named on its own. Keyed on the .gr2 basename — dev-spawned instances have no entity, so the
+ * basename is the only universal key.
+ */
+const _gr2FlagDiffuse = new Float32Array([100 / 255, 100 / 255, 100 / 255]); // 0.392
+const _gr2EmpDiffuse = new Float32Array([128 / 255, 128 / 255, 128 / 255]); // 0.502
+const _gr2EmpAmbient = new Float32Array([127 / 255, 127 / 255, 127 / 255]); // 0.498
+const _gr2FlagAmbient = new Float32Array(3); // scratch: per-frame grayscale of the map ambient
+const _gr2EmpSet = { empelium90_0: 1, kguardian90_7: 1, aguardian90_8: 1, sguardian90_9: 1, treasurebox_2: 1 };
+
+// Lowercased .gr2 basename (no dir, no extension) — the per-model lighting key.
+function gr2Basename(path) {
+	const cut = Math.max(path.lastIndexOf('/'), path.lastIndexOf('\\'));
+	const dot = path.lastIndexOf('.');
+	return path.slice(cut + 1, dot > cut ? dot : path.length).toLowerCase();
+}
+
+// Collapse a map-light color to one grayscale scalar (Rec.601 luma), broadcast R=G=B. Stand-in for
+// the flag's runtime scene-global ambient (0xef90f4, no static byte). VISUAL-UNVERIFIED — swap to a
+// flat average if the in-engine A/B wants it flatter.
+function grayBroadcast(src, out) {
+	const g = 0.299 * src[0] + 0.587 * src[1] + 0.114 * src[2];
+	out[0] = out[1] = out[2] = g;
+	return out;
+}
+
 let _program = null;
 
 // Per-type resource cache (key = gr2 path).
@@ -451,15 +481,11 @@ function render(gl, modelView, projection, normalMat, fog, light, tick) {
 
 	// Per-frame constant uniforms.
 	gl.uniformMatrix4fv(uniform.uProjectionMat, false, projection);
-	// Drive the GR2 shade from the map's own light (parity with Models.js / AnimatedModels.js
-	// — the GR2 .fs math is byte-identical). Falls back to the Phase-0 baked grays if a map
-	// somehow omits a field (dev spawn always has light; the render early-returns without it).
-	// Drive the GR2 shade from the map's own light (parity with Models.js / AnimatedModels.js
-	// — the GR2 .fs math is byte-identical). Falls back to the Phase-0 baked grays if a map
-	// omits a field (dev spawn always has light; the render early-returns without it).
+	// Opacity and env tint come from the map's own light (parity with Models.js / AnimatedModels.js
+	// — the GR2 .fs math is byte-identical). uLightDiffuse / uLightAmbient are byte-decided per model
+	// and set inside the instance loop below. Falls back to the Phase-0 baked grays if a map omits a
+	// field (dev spawn always has light; the render early-returns without it).
 	gl.uniform1f(uniform.uLightOpacity, light.opacity != null ? light.opacity : 1.0);
-	gl.uniform3fv(uniform.uLightDiffuse, light.diffuse || _phaseDiffuse);
-	gl.uniform3fv(uniform.uLightAmbient, light.ambient || _phaseAmbient);
 	gl.uniform3fv(uniform.uLightEnv, light.env || _phaseEnv);
 	gl.uniform1f(uniform.uAlphaRef, ALPHA_REF);
 	gl.uniform1i(uniform.uFogUse, fog.use && fog.exist);
@@ -539,6 +565,22 @@ function render(gl, modelView, projection, normalMat, fog, light, tick) {
 			gl.uniformMatrix4fv(uniform.uModelViewMat, false, _mv);
 			gl.uniformMatrix3fv(uniform.uNormalMat, false, _nmat);
 			gl.uniformMatrix4fv(uniform.uBones, false, bones);
+
+			// Per-model lighting constants (gr2-lighting-shadow-mars26.md §6): the client shades each
+			// GR2 by a byte-decided grayscale diffuse/ambient, not the map light. Re-issued every
+			// iteration because GL uniforms are stateful — a fixed-constant model must not leak its
+			// diffuse/ambient onto the next instance.
+			const base = gr2Basename(inst.path);
+			if (base === 'guildflag90_1') {
+				gl.uniform3fv(uniform.uLightDiffuse, _gr2FlagDiffuse);
+				gl.uniform3fv(uniform.uLightAmbient, grayBroadcast(light.ambient || _phaseAmbient, _gr2FlagAmbient));
+			} else if (_gr2EmpSet[base]) {
+				gl.uniform3fv(uniform.uLightDiffuse, _gr2EmpDiffuse);
+				gl.uniform3fv(uniform.uLightAmbient, _gr2EmpAmbient);
+			} else {
+				gl.uniform3fv(uniform.uLightDiffuse, light.diffuse || _phaseDiffuse);
+				gl.uniform3fv(uniform.uLightAmbient, light.ambient || _phaseAmbient);
+			}
 
 			// Project the model AABB to a screen-space pick box for EntityManager's hover/click
 			// test. Stashed on the instance (not entity.boundingRect) because Entity.render()

--- a/src/Renderer/GR2/GR2ModelRenderer.js
+++ b/src/Renderer/GR2/GR2ModelRenderer.js
@@ -28,6 +28,7 @@ import WebGL from 'Utils/WebGL.js';
 import SpriteRenderer from 'Renderer/SpriteRenderer.js';
 import Session from 'Engine/SessionStorage.js';
 import Altitude from 'Renderer/Map/Altitude.js';
+import FlatColorTile from 'Renderer/Effects/FlatColorTile.js';
 import GR2Loader from 'Loaders/GR2Loader.js';
 import { poseAt, parseAnimated } from 'granny-ro-js/wasm';
 import {
@@ -35,7 +36,6 @@ import {
 	flattenPose,
 	poseCacheKey,
 	quantizePoseTime,
-	recenterEmblem,
 	gr2ActionFor,
 	frustumCullClip
 } from './gr2Pack.js';
@@ -99,6 +99,15 @@ let _instances = [];
 // Pose cache — set each frame to only the poses used that frame (bounds memory, keeps the
 // 40 Hz reuse across rAF frames when the quantized bucket is unchanged).
 let _poseCache = {};
+
+// Debug aid: highlight each instance's anchor CELL with a flat tile. The tile marks the cell
+// CENTER (its shader adds +0.5); the model straddles the cell's -0.4 corner, so the offset between
+// tile and pole shows which junction the model sits on (NE/NW diagnosis). Toggle from the dev
+// console (`mod.debugCell = true`); off by default, no gameplay effect.
+const _dbgCellTile = FlatColorTile('gr2_debug_cell', { r: 0.0, g: 1.0, b: 1.0, a: 0.45 });
+const _dbgTileInst = new _dbgCellTile([0, 0, 0]);
+let _dbgCellInited = false;
+let _debugCell = false;
 
 // granny-ro-js WASM init (texture pixel decode); shared across all types.
 let _readyPromise = null;
@@ -251,6 +260,33 @@ function makeTypeTextures(gl, parsed) {
 	gl.bindTexture(gl.TEXTURE_2D, grey);
 	gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 1, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, new Uint8Array([180, 180, 185, 255]));
 	byFile.__grey = grey;
+	// Emblem placeholder — a 24x24 magenta patch painted into the top-left corner of a 32x32 POT
+	// (the real guild emblem is a 24px request rounded up to the next power-of-two; UV 0..1 sample
+	// the whole 32x32 so the emblem reads at the top-left 75% of the quad). The [24..31] border is
+	// left transparent (killed by the shader's hard alpha-test). Stands in for the dynamic guild
+	// emblem (ZC_GUILD_EMBLEM_IMG, wired later); the asymmetric corner also reads out the flag
+	// orientation. NEAREST + CLAMP because a non-mip 32x32 with the default min-filter would be
+	// incomplete/black.
+	const magenta = gl.createTexture();
+	gl.bindTexture(gl.TEXTURE_2D, magenta);
+	const mpx = new Uint8Array(32 * 32 * 4);
+	for (let y = 0; y < 32; y++) {
+		for (let x = 0; x < 32; x++) {
+			if (x < 24 && y < 24) {
+				const o = (y * 32 + x) * 4;
+				mpx[o] = 255;
+				mpx[o + 1] = 0;
+				mpx[o + 2] = 255;
+				mpx[o + 3] = 255;
+			}
+		}
+	}
+	gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 32, 32, 0, gl.RGBA, gl.UNSIGNED_BYTE, mpx);
+	gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+	gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+	gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+	gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+	byFile.__magenta = magenta;
 	gl.bindTexture(gl.TEXTURE_2D, null);
 	return { byFile: byFile };
 }
@@ -304,7 +340,6 @@ function acquire(path) {
 					const loader = new GR2Loader(buffer);
 					type.parsed = loader.parsed;
 					type.meshes = loader.meshes;
-					recenterEmblem(type.meshes); // render-only: centre the off-baked emblem on the banner
 					type.groundOffset = computeGroundOffset(type.meshes); // drop the base onto the terrain
 					type.aabb = computeLocalAABB(type.meshes); // local bounds for the screen-space pick box
 					type.ipRow = loader.ipRow;
@@ -360,7 +395,8 @@ function buildTypeGL(gl, type) {
 			vbo: vbo,
 			ibo: ibo,
 			count: mesh.indices.length,
-			tex: type.textures.byFile[mesh.texFile] || type.textures.byFile.__grey
+			tex: type.textures.byFile[mesh.texFile] || type.textures.byFile.__grey,
+			emblem: mesh.emblem // route the emblem submesh (Plane01) to the placeholder texture
 		};
 	});
 	type.glReady = true;
@@ -619,7 +655,9 @@ function render(gl, modelView, projection, normalMat, fog, light, tick) {
 
 			for (let s = 0; s < type.submeshes.length; s++) {
 				const sm = type.submeshes[s];
-				gl.bindTexture(gl.TEXTURE_2D, sm.tex);
+				// The emblem submesh (Plane01) draws the magenta placeholder until the dynamic guild
+				// emblem is wired; every other submesh uses its baked texture.
+				gl.bindTexture(gl.TEXTURE_2D, sm.emblem ? type.textures.byFile.__magenta : sm.tex);
 				gl.bindVertexArray(sm.vao);
 				gl.drawElements(gl.TRIANGLES, sm.count, gl.UNSIGNED_SHORT, 0);
 			}
@@ -634,6 +672,31 @@ function render(gl, modelView, projection, normalMat, fog, light, tick) {
 		gl.enable(gl.BLEND);
 	}
 	_poseCache = seen;
+
+	// Debug: paint the anchor cell of every instance (see _debugCell above).
+	if (_debugCell && _instances.length) {
+		if (!_dbgCellInited) {
+			_dbgCellTile.init(gl);
+			_dbgCellInited = true;
+		}
+		const dbgBlendWasEnabled = gl.isEnabled(gl.BLEND);
+		gl.enable(gl.BLEND);
+		gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
+		_dbgCellTile.beforeRender(gl, modelView, projection, fog, tick);
+		for (let i = 0; i < _instances.length; i++) {
+			const inst = _instances[i];
+			const type = _types[inst.path];
+			if (!type || !type.glReady) {
+				continue;
+			}
+			_dbgTileInst.position = inst.pos;
+			_dbgTileInst.render(gl, tick);
+		}
+		_dbgCellTile.afterRender(gl);
+		if (!dbgBlendWasEnabled) {
+			gl.disable(gl.BLEND);
+		}
+	}
 }
 
 // worldAnchorToClip(pos, modelView, projection, out4): project the instance ground anchor to
@@ -868,5 +931,12 @@ export default {
 	spawn: spawn,
 	spawnMany: spawnMany,
 	clear: clear,
-	FADE: FADE
+	FADE: FADE,
+	// Debug: highlight each instance's anchor cell (see _debugCell). Toggle from the dev console.
+	get debugCell() {
+		return _debugCell;
+	},
+	set debugCell(v) {
+		_debugCell = !!v;
+	}
 };

--- a/src/Renderer/GR2/GR2ModelRenderer.js
+++ b/src/Renderer/GR2/GR2ModelRenderer.js
@@ -335,6 +335,10 @@ function quantize4bit(px) {
 	}
 }
 
+// Module-scope scratch canvas reused across emblem uploads (guild/version changes are frequent);
+// created lazily and re-cleared per call by re-setting its size, so no per-change allocation.
+let _emblemCanvas = null;
+
 /**
  * buildEmblemTexture(gl, img, prevTex) — the live per-guild emblem, POT-padded the way the client
  * does it. The client requests the emblem 24x24 then rounds it up to the next power-of-two
@@ -349,7 +353,8 @@ function quantize4bit(px) {
 function buildEmblemTexture(gl, img, prevTex) {
 	const POT = 32,
 		SRC = 24;
-	const cv = document.createElement('canvas');
+	const cv = _emblemCanvas || (_emblemCanvas = document.createElement('canvas'));
+	// Re-setting the size clears the canvas so a smaller/transparent emblem never leaks prior pixels.
 	cv.width = POT;
 	cv.height = POT;
 	const ctx = cv.getContext('2d', { willReadFrequently: true });

--- a/src/Renderer/GR2/actorAction.js
+++ b/src/Renderer/GR2/actorAction.js
@@ -1,0 +1,109 @@
+/**
+ * Renderer/GR2/actorAction.js
+ *
+ * The C3dGrannyGameActor ACTION state machine — SetAction (fcn.00b2c180) + the
+ * per-frame driver (fcn.00b2a1b0 -> fcn.00b2a0a0 / fcn.00689a10), transcribed 1:1.
+ * Full byte-cite: re-ro-clients-asm/ragexe-mars26/pipelines/gr2-mob-action-mechanic-mars26.md.
+ *
+ * THE MODEL CLOCK IS ACTION-RELATIVE. SetAction is a hard cut: it resets the model
+ * clock to 0, so EVERY action — including the return to standby — restarts its clip at
+ * t=0. A missing animation bank yields the BIND pose (animIndex -1), not a held frame.
+ *
+ * Pure (no WebGL, no wasm) so the headless unit tests drive the transitions directly.
+ *
+ * This file is part of ROBrowser, (http://www.robrowser.com/).
+ */
+
+/**
+ * actionType -> anim index (fcn.00b2c180.c:21-53) + name (fcn.00977090).
+ */
+export const ACTION = {
+	stand: { type: 0x00, idx: 0, name: 'ST_STAND' },
+	move: { type: 0x08, idx: 1, name: 'ST_MOVE' },
+	attack: { type: 0x50, idx: 2, name: 'ST_ATTACK' },
+	dead: { type: 0x40, idx: 3, name: 'ST_DEAD' },
+	damage: { type: 0x30, idx: 4, name: 'ST_DAMAGE' }
+};
+
+/**
+ * createActor() -> a fresh actor in the standby state.
+ */
+export function createActor() {
+	return { name: 'stand', startT: 0, loop: false };
+}
+
+/**
+ * setAction(actor, name, tNow) — the hard cut: reset the action clock (fcn.00b2c180.c:63
+ * +0x514=0) and clear the loop latch. A caller that wants the clip to loop (a mob re-driven
+ * each movement tick) re-arms actor.loop after.
+ */
+export function setAction(actor, name, tNow) {
+	if (!ACTION[name]) {
+		return;
+	}
+	actor.name = name;
+	actor.startT = tNow;
+	actor.loop = false;
+}
+
+/**
+ * actorPose(actor, model, tNow, standbyIdx, frozenT) -> { animIndex, t }, evaluated EVERY
+ * frame (standby included) so the clip clock is action-relative. standbyIdx = the model's
+ * standby clip (registry animIndex; -1 = the NPC bind pose). frozenT (seconds) freezes the
+ * standby scrub for manual A/B; pass null to run. Mutates actor on revert.
+ */
+export function actorPose(actor, model, tNow, standbyIdx, frozenT) {
+	const anims = (model.parsed && model.parsed.animations) || [];
+	const elapsed = (tNow - actor.startT) / 1000;
+
+	if (actor.name === 'stand') {
+		if (standbyIdx < 0) {
+			return { animIndex: -1, t: 0 };
+		}
+		const standbyDur = anims[standbyIdx] ? anims[standbyIdx].duration || 1 : 1;
+		return { animIndex: standbyIdx, t: (frozenT != null ? frozenT : elapsed) % standbyDur };
+	}
+
+	const a = ACTION[actor.name];
+	const present = anims[a.idx] != null;
+
+	if (actor.name === 'attack') {
+		// The ONLY action with a per-frame auto-revert (fcn.00b2a1b0.c:53, gated on +0x52c==2).
+		if (!present) {
+			return { animIndex: -1, t: 0 };
+		}
+		const dur = anims[a.idx].duration || 1;
+		if (elapsed >= dur) {
+			setAction(actor, 'stand', tNow);
+			return actorPose(actor, model, tNow, standbyIdx, frozenT);
+		}
+		return { animIndex: a.idx, t: elapsed };
+	}
+
+	if (actor.name === 'dead') {
+		// Holds its last frame; the unit is removed by the 0x80 CLR_DEAD vanish, not returned.
+		if (!present) {
+			return { animIndex: -1, t: 0 };
+		}
+		const dur = anims[a.idx].duration || 1;
+		return { animIndex: a.idx, t: Math.min(elapsed, dur) };
+	}
+
+	// damage / move: no per-frame auto-revert (the +0x9d flag is AI-can-act-again, not clip
+	// visibility). A missing bank hard-cuts to standby.
+	if (!present) {
+		setAction(actor, 'stand', tNow);
+		return { animIndex: -1, t: 0 };
+	}
+	const durDM = anims[a.idx].duration || 1;
+	// actor.loop = a continuously-driven MOVE (SetAction(MOVE) re-issued each movement tick):
+	// scrub modulo duration and never auto-revert — the caller ends it with setAction('stand').
+	if (actor.loop) {
+		return { animIndex: a.idx, t: elapsed % durDM };
+	}
+	if (elapsed >= durDM) {
+		setAction(actor, 'stand', tNow);
+		return actorPose(actor, model, tNow, standbyIdx, frozenT);
+	}
+	return { animIndex: a.idx, t: elapsed };
+}

--- a/src/Renderer/GR2/gr2Banks.js
+++ b/src/Renderer/GR2/gr2Banks.js
@@ -1,0 +1,44 @@
+/**
+ * Renderer/GR2/gr2Banks.js
+ *
+ * Per-model external animation bank registry (port of the sandbox models.js
+ * `banks` field). The main data/model/3dmob/<name>90_<N>.gr2 carries the mesh +
+ * embedded standby (anim 0) only; move/attack/dead/damage live in separate bank
+ * files data/model/3dmob_bone/<setId>_<suffix>.gr2 (client fcn.00683e40; setId
+ * from fcn.006800d0). A model that does not declare a bank (Emperium dead/damage,
+ * Treasure Box move/attack) correctly falls to the bind pose on that action.
+ *
+ * Pure (no GL / IO) so the headless unit tests exercise it directly.
+ *
+ * This file is part of ROBrowser, (http://www.robrowser.com/).
+ */
+
+/**
+ * setId -> the external bank suffixes that model ships. setId is the integer <N>
+ * suffix of the model filename (guildflag90_1 -> 1, treasurebox_2 -> 2,
+ * empelium90_0 -> 0, sguardian90_9 -> 9). Sourced from the sandbox models.js oracle:
+ * guardians (7/8/9) ship all four, treasure box (2) ships {dead,damage}, emperium (0)
+ * and flag (1) ship none (embedded standby only).
+ */
+const GR2_BANKS = {
+	2: ['dead', 'damage'], // treasurebox
+	7: ['attack', 'damage', 'dead', 'move'], // kguardian
+	8: ['attack', 'damage', 'dead', 'move'], // aguardian
+	9: ['attack', 'damage', 'dead', 'move'] // sguardian
+	// 0 emperium, 1 flag -> none (embedded standby only)
+};
+
+/**
+ * bankPathsFor(path) -> [{ name, path }] : the declared external bank files for a
+ * model, given its main .gr2 path. Empty when the model ships no external banks.
+ * @param {string} path e.g. 'data/model/3dmob/sguardian90_9.gr2'
+ */
+export function bankPathsFor(path) {
+	const match = path.match(/_(\d+)\.gr2$/i);
+	const setId = match ? match[1] : null;
+	const names = (setId != null && GR2_BANKS[setId]) || [];
+	return names.map(name => ({
+		name: name,
+		path: 'data/model/3dmob_bone/' + setId + '_' + name + '.gr2'
+	}));
+}

--- a/src/Renderer/GR2/gr2Banks.js
+++ b/src/Renderer/GR2/gr2Banks.js
@@ -20,11 +20,13 @@
  * guardians (7/8/9) ship all four, treasure box (2) ships {dead,damage}, emperium (0)
  * and flag (1) ship none (embedded standby only).
  */
+// Keys are strings: setId is captured as a string from the filename regex below, so the
+// lookup GR2_BANKS[setId] matches on the string key directly (no JS numeric-key coercion).
 const GR2_BANKS = {
-	2: ['dead', 'damage'], // treasurebox
-	7: ['attack', 'damage', 'dead', 'move'], // kguardian
-	8: ['attack', 'damage', 'dead', 'move'], // aguardian
-	9: ['attack', 'damage', 'dead', 'move'] // sguardian
+	'2': ['dead', 'damage'], // treasurebox
+	'7': ['attack', 'damage', 'dead', 'move'], // kguardian
+	'8': ['attack', 'damage', 'dead', 'move'], // aguardian
+	'9': ['attack', 'damage', 'dead', 'move'] // sguardian
 	// 0 emperium, 1 flag -> none (embedded standby only)
 };
 

--- a/src/Renderer/GR2/gr2Math.js
+++ b/src/Renderer/GR2/gr2Math.js
@@ -1,0 +1,28 @@
+/**
+ * Renderer/GR2/gr2Math.js
+ *
+ * D3D row-vector 4x4 matrix helpers (convention v' = v.M) shared by the GR2 world-matrix
+ * builder (gr2World.js) and the loader's InitialPlacement decode (GR2Loader.js). granny-ro-js
+ * hands geometry back row-major, so the whole GR2 chain is built row-vector and handed to
+ * GL / gl-matrix as-is (see gr2World.js MATRIX CONVENTION).
+ *
+ * This file is part of ROBrowser, (http://www.robrowser.com/).
+ */
+
+export const IDENTITY_ROW = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+
+export function mul(a, b) {
+	const o = new Array(16);
+	for (let r = 0; r < 4; r++) {
+		for (let c = 0; c < 4; c++) {
+			let s = 0;
+			for (let k = 0; k < 4; k++) {
+				s += a[r * 4 + k] * b[k * 4 + c];
+			}
+			o[r * 4 + c] = s;
+		}
+	}
+	return o;
+}
+
+export const trans = (x, y, z) => [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, x, y, z, 1];

--- a/src/Renderer/GR2/gr2Pack.js
+++ b/src/Renderer/GR2/gr2Pack.js
@@ -1,0 +1,141 @@
+/**
+ * Renderer/GR2/gr2Pack.js
+ *
+ * Pure (no WebGL, no wasm) helpers for the GR2 GPU-skin renderer: the roBrowser
+ * vertex interleave, pose flattening, and the 40 Hz pose-cache key. Kept free of
+ * GL / granny-ro-js imports so the headless unit tests can exercise them directly.
+ *
+ * This file is part of ROBrowser, (http://www.robrowser.com/).
+ */
+
+/**
+ * Rag tick rate — poses are recomputed on the 40 Hz game tick, not per rAF, so
+ * same-type / same-phase mobs collapse to a single poseAt per bucket.
+ */
+export const POSE_HZ = 40;
+
+/**
+ * Max bones a GR2 skeleton may carry (mat4 uBones[48] in GR2Model.vs). The verified
+ * guildflag is 41; the client's 3dmob actors stay well under this.
+ */
+export const BONE_CAP = 48;
+
+/**
+ * packRobrowserInterleave(mesh) -> Float32Array(vcount * 16): roBrowser's model
+ * vertex layout with the grafted GPU-skin attributes. Positions come from the
+ * BIND pose (the vertex shader re-poses them from uBones).
+ *
+ *   aPosition@0(3) . aNormal@3(3) . aTextureCoord@6(2) . aBoneIndex@8(4) . aBoneWeight@12(4)
+ *   = 16 floats/vert, stride 64 bytes.
+ */
+export function packRobrowserInterleave(mesh) {
+	const n = mesh.vcount;
+	const buf = new Float32Array(n * 16);
+	for (let i = 0; i < n; i++) {
+		const o = i * 16;
+		buf[o] = mesh.bind[i * 3];
+		buf[o + 1] = mesh.bind[i * 3 + 1];
+		buf[o + 2] = mesh.bind[i * 3 + 2];
+		buf[o + 3] = mesh.nrm[i * 3];
+		buf[o + 4] = mesh.nrm[i * 3 + 1];
+		buf[o + 5] = mesh.nrm[i * 3 + 2];
+		buf[o + 6] = mesh.uv[i * 2];
+		buf[o + 7] = mesh.uv[i * 2 + 1];
+		buf[o + 8] = mesh.bidx[i * 4];
+		buf[o + 9] = mesh.bidx[i * 4 + 1];
+		buf[o + 10] = mesh.bidx[i * 4 + 2];
+		buf[o + 11] = mesh.bidx[i * 4 + 3];
+		buf[o + 12] = mesh.bw[i * 4];
+		buf[o + 13] = mesh.bw[i * 4 + 1];
+		buf[o + 14] = mesh.bw[i * 4 + 2];
+		buf[o + 15] = mesh.bw[i * 4 + 3];
+	}
+	return buf;
+}
+
+/**
+ * flattenPose(pose, boneCount) -> Float32Array(boneCount * 16): the granny skinning
+ * matrices laid out contiguously for the uBones uniform array (column-major per bone).
+ */
+export function flattenPose(pose, boneCount) {
+	const s = new Float32Array(boneCount * 16);
+	for (let i = 0; i < boneCount; i++) {
+		s.set(pose.skinningMatrices[i], i * 16);
+	}
+	return s;
+}
+
+/**
+ * identityPose(boneCount) -> Float32Array of identity mat4s (the undeformed bind pose).
+ */
+export function identityPose(boneCount) {
+	const s = new Float32Array(boneCount * 16);
+	for (let i = 0; i < boneCount; i++) {
+		const o = i * 16;
+		s[o] = s[o + 5] = s[o + 10] = s[o + 15] = 1;
+	}
+	return s;
+}
+
+/**
+ * recenterEmblem(meshes) — RENDER-only fix: guildflag90_1.gr2 bakes the emblem submesh (Plane01)
+ * ~+1.5u off the banner centre in X, but the client renders it centred (2008 + modern, verified).
+ * The granny deform alone doesn't move it (skinning == the DLL oracle), so we recentre Plane01 on
+ * the banner in the bind positions before upload. Mutates the emblem's bind array; returns the dx
+ * applied (0 when there is no emblem/banner pair). granny Z = up.
+ */
+export function recenterEmblem(meshes) {
+	const emblem = meshes.find(m => m.emblem);
+	const banner = meshes.find(m => !m.emblem && m.vcount > 50);
+	if (!emblem || !banner) {
+		return 0;
+	}
+	let ex = 0;
+	let zmin = Infinity;
+	let zmax = -Infinity;
+	for (let i = 0; i < emblem.vcount; i++) {
+		ex += emblem.bind[i * 3];
+		const z = emblem.bind[i * 3 + 2];
+		if (z < zmin) {
+			zmin = z;
+		}
+		if (z > zmax) {
+			zmax = z;
+		}
+	}
+	ex /= emblem.vcount;
+	let bx = 0;
+	let bc = 0;
+	for (let i = 0; i < banner.vcount; i++) {
+		const z = banner.bind[i * 3 + 2];
+		if (z >= zmin - 1 && z <= zmax + 1) {
+			bx += banner.bind[i * 3];
+			bc++;
+		}
+	}
+	if (!bc) {
+		return 0;
+	}
+	const dx = bx / bc - ex;
+	for (let i = 0; i < emblem.vcount; i++) {
+		emblem.bind[i * 3] += dx;
+	}
+	return dx;
+}
+
+/**
+ * quantizePoseTime(t, hz) -> integer bucket index at hz (default 40 Hz). Near-equal
+ * clip times inside one 1/40 s bucket collapse to the same bucket, so the pose cache
+ * computes one poseAt per (type, anim, bucket).
+ */
+export function quantizePoseTime(t, hz) {
+	return Math.round(t * (hz || POSE_HZ));
+}
+
+/**
+ * poseCacheKey(path, animIndex, quant) -> cache key for a posed skeleton. Distinct
+ * gr2 path, anim index, or time bucket never collide.
+ */
+export function poseCacheKey(path, animIndex, quant) {
+	return path + '|' + animIndex + '|' + quant;
+}

--- a/src/Renderer/GR2/gr2Pack.js
+++ b/src/Renderer/GR2/gr2Pack.js
@@ -78,52 +78,6 @@ export function identityPose(boneCount) {
 }
 
 /**
- * recenterEmblem(meshes) — RENDER-only fix: guildflag90_1.gr2 bakes the emblem submesh (Plane01)
- * ~+1.5u off the banner centre in X, but the client renders it centred (2008 + modern, verified).
- * The granny deform alone doesn't move it (skinning == the DLL oracle), so we recentre Plane01 on
- * the banner in the bind positions before upload. Mutates the emblem's bind array; returns the dx
- * applied (0 when there is no emblem/banner pair). granny Z = up.
- */
-export function recenterEmblem(meshes) {
-	const emblem = meshes.find(m => m.emblem);
-	const banner = meshes.find(m => !m.emblem && m.vcount > 50);
-	if (!emblem || !banner) {
-		return 0;
-	}
-	let ex = 0;
-	let zmin = Infinity;
-	let zmax = -Infinity;
-	for (let i = 0; i < emblem.vcount; i++) {
-		ex += emblem.bind[i * 3];
-		const z = emblem.bind[i * 3 + 2];
-		if (z < zmin) {
-			zmin = z;
-		}
-		if (z > zmax) {
-			zmax = z;
-		}
-	}
-	ex /= emblem.vcount;
-	let bx = 0;
-	let bc = 0;
-	for (let i = 0; i < banner.vcount; i++) {
-		const z = banner.bind[i * 3 + 2];
-		if (z >= zmin - 1 && z <= zmax + 1) {
-			bx += banner.bind[i * 3];
-			bc++;
-		}
-	}
-	if (!bc) {
-		return 0;
-	}
-	const dx = bx / bc - ex;
-	for (let i = 0; i < emblem.vcount; i++) {
-		emblem.bind[i * 3] += dx;
-	}
-	return dx;
-}
-
-/**
  * quantizePoseTime(t, hz) -> integer bucket index at hz (default 40 Hz). Near-equal
  * clip times inside one 1/40 s bucket collapse to the same bucket, so the pose cache
  * computes one poseAt per (type, anim, bucket).

--- a/src/Renderer/GR2/gr2Pack.js
+++ b/src/Renderer/GR2/gr2Pack.js
@@ -139,3 +139,38 @@ export function quantizePoseTime(t, hz) {
 export function poseCacheKey(path, animIndex, quant) {
 	return path + '|' + animIndex + '|' + quant;
 }
+
+/**
+ * gr2ActionFor(entity) -> the GR2 action name for a mob entity's CURRENT action, read
+ * SEMANTICALLY via the entity's own ACTION enum (correct for MOB and NPC). Idle / state-0 /
+ * any unmapped action -> 'stand' (animated idx-0 standby; a missing bank falls to poseAt(-1)).
+ */
+export function gr2ActionFor(entity) {
+	const A = entity.ACTION;
+	const a = entity.action;
+	if (a === A.DIE) {
+		return 'dead';
+	}
+	if (a === A.HURT) {
+		return 'damage';
+	}
+	if (a === A.ATTACK || a === A.ATTACK1 || a === A.ATTACK2 || a === A.ATTACK3) {
+		return 'attack';
+	}
+	if (a === A.WALK) {
+		return 'move';
+	}
+	return 'stand';
+}
+
+/**
+ * frustumCullClip(x, y, w, margin) -> true when a clip-space point is off-screen (cull):
+ * behind the camera (w <= 0) or beyond the padded [-1,1] NDC box on x/y.
+ */
+export function frustumCullClip(x, y, w, margin) {
+	if (w <= 0) {
+		return true;
+	}
+	const m = (1 + margin) * w;
+	return x < -m || x > m || y < -m || y > m;
+}

--- a/src/Renderer/GR2/gr2World.js
+++ b/src/Renderer/GR2/gr2World.js
@@ -23,10 +23,12 @@
  * extra transpose. Do NOT transpose the output.
  *
  * /5 REFERENTIAL (build-7). roBrowser lands the RO world at /5 (World/Altitude/Ground
- * divide position + scale + heights by 5). The GR2 geometry and its cell-straddle scale
- * by RB_UNIT_SCALE (0.2 = 1.0u / 5.0u) so the model reads 1.0-cell-sized; the world
- * POSITION is left in the caller's referential (co-located with the /5 ground). See
- * re-ro-clients-asm/sandbox/CORRESPONDENCE.md (build-7).
+ * divide position + scale + heights by 5). The GR2 geometry scales by RB_UNIT_SCALE
+ * (0.2 = 1.0u / 5.0u) so the model reads 1.0-cell-sized; the world POSITION is left in the
+ * caller's referential (co-located with the /5 ground) plus a +0.5 cell-CENTRE offset — the
+ * roBrowser convention every 2D visual uses to reach the cell middle from the raw corner (see
+ * RB_PLACEMENT_OFS). The model origin lands on the cell centre, co-located with roBrowser's 2D
+ * sprite/shadow. See re-ro-clients-asm/sandbox/CORRESPONDENCE.md (build-7).
  *
  * YAW. `((dir + 180) / 180) * pi` — the +180 is asm-cited (mars26 fcn.00b2ad20.asm:160
  * addss 180.0 / ver12 fcn.00408b70). The sandbox leaves the offset vs roBrowser's own
@@ -41,8 +43,34 @@
 /** Geometry scale under the /5 referential (0.2 = 1.0u / 5.0u). */
 export const RB_UNIT_SCALE = 0.2;
 
-/** Cell-straddle offset on X,Z, scaled with the geometry (0.2 * -2.0). */
-export const RB_PLACEMENT_OFS = -0.4;
+/**
+ * Horizontal cell offset on X,Z. +0.5 = the CELL CENTRE — where every roBrowser 2D visual lands.
+ * A raw integer entity position (x,y) is the cell CORNER; roBrowser reaches the cell middle by
+ * adding +0.5: the sprite body + shadow in SpriteRenderer.vs ("xyz = x(-z)y + middle of cell
+ * (0.5)"), Altitude.getCellHeight ("middle of the cell", +0.5), and the name/HP overlay
+ * (EntityRender.js:93-95, position+0.5). The GR2 draw path bypasses SpriteRenderer.vs, so it must
+ * add the +0.5 itself — otherwise the model sits half a cell off (on the corner) from the 2D
+ * shadow it is read against and from the GridSelector cell quad ([x,x+1]x[y,y+1], centre
+ * (x+0.5,y+0.5)). The flag mesh is centred at model X=0/Y=0, so +0.5
+ * drops its central pillar on the cell centre.
+ *
+ * NOT the old -0.4 straddle: that was 0.2*-2.0 from the -2.0 (0xe316c8) in the DEAD CGrannyPc
+ * draw fcn.00c03e10. The live flag draw C3dGrannyGameActor fcn.00b2ad20 reads a RAW origin
+ * [esi+0x10] -> PostMultTranslate with no draw-time offset — but that origin is ITSELF the cell
+ * CENTRE: the client anchors actors at the cell middle (confirmed against the official client
+ * reference shot — the flag sits centred on its cell) and bakes the half-cell (+2.5 world = +0.5
+ * cell) into the stored world position at cell->world conversion time. That is why the offset
+ * surfaces at NO client consumer: the draw feeds the origin raw, the 2D sprite projector
+ * (fcn.00539820/fcn.00539650) reads it raw, and the ground sampler fcn.0042c700 interpolates
+ * height by the raw sub-cell fraction (0x42c7a0) and adds no +0.5 of its own — the fraction is
+ * already 0.5. roBrowser takes the mirror approach: it stores the raw integer corner and adds
+ * +0.5 at each consumer (SpriteRenderer.vs, Altitude.getCellHeight, EntityRender overlay, and here).
+ * Same cell centre, offset applied at a different pipeline stage — so +0.5 faithfully reproduces
+ * the client's centre anchor, it is not merely a roBrowser-internal convention. (The exact +2.5
+ * immediate inside the client's cell->world conversion is a documented reverse-engineering stall:
+ * the setter is unreachable statically from both the packet dispatcher and the actor factory.)
+ */
+export const RB_PLACEMENT_OFS = 0.5;
 
 const IDENTITY_ROW = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
 
@@ -77,7 +105,7 @@ const _trans = (x, y, z) => [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, x, y, z, 1];
 
 /**
  * flagCore(dir, pos) -> the reflection-free world core Rx(rxSign*pi/2) . Ry(yaw) . S . T
- * at the /5 referential (geometry x0.2, straddle -0.4). Position is fed unchanged.
+ * at the /5 referential (geometry x0.2, +0.5 cell-centre offset). Position is fed unchanged.
  */
 export function flagCore(dir, pos, opts) {
 	const o = opts || {};
@@ -95,14 +123,19 @@ export function flagCore(dir, pos, opts) {
 }
 
 /**
- * computeGroundOffset(meshes, opts) -> the heightOffset that puts the model's base flush on the
- * terrain. roBrowser's render inverts world Y on screen (proven on the live map: a model placed at
- * world Y ABOVE the ground draws BELOW it / occluded), so the base — the part that must touch the
+ * computeGroundOffset(meshes, ipRow, opts) -> the heightOffset that puts the model's base flush on
+ * the terrain. roBrowser's render inverts world Y on screen (proven on the live map: a model placed
+ * at world Y ABOVE the ground draws BELOW it / occluded), so the base — the part that must touch the
  * ground line — is the world-Y MAX vertex. We ground that: no vertex ends up above the ground's
  * world Y, so nothing renders under the terrain. Yaw-independent (uses the world matrix's Y-row).
+ *
+ * The model's granny InitialPlacement (ipRow) MUST be threaded here so grounding runs in the SAME
+ * frame the draw uses (`v . ipRow . flagCore`). A non-identity IP (e.g. the treasurebox's 90 deg X
+ * rotation, or the guardians' Y translation) reorients/shifts the mesh; grounding with a null IP
+ * would compute the base in the wrong frame and the model floats / sinks / lies flat on the ground.
  */
-export function computeGroundOffset(meshes, opts) {
-	const m = buildWorld(0, [0, 0, 0], null, opts);
+export function computeGroundOffset(meshes, ipRow, opts) {
+	const m = buildWorld(0, [0, 0, 0], ipRow, opts);
 	const a = m[1];
 	const b = m[5];
 	const c = m[9];

--- a/src/Renderer/GR2/gr2World.js
+++ b/src/Renderer/GR2/gr2World.js
@@ -4,9 +4,16 @@
  * The GR2 world matrix — port of the sandbox `gr2BuilderRobrowser` (draw path
  * reconciled to roBrowser's /5 referential). Byte-cited from the client 3dmob draw
  * path (mars26 fcn.00b2ad20 / ver12 fcn.00567e70): Rx(+pi/2) . Ry((dir+180)) . S . T,
- * with the granny-RH -> render-LH X reflection (flipX) and the model's own granny
- * InitialPlacement (ipRow) applied innermost. (The sandbox used Rx(-pi/2) for its folded
- * camera; roBrowser's standard Y-up camera needs the faithful +pi/2 — see flagCore.)
+ * with the model's own granny InitialPlacement (ipRow) applied innermost.
+ *
+ * HANDEDNESS. There is deliberately NO model-space X reflection here. A granny-RH
+ * model reaches the screen correctly through exactly ONE reflection: either a Y-up
+ * camera with an in-model flipX . Rx(-pi/2), OR a Y-INVERTING camera with a clean
+ * Rx(+pi/2) and no flipX — the two are equivalent, and stacking both mirrors the
+ * model. roBrowser's camera already inverts world Y on screen (see computeGroundOffset
+ * below / Camera.js "inversed Y-Z axis"), so that inversion IS the RH->LH bridge and
+ * the world matrix stays a clean, reflection-free Rx . Ry . S . T (det +1). (The
+ * sandbox, which keeps a plain Y-up camera, carries the flipX in-model instead.)
  *
  * MATRIX CONVENTION. The chain is built row-vector (D3D, v' = v.M) with the local
  * `_mul` helper, then the flat array is handed to GL / gl-matrix as-is. A row-major
@@ -39,9 +46,6 @@ export const RB_PLACEMENT_OFS = -0.4;
 
 const IDENTITY_ROW = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
 
-// Model-space X reflection (row-vector) — the granny-RH -> render-LH handedness bridge.
-const FLIP_X = [-1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
-
 // Row-vector 4x4 helpers (D3D convention v' = v.M).
 function _mul(a, b) {
 	const o = new Array(16);
@@ -72,14 +76,15 @@ const _scale = s => [s, 0, 0, 0, 0, s, 0, 0, 0, 0, s, 0, 0, 0, 0, 1];
 const _trans = (x, y, z) => [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, x, y, z, 1];
 
 /**
- * flagCore(dir, pos) -> the flip-free world core Rx(-pi/2) . Ry(yaw) . S . T at the
- * /5 referential (geometry x0.2, straddle -0.4). Position is fed unchanged.
+ * flagCore(dir, pos) -> the reflection-free world core Rx(rxSign*pi/2) . Ry(yaw) . S . T
+ * at the /5 referential (geometry x0.2, straddle -0.4). Position is fed unchanged.
  */
 export function flagCore(dir, pos, opts) {
 	const o = opts || {};
-	// Orientation reconciled empirically on the live map against roBrowser's Y-up camera +
-	// Camera.direction remap: rxSign +1 (pitch), yawOffsetDeg +180 on top of the asm-cited
-	// (dir+180). The opts stay exposed for re-tuning other eras/models.
+	// Orientation reconciled on the live map against roBrowser's Y-INVERTING camera (which now
+	// carries the sole granny-RH -> render-LH reflection; there is no in-model flipX). rxSign +1
+	// (pitch), yawOffsetDeg +180 on top of the asm-cited (dir+180). The opts stay exposed for
+	// re-tuning other eras/models.
 	const rxSign = o.rxSign != null ? o.rxSign : 1;
 	const yawOffset = o.yawOffsetDeg != null ? o.yawOffsetDeg : 180;
 	const yaw = ((dir + 180 + yawOffset) / 180) * Math.PI;
@@ -117,7 +122,9 @@ export function computeGroundOffset(meshes, opts) {
 
 /**
  * buildWorld(dir, pos, ipRow) -> Float32Array(16) GR2 world matrix.
- * Chain (row-vector, IP innermost): v . ipRow . flipX . flagCore(dir, pos).
+ * Chain (row-vector, IP innermost): v . ipRow . flagCore(dir, pos) — a clean,
+ * reflection-free Rx . Ry . S . T (det +1). The granny-RH -> render-LH reflection is
+ * provided by roBrowser's Y-inverting camera, not by this matrix (see HANDEDNESS above).
  * Hand the result straight to gl-matrix `mat4.multiply(out, view, world)` (see MATRIX
  * CONVENTION above) — it is already the column-major world matrix.
  *
@@ -128,8 +135,5 @@ export function computeGroundOffset(meshes, opts) {
 export function buildWorld(dir, pos, ipRow, opts) {
 	const o = opts || {};
 	const ip = ipRow || IDENTITY_ROW;
-	// flipX (default on) = the granny-RH -> render-LH X reflection. Exposed as an opt for the
-	// empirical mirror reconciliation on other eras/models.
-	const flip = o.flipX === false ? IDENTITY_ROW : FLIP_X;
-	return new Float32Array(_mul(ip, _mul(flip, flagCore(dir, pos, o))));
+	return new Float32Array(_mul(ip, flagCore(dir, pos, o)));
 }

--- a/src/Renderer/GR2/gr2World.js
+++ b/src/Renderer/GR2/gr2World.js
@@ -15,8 +15,8 @@
  * the world matrix stays a clean, reflection-free Rx . Ry . S . T (det +1). (The
  * sandbox, which keeps a plain Y-up camera, carries the flipX in-model instead.)
  *
- * MATRIX CONVENTION. The chain is built row-vector (D3D, v' = v.M) with the local
- * `_mul` helper, then the flat array is handed to GL / gl-matrix as-is. A row-major
+ * MATRIX CONVENTION. The chain is built row-vector (D3D, v' = v.M) with the shared
+ * `mul` helper (gr2Math.js), then the flat array is handed to GL / gl-matrix as-is. A row-major
  * array reinterpreted column-major IS its transpose, and column-vector M.v with the
  * transpose equals row-vector v.M — so `mat4.multiply(out, Camera.modelView, world)`
  * (gl-matrix is column-major) reproduces the sandbox `multiply4(view, model)` with no
@@ -33,12 +33,14 @@
  * YAW. `((dir + 180) / 180) * pi` — the +180 is asm-cited (mars26 fcn.00b2ad20.asm:160
  * addss 180.0 / ver12 fcn.00408b70). The sandbox leaves the offset vs roBrowser's own
  * Camera.direction remap (floor((angle[1]+22.5)/45)%8, rendered dir = (Camera.direction
- * + entity.direction) mod 8) UNRESOLVED by design — both sandbox halves share flagCore
+ * + entity.direction) mod 8) UNRESOLVED by design — both sandbox halves share worldCore
  * so they coincide with no offset. Here it is pinned empirically on the live map (see the
- * baked defaults in flagCore) and will thread into the Entity direction remap.
+ * baked defaults in worldCore) and will thread into the Entity direction remap.
  *
  * This file is part of ROBrowser, (http://www.robrowser.com/).
  */
+
+import { mul, trans, IDENTITY_ROW } from 'Renderer/GR2/gr2Math.js';
 
 /** Geometry scale under the /5 referential (0.2 = 1.0u / 5.0u). */
 export const RB_UNIT_SCALE = 0.2;
@@ -72,24 +74,8 @@ export const RB_UNIT_SCALE = 0.2;
  */
 export const RB_PLACEMENT_OFS = 0.5;
 
-const IDENTITY_ROW = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
-
-// Row-vector 4x4 helpers (D3D convention v' = v.M).
-function _mul(a, b) {
-	const o = new Array(16);
-	for (let r = 0; r < 4; r++) {
-		for (let c = 0; c < 4; c++) {
-			let s = 0;
-			for (let k = 0; k < 4; k++) {
-				s += a[r * 4 + k] * b[k * 4 + c];
-			}
-			o[r * 4 + c] = s;
-		}
-	}
-	return o;
-}
-
-// D3DXMatrixRotationX / Y (row-vector).
+// Row-vector 4x4 helpers (D3DXMatrixRotationX / Y / Scaling). `mul`, `trans` and IDENTITY_ROW
+// are shared with the loader via gr2Math.js; these three are GR2-world-only.
 const _rotX = a => {
 	const s = Math.sin(a);
 	const c = Math.cos(a);
@@ -101,24 +87,27 @@ const _rotY = a => {
 	return [c, 0, -s, 0, 0, 1, 0, 0, s, 0, c, 0, 0, 0, 0, 1];
 };
 const _scale = s => [s, 0, 0, 0, 0, s, 0, 0, 0, 0, s, 0, 0, 0, 0, 1];
-const _trans = (x, y, z) => [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, x, y, z, 1];
+
+// Effective yaw offset in degrees: the asm-cited +180 (mars26 fcn.00b2ad20.asm:160 addss 180.0
+// / ver12 fcn.00408b70) plus a live-map +180 reconciliation against roBrowser's own
+// Camera.direction remap — 360 total. Exposed via opts.yawOffsetDeg for re-tuning other eras.
+const YAW_BASE_DEG = 360;
 
 /**
- * flagCore(dir, pos) -> the reflection-free world core Rx(rxSign*pi/2) . Ry(yaw) . S . T
+ * worldCore(dir, pos) -> the reflection-free world core Rx(rxSign*pi/2) . Ry(yaw) . S . T
  * at the /5 referential (geometry x0.2, +0.5 cell-centre offset). Position is fed unchanged.
  */
-export function flagCore(dir, pos, opts) {
+export function worldCore(dir, pos, opts) {
 	const o = opts || {};
 	// Orientation reconciled on the live map against roBrowser's Y-INVERTING camera (which now
 	// carries the sole granny-RH -> render-LH reflection; there is no in-model flipX). rxSign +1
-	// (pitch), yawOffsetDeg +180 on top of the asm-cited (dir+180). The opts stay exposed for
-	// re-tuning other eras/models.
+	// (pitch), yaw offset YAW_BASE_DEG. The opts stay exposed for re-tuning other eras/models.
 	const rxSign = o.rxSign != null ? o.rxSign : 1;
-	const yawOffset = o.yawOffsetDeg != null ? o.yawOffsetDeg : 180;
-	const yaw = ((dir + 180 + yawOffset) / 180) * Math.PI;
-	let m = _mul(_rotX((rxSign * Math.PI) / 2), _rotY(yaw));
-	m = _mul(m, _scale(RB_UNIT_SCALE));
-	m = _mul(m, _trans(pos[0] + RB_PLACEMENT_OFS, pos[1] + (o.heightOffset || 0), pos[2] + RB_PLACEMENT_OFS));
+	const yawOffset = o.yawOffsetDeg != null ? o.yawOffsetDeg : YAW_BASE_DEG;
+	const yaw = ((dir + yawOffset) / 180) * Math.PI;
+	let m = mul(_rotX((rxSign * Math.PI) / 2), _rotY(yaw));
+	m = mul(m, _scale(RB_UNIT_SCALE));
+	m = mul(m, trans(pos[0] + RB_PLACEMENT_OFS, pos[1] + (o.heightOffset || 0), pos[2] + RB_PLACEMENT_OFS));
 	return m;
 }
 
@@ -130,7 +119,7 @@ export function flagCore(dir, pos, opts) {
  * world Y, so nothing renders under the terrain. Yaw-independent (uses the world matrix's Y-row).
  *
  * The model's granny InitialPlacement (ipRow) MUST be threaded here so grounding runs in the SAME
- * frame the draw uses (`v . ipRow . flagCore`). A non-identity IP (e.g. the treasurebox's 90 deg X
+ * frame the draw uses (`v . ipRow . worldCore`). A non-identity IP (e.g. the treasurebox's 90 deg X
  * rotation, or the guardians' Y translation) reorients/shifts the mesh; grounding with a null IP
  * would compute the base in the wrong frame and the model floats / sinks / lies flat on the ground.
  */
@@ -155,7 +144,7 @@ export function computeGroundOffset(meshes, ipRow, opts) {
 
 /**
  * buildWorld(dir, pos, ipRow) -> Float32Array(16) GR2 world matrix.
- * Chain (row-vector, IP innermost): v . ipRow . flagCore(dir, pos) — a clean,
+ * Chain (row-vector, IP innermost): v . ipRow . worldCore(dir, pos) — a clean,
  * reflection-free Rx . Ry . S . T (det +1). The granny-RH -> render-LH reflection is
  * provided by roBrowser's Y-inverting camera, not by this matrix (see HANDEDNESS above).
  * Hand the result straight to gl-matrix `mat4.multiply(out, view, world)` (see MATRIX
@@ -168,5 +157,5 @@ export function computeGroundOffset(meshes, ipRow, opts) {
 export function buildWorld(dir, pos, ipRow, opts) {
 	const o = opts || {};
 	const ip = ipRow || IDENTITY_ROW;
-	return new Float32Array(_mul(ip, flagCore(dir, pos, o)));
+	return new Float32Array(mul(ip, worldCore(dir, pos, o)));
 }

--- a/src/Renderer/GR2/gr2World.js
+++ b/src/Renderer/GR2/gr2World.js
@@ -1,0 +1,135 @@
+/**
+ * Renderer/GR2/gr2World.js
+ *
+ * The GR2 world matrix — port of the sandbox `gr2BuilderRobrowser` (draw path
+ * reconciled to roBrowser's /5 referential). Byte-cited from the client 3dmob draw
+ * path (mars26 fcn.00b2ad20 / ver12 fcn.00567e70): Rx(+pi/2) . Ry((dir+180)) . S . T,
+ * with the granny-RH -> render-LH X reflection (flipX) and the model's own granny
+ * InitialPlacement (ipRow) applied innermost. (The sandbox used Rx(-pi/2) for its folded
+ * camera; roBrowser's standard Y-up camera needs the faithful +pi/2 — see flagCore.)
+ *
+ * MATRIX CONVENTION. The chain is built row-vector (D3D, v' = v.M) with the local
+ * `_mul` helper, then the flat array is handed to GL / gl-matrix as-is. A row-major
+ * array reinterpreted column-major IS its transpose, and column-vector M.v with the
+ * transpose equals row-vector v.M — so `mat4.multiply(out, Camera.modelView, world)`
+ * (gl-matrix is column-major) reproduces the sandbox `multiply4(view, model)` with no
+ * extra transpose. Do NOT transpose the output.
+ *
+ * /5 REFERENTIAL (build-7). roBrowser lands the RO world at /5 (World/Altitude/Ground
+ * divide position + scale + heights by 5). The GR2 geometry and its cell-straddle scale
+ * by RB_UNIT_SCALE (0.2 = 1.0u / 5.0u) so the model reads 1.0-cell-sized; the world
+ * POSITION is left in the caller's referential (co-located with the /5 ground). See
+ * re-ro-clients-asm/sandbox/CORRESPONDENCE.md (build-7).
+ *
+ * YAW. `((dir + 180) / 180) * pi` — the +180 is asm-cited (mars26 fcn.00b2ad20.asm:160
+ * addss 180.0 / ver12 fcn.00408b70). The sandbox leaves the offset vs roBrowser's own
+ * Camera.direction remap (floor((angle[1]+22.5)/45)%8, rendered dir = (Camera.direction
+ * + entity.direction) mod 8) UNRESOLVED by design — both sandbox halves share flagCore
+ * so they coincide with no offset. Here it is pinned empirically on the live map (see the
+ * baked defaults in flagCore) and will thread into the Entity direction remap.
+ *
+ * This file is part of ROBrowser, (http://www.robrowser.com/).
+ */
+
+/** Geometry scale under the /5 referential (0.2 = 1.0u / 5.0u). */
+export const RB_UNIT_SCALE = 0.2;
+
+/** Cell-straddle offset on X,Z, scaled with the geometry (0.2 * -2.0). */
+export const RB_PLACEMENT_OFS = -0.4;
+
+const IDENTITY_ROW = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+
+// Model-space X reflection (row-vector) — the granny-RH -> render-LH handedness bridge.
+const FLIP_X = [-1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+
+// Row-vector 4x4 helpers (D3D convention v' = v.M).
+function _mul(a, b) {
+	const o = new Array(16);
+	for (let r = 0; r < 4; r++) {
+		for (let c = 0; c < 4; c++) {
+			let s = 0;
+			for (let k = 0; k < 4; k++) {
+				s += a[r * 4 + k] * b[k * 4 + c];
+			}
+			o[r * 4 + c] = s;
+		}
+	}
+	return o;
+}
+
+// D3DXMatrixRotationX / Y (row-vector).
+const _rotX = a => {
+	const s = Math.sin(a);
+	const c = Math.cos(a);
+	return [1, 0, 0, 0, 0, c, s, 0, 0, -s, c, 0, 0, 0, 0, 1];
+};
+const _rotY = a => {
+	const s = Math.sin(a);
+	const c = Math.cos(a);
+	return [c, 0, -s, 0, 0, 1, 0, 0, s, 0, c, 0, 0, 0, 0, 1];
+};
+const _scale = s => [s, 0, 0, 0, 0, s, 0, 0, 0, 0, s, 0, 0, 0, 0, 1];
+const _trans = (x, y, z) => [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, x, y, z, 1];
+
+/**
+ * flagCore(dir, pos) -> the flip-free world core Rx(-pi/2) . Ry(yaw) . S . T at the
+ * /5 referential (geometry x0.2, straddle -0.4). Position is fed unchanged.
+ */
+export function flagCore(dir, pos, opts) {
+	const o = opts || {};
+	// Orientation reconciled empirically on the live map against roBrowser's Y-up camera +
+	// Camera.direction remap: rxSign +1 (pitch), yawOffsetDeg +180 on top of the asm-cited
+	// (dir+180). The opts stay exposed for re-tuning other eras/models.
+	const rxSign = o.rxSign != null ? o.rxSign : 1;
+	const yawOffset = o.yawOffsetDeg != null ? o.yawOffsetDeg : 180;
+	const yaw = ((dir + 180 + yawOffset) / 180) * Math.PI;
+	let m = _mul(_rotX((rxSign * Math.PI) / 2), _rotY(yaw));
+	m = _mul(m, _scale(RB_UNIT_SCALE));
+	m = _mul(m, _trans(pos[0] + RB_PLACEMENT_OFS, pos[1] + (o.heightOffset || 0), pos[2] + RB_PLACEMENT_OFS));
+	return m;
+}
+
+/**
+ * computeGroundOffset(meshes, opts) -> the heightOffset that puts the model's base flush on the
+ * terrain. roBrowser's render inverts world Y on screen (proven on the live map: a model placed at
+ * world Y ABOVE the ground draws BELOW it / occluded), so the base — the part that must touch the
+ * ground line — is the world-Y MAX vertex. We ground that: no vertex ends up above the ground's
+ * world Y, so nothing renders under the terrain. Yaw-independent (uses the world matrix's Y-row).
+ */
+export function computeGroundOffset(meshes, opts) {
+	const m = buildWorld(0, [0, 0, 0], null, opts);
+	const a = m[1];
+	const b = m[5];
+	const c = m[9];
+	let max = -Infinity;
+	for (let k = 0; k < meshes.length; k++) {
+		const bind = meshes[k].bind;
+		const vc = meshes[k].vcount;
+		for (let i = 0; i < vc; i++) {
+			const y = a * bind[i * 3] + b * bind[i * 3 + 1] + c * bind[i * 3 + 2];
+			if (y > max) {
+				max = y;
+			}
+		}
+	}
+	return max === -Infinity ? 0 : -max;
+}
+
+/**
+ * buildWorld(dir, pos, ipRow) -> Float32Array(16) GR2 world matrix.
+ * Chain (row-vector, IP innermost): v . ipRow . flipX . flagCore(dir, pos).
+ * Hand the result straight to gl-matrix `mat4.multiply(out, view, world)` (see MATRIX
+ * CONVENTION above) — it is already the column-major world matrix.
+ *
+ * @param {number} dir - actor facing fed into Ry((dir+180))
+ * @param {number[]} pos - world position [x, y, z] (caller referential, left unscaled)
+ * @param {number[]} [ipRow] - the model's granny InitialPlacement row-vector mat4 (identity for flags)
+ */
+export function buildWorld(dir, pos, ipRow, opts) {
+	const o = opts || {};
+	const ip = ipRow || IDENTITY_ROW;
+	// flipX (default on) = the granny-RH -> render-LH X reflection. Exposed as an opt for the
+	// empirical mirror reconciliation on other eras/models.
+	const flip = o.flipX === false ? IDENTITY_ROW : FLIP_X;
+	return new Float32Array(_mul(ip, _mul(flip, flagCore(dir, pos, o))));
+}

--- a/src/Renderer/MapRenderer.js
+++ b/src/Renderer/MapRenderer.js
@@ -280,6 +280,9 @@ class MapRenderer {
 
 		Models.render(gl, modelView, projection, normalMat, fog, light);
 		AnimatedModels.render(gl, modelView, projection, normalMat, fog, light, tick);
+		// GR2 mobs render here with the opaque world models, before EntityManager.render below
+		// -- hence the 1-frame lag documented in GR2ModelRenderer.render (syncFromEntity reads the
+		// entity pose one frame stale). Ordering is intentional (opaque geometry pass).
 		GR2ModelRenderer.render(gl, modelView, projection, normalMat, fog, light, tick);
 
 		// Render transparent elements before ground

--- a/src/Renderer/MapRenderer.js
+++ b/src/Renderer/MapRenderer.js
@@ -27,6 +27,7 @@ import Altitude from 'Renderer/Map/Altitude.js';
 import Water from 'Renderer/Map/Water.js';
 import Models from 'Renderer/Map/Models.js';
 import AnimatedModels from 'Renderer/Map/AnimatedModels.js';
+import GR2ModelRenderer from 'Renderer/GR2/GR2ModelRenderer.js';
 import Sounds from 'Renderer/Map/Sounds.js';
 import Effects from 'Renderer/Map/Effects.js';
 import SpriteRenderer from 'Renderer/SpriteRenderer.js';
@@ -188,6 +189,7 @@ class MapRenderer {
 		Water.free(gl);
 		Models.free(gl);
 		AnimatedModels.free(gl);
+		GR2ModelRenderer.free(gl);
 		Damage.free(gl);
 		EffectManager.free(gl);
 		SignboardManager.free();
@@ -278,6 +280,7 @@ class MapRenderer {
 
 		Models.render(gl, modelView, projection, normalMat, fog, light);
 		AnimatedModels.render(gl, modelView, projection, normalMat, fog, light, tick);
+		GR2ModelRenderer.render(gl, modelView, projection, normalMat, fog, light, tick);
 
 		// Render transparent elements before ground
 		ScreenEffectManager.render(gl, modelView, projection, fog, tick, true);

--- a/tests/loaders/GR2Loader.test.js
+++ b/tests/loaders/GR2Loader.test.js
@@ -141,11 +141,13 @@ describe('GR2Loader.ipRowFromTransform', () => {
         expect(Array.from(M)).toEqual(IDENTITY);
     });
 
-    it('applies HAS_POSITION as a row-vector translation', () => {
+    it('applies HAS_POSITION INVERTED (the InitialPlacement is undone to render at the actor origin)', () => {
         const M = GR2Loader.ipRowFromTransform({ flags: 1, position: [5, 6, 7] });
-        expect(M[12]).toBeCloseTo(5, 6);
-        expect(M[13]).toBeCloseTo(6, 6);
-        expect(M[14]).toBeCloseTo(7, 6);
+        // Row-vector translation carries -p: a model authored off-origin is re-centred onto
+        // its cell (Kguardian90_7 IP [0.045,-7.253,0] -> +7.253 forward, aligning it with siblings).
+        expect(M[12]).toBeCloseTo(-5, 6);
+        expect(M[13]).toBeCloseTo(-6, 6);
+        expect(M[14]).toBeCloseTo(-7, 6);
         // Linear part stays identity.
         expect(M[0]).toBeCloseTo(1, 6);
         expect(M[5]).toBeCloseTo(1, 6);

--- a/tests/loaders/GR2Loader.test.js
+++ b/tests/loaders/GR2Loader.test.js
@@ -1,0 +1,171 @@
+import { describe, it, expect } from 'vitest';
+import GR2Loader from 'Loaders/GR2Loader.js';
+
+/**
+ * Build a synthetic granny-ro-js `parsed` object: two textured meshes (a body and an
+ * emblem "Plane01"), plus a matless proxy submesh that packModel must drop. The skeleton
+ * has 3 bones; each mesh binds a subset of them by name so we can assert local->global remap.
+ */
+function buildParsed() {
+    const skeleton = { bones: [{ name: 'root' }, { name: 'mid' }, { name: 'tip' }] };
+
+    // Body: 2 verts. boneBindings [mid, root] => local->global [1, 0].
+    const body = {
+        name: 'Object08',
+        vertexCount: 2,
+        positions: [[0, 0, 0], [1, 2, 3]],
+        normals: [[1, 0, 0], [0, 0, 1]],
+        uvs: [[0, 0], [1, 1]],
+        indices: [0, 1, 0],
+        boneBindings: [{ name: 'mid' }, { name: 'root' }],
+        // vert0: weighted to local 0 (=> global 1) and local 1 (=> global 0), unnormalized sum 2.
+        // vert1: no weights => rigid, must bind fully to l2g[0] (=> global 1) with weight 1.
+        vertexWeights: [[{ boneIndex: 0, weight: 1 }, { boneIndex: 1, weight: 1 }], []],
+        materials: [{ textureFile: 'flag.tga' }]
+    };
+
+    // Emblem: 1 vert. Name matches /Plane/i => emblem flag true.
+    const emblem = {
+        name: 'Plane01',
+        vertexCount: 1,
+        positions: [[5, 5, 5]],
+        normals: [[0, 1, 0]],
+        uvs: [[0.5, 0.5]],
+        indices: [0],
+        boneBindings: [{ name: 'tip' }],
+        vertexWeights: [[{ boneIndex: 0, weight: 1 }]],
+        materials: [{ textureFile: 'emblem.bmp' }]
+    };
+
+    // Matless proxy: no textured material => dropped.
+    const proxy = {
+        name: 'Bip01 Proxy',
+        vertexCount: 1,
+        positions: [[0, 0, 0]],
+        normals: [[0, 0, 1]],
+        uvs: [[0, 0]],
+        indices: [0],
+        boneBindings: [{ name: 'root' }],
+        vertexWeights: [[{ boneIndex: 0, weight: 1 }]],
+        materials: []
+    };
+
+    return { skeletons: [skeleton], meshes: [body, emblem, proxy] };
+}
+
+describe('GR2Loader.packModel', () => {
+    it('drops matless proxy submeshes', () => {
+        const { meshes } = GR2Loader.packModel(buildParsed());
+        expect(meshes).toHaveLength(2);
+        expect(meshes.map(m => m.name)).toEqual(['Object08', 'Plane01']);
+    });
+
+    it('reports the global bone count', () => {
+        const { boneCount } = GR2Loader.packModel(buildParsed());
+        expect(boneCount).toBe(3);
+    });
+
+    it('remaps mesh-local bone bindings to global skeleton indices', () => {
+        const { meshes } = GR2Loader.packModel(buildParsed());
+        const body = meshes[0];
+        // vert0 local bones 0,1 => global 1 (mid), 0 (root).
+        expect(body.bidx[0]).toBe(1);
+        expect(body.bidx[1]).toBe(0);
+    });
+
+    it('binds rigid (weightless) vertices fully to the first bound bone', () => {
+        const { meshes } = GR2Loader.packModel(buildParsed());
+        const body = meshes[0];
+        // vert1 had no weights => bidx = l2g[0] = global 1, weight 1.
+        expect(body.bidx[4]).toBe(1);
+        expect(body.bw[4]).toBeCloseTo(1, 6);
+    });
+
+    it('normalizes the top-4 weights to sum 1', () => {
+        const { meshes } = GR2Loader.packModel(buildParsed());
+        const body = meshes[0];
+        const sum = body.bw[0] + body.bw[1] + body.bw[2] + body.bw[3];
+        expect(sum).toBeCloseTo(1, 6);
+        // vert0 had equal unnormalized weights => 0.5 / 0.5.
+        expect(body.bw[0]).toBeCloseTo(0.5, 6);
+        expect(body.bw[1]).toBeCloseTo(0.5, 6);
+    });
+
+    it('passes normals through unit-length', () => {
+        const { meshes } = GR2Loader.packModel(buildParsed());
+        for (const m of meshes) {
+            for (let i = 0; i < m.vcount; i++) {
+                const x = m.nrm[i * 3];
+                const y = m.nrm[i * 3 + 1];
+                const z = m.nrm[i * 3 + 2];
+                expect(Math.hypot(x, y, z)).toBeCloseTo(1, 6);
+            }
+        }
+    });
+
+    it('emits attribute arrays that are 16-float interleavable (16 * vcount)', () => {
+        const { meshes } = GR2Loader.packModel(buildParsed());
+        for (const m of meshes) {
+            const N = m.vcount;
+            expect(m.bind).toHaveLength(N * 3);
+            expect(m.nrm).toHaveLength(N * 3);
+            expect(m.uv).toHaveLength(N * 2);
+            expect(m.bidx).toHaveLength(N * 4);
+            expect(m.bw).toHaveLength(N * 4);
+            const total = m.bind.length + m.nrm.length + m.uv.length + m.bidx.length + m.bw.length;
+            expect(total).toBe(N * 16);
+            expect(m.indices).toBeInstanceOf(Uint16Array);
+        }
+    });
+
+    it('flags the Plane* mesh as the emblem', () => {
+        const { meshes } = GR2Loader.packModel(buildParsed());
+        expect(meshes[0].emblem).toBe(false);
+        expect(meshes[1].emblem).toBe(true);
+    });
+
+    it('throws when the model has no skeleton', () => {
+        expect(() => GR2Loader.packModel({ skeletons: [], meshes: [] })).toThrow(/no skeleton/);
+    });
+});
+
+describe('GR2Loader.ipRowFromTransform', () => {
+    const IDENTITY = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+
+    it('returns identity when the transform is absent', () => {
+        expect(Array.from(GR2Loader.ipRowFromTransform(undefined))).toEqual(IDENTITY);
+    });
+
+    it('returns identity when flags is 0', () => {
+        const M = GR2Loader.ipRowFromTransform({ flags: 0, position: [9, 9, 9] });
+        expect(Array.from(M)).toEqual(IDENTITY);
+    });
+
+    it('applies HAS_POSITION as a row-vector translation', () => {
+        const M = GR2Loader.ipRowFromTransform({ flags: 1, position: [5, 6, 7] });
+        expect(M[12]).toBeCloseTo(5, 6);
+        expect(M[13]).toBeCloseTo(6, 6);
+        expect(M[14]).toBeCloseTo(7, 6);
+        // Linear part stays identity.
+        expect(M[0]).toBeCloseTo(1, 6);
+        expect(M[5]).toBeCloseTo(1, 6);
+        expect(M[10]).toBeCloseTo(1, 6);
+    });
+
+    it('applies HAS_ORIENTATION quat Rx(+90) (treasurebox case)', () => {
+        const s = Math.SQRT1_2; // 0.70710678
+        const M = GR2Loader.ipRowFromTransform({ flags: 2, orientation: [s, 0, 0, s] });
+        // Row-vector Rx(+90): [1,0,0, 0,0,1, 0,-1,0].
+        const expected = [1, 0, 0, 0, 0, 0, 1, 0, 0, -1, 0, 0, 0, 0, 0, 1];
+        for (let i = 0; i < 16; i++) {
+            expect(M[i]).toBeCloseTo(expected[i], 6);
+        }
+    });
+
+    it('applies HAS_SCALESHEAR as the 3x3 linear block', () => {
+        const M = GR2Loader.ipRowFromTransform({ flags: 4, scaleShear: [2, 0, 0, 0, 3, 0, 0, 0, 4] });
+        expect(M[0]).toBeCloseTo(2, 6);
+        expect(M[5]).toBeCloseTo(3, 6);
+        expect(M[10]).toBeCloseTo(4, 6);
+    });
+});

--- a/tests/renderer/GR2/actorAction.test.js
+++ b/tests/renderer/GR2/actorAction.test.js
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import { ACTION, createActor, setAction, actorPose } from 'Renderer/GR2/actorAction.js';
+
+// A model with all five action banks present (indices 0..4 by ACTION order).
+function fullModel() {
+	return {
+		parsed: {
+			animations: [
+				{ duration: 2 }, // 0 stand
+				{ duration: 1.5 }, // 1 move
+				{ duration: 0.5 }, // 2 attack
+				{ duration: 3 }, // 3 dead
+				{ duration: 1 } // 4 damage
+			]
+		}
+	};
+}
+// A model with only the standby bank (attack/move/... banks absent -> bind pose).
+function banklessModel() {
+	return { parsed: { animations: [{ duration: 2 }] } };
+}
+
+describe('actorAction state machine', () => {
+	it('starts in standby and loops the standby clip by its own duration', () => {
+		const actor = createActor();
+		expect(actor.name).toBe('stand');
+		// standbyIdx 0, duration 2 s: elapsed 3 s -> t = 3 % 2 = 1.
+		const pose = actorPose(actor, fullModel(), 3000, 0, null);
+		expect(pose.animIndex).toBe(0);
+		expect(pose.t).toBeCloseTo(1, 5);
+	});
+
+	it('standbyIdx < 0 is the NPC bind pose', () => {
+		const pose = actorPose(createActor(), fullModel(), 1000, -1, null);
+		expect(pose).toEqual({ animIndex: -1, t: 0 });
+	});
+
+	it('setAction hard-cuts: resets the clock and clears the loop latch', () => {
+		const actor = createActor();
+		actor.loop = true;
+		setAction(actor, 'attack', 500);
+		expect(actor.name).toBe('attack');
+		expect(actor.startT).toBe(500);
+		expect(actor.loop).toBe(false);
+	});
+
+	it('attack plays clip-relative, then auto-reverts to standby on clip end', () => {
+		const actor = createActor();
+		setAction(actor, 'attack', 0);
+		// Mid-clip (attack dur 0.5 s): elapsed 0.3 s.
+		let pose = actorPose(actor, fullModel(), 300, 0, null);
+		expect(pose.animIndex).toBe(ACTION.attack.idx);
+		expect(pose.t).toBeCloseTo(0.3, 5);
+		// Past clip end -> reverts to standby (which restarts at 0 relative to now).
+		pose = actorPose(actor, fullModel(), 600, 0, null);
+		expect(actor.name).toBe('stand');
+		expect(pose.animIndex).toBe(0);
+		expect(pose.t).toBeCloseTo(0, 5);
+	});
+
+	it('dead holds its last frame (min(elapsed, dur))', () => {
+		const actor = createActor();
+		setAction(actor, 'dead', 0);
+		const pose = actorPose(actor, fullModel(), 10000, 0, null); // dead dur 3 s
+		expect(actor.name).toBe('dead');
+		expect(pose.animIndex).toBe(ACTION.dead.idx);
+		expect(pose.t).toBeCloseTo(3, 5);
+	});
+
+	it('move loops when latched and never auto-reverts', () => {
+		const actor = createActor();
+		setAction(actor, 'move', 0);
+		actor.loop = true;
+		const pose = actorPose(actor, fullModel(), 2000, 0, null); // move dur 1.5 s -> 2 % 1.5 = 0.5
+		expect(actor.name).toBe('move');
+		expect(pose.animIndex).toBe(ACTION.move.idx);
+		expect(pose.t).toBeCloseTo(0.5, 5);
+	});
+
+	it('damage is one-shot: reverts to standby after its duration', () => {
+		const actor = createActor();
+		setAction(actor, 'damage', 0);
+		const pose = actorPose(actor, fullModel(), 1200, 0, null); // damage dur 1 s
+		expect(actor.name).toBe('stand');
+		expect(pose.animIndex).toBe(0);
+	});
+
+	it('a missing bank yields the bind pose (attack held; move hard-cuts to standby)', () => {
+		const attacker = createActor();
+		setAction(attacker, 'attack', 0);
+		expect(actorPose(attacker, banklessModel(), 100, 0, null)).toEqual({ animIndex: -1, t: 0 });
+		expect(attacker.name).toBe('attack'); // held, no revert
+
+		const mover = createActor();
+		setAction(mover, 'move', 0);
+		expect(actorPose(mover, banklessModel(), 100, 0, null)).toEqual({ animIndex: -1, t: 0 });
+		expect(mover.name).toBe('stand'); // hard-cut to standby
+	});
+});

--- a/tests/renderer/GR2/gr2Banks.test.js
+++ b/tests/renderer/GR2/gr2Banks.test.js
@@ -27,4 +27,12 @@ describe('gr2Banks.bankPathsFor', () => {
 		expect(bankPathsFor('data/model/3dmob/dragon_5.gr2')).toEqual([]);
 		expect(bankPathsFor('nonsense.gr2')).toEqual([]);
 	});
+
+	it('resolves the bank set through the string setId key (regex captures a string)', () => {
+		// setId is captured as a string from the filename regex, and GR2_BANKS is keyed by strings
+		// to match. Guards against a future numeric-only-key or Map swap where a string lookup would
+		// miss: a declared setId ('9') must still resolve, an undeclared one ('0') must stay empty.
+		expect(bankPathsFor('data/model/3dmob/sguardian90_9.gr2').length).toBeGreaterThan(0);
+		expect(bankPathsFor('data/model/3dmob/empelium90_0.gr2')).toEqual([]);
+	});
 });

--- a/tests/renderer/GR2/gr2Banks.test.js
+++ b/tests/renderer/GR2/gr2Banks.test.js
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { bankPathsFor } from 'Renderer/GR2/gr2Banks.js';
+
+describe('gr2Banks.bankPathsFor', () => {
+	it('guardians (setId 7/8/9) declare all four external banks', () => {
+		const banks = bankPathsFor('data/model/3dmob/sguardian90_9.gr2');
+		expect(banks.map(b => b.name).sort()).toEqual(['attack', 'damage', 'dead', 'move']);
+		expect(banks).toContainEqual({ name: 'move', path: 'data/model/3dmob_bone/9_move.gr2' });
+		expect(banks).toContainEqual({ name: 'attack', path: 'data/model/3dmob_bone/9_attack.gr2' });
+		// setId comes from the filename suffix.
+		expect(bankPathsFor('data/model/3dmob/kguardian90_7.gr2')[0].path).toContain('3dmob_bone/7_');
+		expect(bankPathsFor('data/model/3dmob/aguardian90_8.gr2')[0].path).toContain('3dmob_bone/8_');
+	});
+
+	it('treasure box (setId 2) declares only dead + damage', () => {
+		const banks = bankPathsFor('data/model/3dmob/treasurebox_2.gr2');
+		expect(banks.map(b => b.name).sort()).toEqual(['damage', 'dead']);
+		expect(banks).toContainEqual({ name: 'dead', path: 'data/model/3dmob_bone/2_dead.gr2' });
+	});
+
+	it('emperium (0) and flag (1) declare no external banks (embedded standby only)', () => {
+		expect(bankPathsFor('data/model/3dmob/empelium90_0.gr2')).toEqual([]);
+		expect(bankPathsFor('data/model/3dmob/guildflag90_1.gr2')).toEqual([]);
+	});
+
+	it('a path without a numeric setId suffix yields no banks', () => {
+		expect(bankPathsFor('data/model/3dmob/dragon_5.gr2')).toEqual([]);
+		expect(bankPathsFor('nonsense.gr2')).toEqual([]);
+	});
+});

--- a/tests/renderer/GR2/gr2Entity.test.js
+++ b/tests/renderer/GR2/gr2Entity.test.js
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { gr2ActionFor, frustumCullClip } from 'Renderer/GR2/gr2Pack.js';
+
+// The mob ACTION enum (EntityAction.js): IDLE=0, WALK=1, ATTACK=2, HURT=3, DIE=4.
+const MOB = { IDLE: 0, WALK: 1, ATTACK: 2, HURT: 3, DIE: 4 };
+// An NPC enum lacks WALK/ATTACK/DIE keys -> those comparisons never match.
+const NPC = { IDLE: 0 };
+
+describe('gr2ActionFor (entity action -> GR2 action name)', () => {
+	it('maps a mob action enum semantically', () => {
+		expect(gr2ActionFor({ ACTION: MOB, action: MOB.DIE })).toBe('dead');
+		expect(gr2ActionFor({ ACTION: MOB, action: MOB.HURT })).toBe('damage');
+		expect(gr2ActionFor({ ACTION: MOB, action: MOB.ATTACK })).toBe('attack');
+		expect(gr2ActionFor({ ACTION: MOB, action: MOB.WALK })).toBe('move');
+		expect(gr2ActionFor({ ACTION: MOB, action: MOB.IDLE })).toBe('stand');
+	});
+
+	it('defaults to stand for an out-of-range / negative action', () => {
+		expect(gr2ActionFor({ ACTION: MOB, action: -1 })).toBe('stand');
+		expect(gr2ActionFor({ ACTION: MOB, action: 99 })).toBe('stand');
+	});
+
+	it('an NPC (no WALK/ATTACK/DIE keys) at state 0 stays stand', () => {
+		expect(gr2ActionFor({ ACTION: NPC, action: 0 })).toBe('stand');
+	});
+});
+
+describe('frustumCullClip', () => {
+	it('keeps a point inside the NDC box', () => {
+		// clip x=0.5, y=-0.3, w=1 -> |x/w|,|y/w| < 1
+		expect(frustumCullClip(0.5, -0.3, 1, 0.2)).toBe(false);
+	});
+
+	it('culls a point behind the camera (w <= 0)', () => {
+		expect(frustumCullClip(0, 0, 0, 0.2)).toBe(true);
+		expect(frustumCullClip(0, 0, -2, 0.2)).toBe(true);
+	});
+
+	it('culls a point beyond the padded box on x or y', () => {
+		// margin 0.2 -> bound = 1.2 * w. x = 1.5 * w is outside.
+		expect(frustumCullClip(1.5, 0, 1, 0.2)).toBe(true);
+		expect(frustumCullClip(0, -1.5, 1, 0.2)).toBe(true);
+	});
+
+	it('keeps a point exactly on the margin edge', () => {
+		// x = 1.2 * w == bound -> not strictly greater, kept.
+		expect(frustumCullClip(1.2, 0, 1, 0.2)).toBe(false);
+	});
+});

--- a/tests/renderer/GR2/gr2Pack.test.js
+++ b/tests/renderer/GR2/gr2Pack.test.js
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import {
+	packRobrowserInterleave,
+	flattenPose,
+	identityPose,
+	quantizePoseTime,
+	poseCacheKey,
+	POSE_HZ
+} from 'Renderer/GR2/gr2Pack.js';
+
+/**
+ * Synthetic 2-vertex packed mesh (the shape GR2Loader.packModel emits).
+ */
+function makeMesh() {
+	return {
+		vcount: 2,
+		bind: new Float32Array([1, 2, 3, 4, 5, 6]),
+		nrm: new Float32Array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6]),
+		uv: new Float32Array([0.7, 0.8, 0.9, 1.0]),
+		bidx: new Float32Array([10, 11, 12, 13, 20, 21, 22, 23]),
+		bw: new Float32Array([0.25, 0.25, 0.25, 0.25, 0.4, 0.3, 0.2, 0.1])
+	};
+}
+
+describe('packRobrowserInterleave', () => {
+	it('lays out 16 floats/vert at pos@0 normal@3 uv@6 bidx@8 bw@12', () => {
+		const mesh = makeMesh();
+		const buf = packRobrowserInterleave(mesh);
+
+		expect(buf).toBeInstanceOf(Float32Array);
+		expect(buf.length).toBe(mesh.vcount * 16);
+
+		for (let i = 0; i < mesh.vcount; i++) {
+			const o = i * 16;
+			// Position sources the BIND pose (the vertex shader re-poses it), not a runtime position.
+			expect([buf[o], buf[o + 1], buf[o + 2]]).toEqual([mesh.bind[i * 3], mesh.bind[i * 3 + 1], mesh.bind[i * 3 + 2]]);
+			expect([buf[o + 3], buf[o + 4], buf[o + 5]]).toEqual([mesh.nrm[i * 3], mesh.nrm[i * 3 + 1], mesh.nrm[i * 3 + 2]]);
+			expect([buf[o + 6], buf[o + 7]]).toEqual([mesh.uv[i * 2], mesh.uv[i * 2 + 1]]);
+			expect([buf[o + 8], buf[o + 9], buf[o + 10], buf[o + 11]]).toEqual([
+				mesh.bidx[i * 4],
+				mesh.bidx[i * 4 + 1],
+				mesh.bidx[i * 4 + 2],
+				mesh.bidx[i * 4 + 3]
+			]);
+			expect([buf[o + 12], buf[o + 13], buf[o + 14], buf[o + 15]]).toEqual([
+				mesh.bw[i * 4],
+				mesh.bw[i * 4 + 1],
+				mesh.bw[i * 4 + 2],
+				mesh.bw[i * 4 + 3]
+			]);
+		}
+	});
+});
+
+describe('flattenPose / identityPose', () => {
+	it('flattens skinning matrices contiguously', () => {
+		const pose = { skinningMatrices: [new Float32Array(16).fill(2), new Float32Array(16).fill(3)] };
+		const flat = flattenPose(pose, 2);
+		expect(flat.length).toBe(32);
+		expect(flat[0]).toBe(2);
+		expect(flat[16]).toBe(3);
+	});
+
+	it('identityPose emits identity mat4s', () => {
+		const id = identityPose(2);
+		expect(id.length).toBe(32);
+		// Diagonal set, off-diagonal zero.
+		expect([id[0], id[5], id[10], id[15]]).toEqual([1, 1, 1, 1]);
+		expect([id[16], id[21], id[26], id[31]]).toEqual([1, 1, 1, 1]);
+		expect(id[1]).toBe(0);
+	});
+});
+
+describe('pose cache key / quantization', () => {
+	it('collapses near-equal clip times inside one 1/40 s bucket', () => {
+		expect(POSE_HZ).toBe(40);
+		// 0.011 s and 0.012 s both round to bucket 0 at 40 Hz.
+		expect(quantizePoseTime(0.011)).toBe(quantizePoseTime(0.012));
+		expect(poseCacheKey('a.gr2', 0, quantizePoseTime(0.011))).toBe(poseCacheKey('a.gr2', 0, quantizePoseTime(0.012)));
+	});
+
+	it('separates distinct time buckets, anim indices, and paths', () => {
+		expect(quantizePoseTime(0.011)).not.toBe(quantizePoseTime(0.05));
+		const base = poseCacheKey('a.gr2', 0, 0);
+		expect(poseCacheKey('a.gr2', 0, 1)).not.toBe(base); // bucket
+		expect(poseCacheKey('a.gr2', 1, 0)).not.toBe(base); // anim
+		expect(poseCacheKey('b.gr2', 0, 0)).not.toBe(base); // path
+	});
+});

--- a/tests/renderer/GR2/gr2World.test.js
+++ b/tests/renderer/GR2/gr2World.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildWorld, flagCore, computeGroundOffset, RB_UNIT_SCALE, RB_PLACEMENT_OFS } from 'Renderer/GR2/gr2World.js';
+import { buildWorld, worldCore, computeGroundOffset, RB_UNIT_SCALE, RB_PLACEMENT_OFS } from 'Renderer/GR2/gr2World.js';
 
 // Row-major flat mat4 (v.M): 3x3 linear at [0,1,2 / 4,5,6 / 8,9,10], translation at [12,13,14].
 const rowMag = (m, r) => Math.hypot(m[r * 4], m[r * 4 + 1], m[r * 4 + 2]);
@@ -53,8 +53,8 @@ describe('gr2World.buildWorld — /5 referential (build-7 reconciliation)', () =
 		}
 	});
 
-	it('flagCore leaves position unscaled (scale hits geometry, not translation)', () => {
-		const core = flagCore(90, [4, 0, 8]);
+	it('worldCore leaves position unscaled (scale hits geometry, not translation)', () => {
+		const core = worldCore(90, [4, 0, 8]);
 		expect(Math.abs(core[12] - (4 + RB_PLACEMENT_OFS))).toBeLessThan(1e-6);
 		expect(Math.abs(core[14] - (8 + RB_PLACEMENT_OFS))).toBeLessThan(1e-6);
 	});
@@ -76,7 +76,7 @@ describe('gr2World.computeGroundOffset — grounds in the model IP frame', () =>
 	it('a non-identity ipRow changes the grounding (IP is threaded, not ignored)', () => {
 		const offIdentity = computeGroundOffset([mesh], null);
 		const offRotated = computeGroundOffset([mesh], ipRotX);
-		// The IP reorients the mesh before flagCore, so the world-Y extreme differs -> different
+		// The IP reorients the mesh before worldCore, so the world-Y extreme differs -> different
 		// heightOffset. Equality here would mean the IP was dropped (the pre-fix bug).
 		expect(Math.abs(offIdentity - offRotated)).toBeGreaterThan(1e-3);
 	});

--- a/tests/renderer/GR2/gr2World.test.js
+++ b/tests/renderer/GR2/gr2World.test.js
@@ -27,8 +27,8 @@ describe('gr2World.buildWorld — /5 referential (build-7 reconciliation)', () =
 		}
 	});
 
-	it('preserves chirality (det(3x3) < 0 — the flipX reflection is intact)', () => {
-		expect(det3(rb)).toBeLessThan(0);
+	it('is reflection-free (det(3x3) > 0 — no in-model flipX; the camera carries RH->LH)', () => {
+		expect(det3(rb)).toBeGreaterThan(0);
 	});
 
 	it('straddles the cell by -0.4 on X,Z with position fed unchanged', () => {

--- a/tests/renderer/GR2/gr2World.test.js
+++ b/tests/renderer/GR2/gr2World.test.js
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { buildWorld, flagCore, RB_UNIT_SCALE, RB_PLACEMENT_OFS } from 'Renderer/GR2/gr2World.js';
+
+// Row-major flat mat4 (v.M): 3x3 linear at [0,1,2 / 4,5,6 / 8,9,10], translation at [12,13,14].
+const rowMag = (m, r) => Math.hypot(m[r * 4], m[r * 4 + 1], m[r * 4 + 2]);
+function det3(m) {
+	const a = m[0],
+		b = m[1],
+		c = m[2],
+		d = m[4],
+		e = m[5],
+		f = m[6],
+		g = m[8],
+		h = m[9],
+		i = m[10];
+	return a * (e * i - f * h) - b * (d * i - f * g) + c * (d * h - e * g);
+}
+
+describe('gr2World.buildWorld — /5 referential (build-7 reconciliation)', () => {
+	// DIR 90 exercises a real rotation; POS 0 isolates the straddle.
+	const rb = buildWorld(90, [0, 0, 0]);
+
+	it('scales the geometry 3x3 rows to 0.2 (the /5 master scale)', () => {
+		expect(RB_UNIT_SCALE).toBe(0.2);
+		for (let r = 0; r < 3; r++) {
+			expect(Math.abs(rowMag(rb, r) - 0.2)).toBeLessThan(1e-6);
+		}
+	});
+
+	it('preserves chirality (det(3x3) < 0 — the flipX reflection is intact)', () => {
+		expect(det3(rb)).toBeLessThan(0);
+	});
+
+	it('straddles the cell by -0.4 on X,Z with position fed unchanged', () => {
+		expect(RB_PLACEMENT_OFS).toBe(-0.4);
+		expect(Math.abs(rb[12] - -0.4)).toBeLessThan(1e-6);
+		expect(Math.abs(rb[13] - 0)).toBeLessThan(1e-6);
+		expect(Math.abs(rb[14] - -0.4)).toBeLessThan(1e-6);
+
+		// Position is left in the caller referential (only geometry + straddle scale) — a mob at
+		// cell (10, 20) translates to (10 - 0.4, 0, 20 - 0.4), NOT (2 - 0.4, ...).
+		const placed = buildWorld(90, [10, 0, 20]);
+		expect(Math.abs(placed[12] - 9.6)).toBeLessThan(1e-6);
+		expect(Math.abs(placed[14] - 19.6)).toBeLessThan(1e-6);
+	});
+
+	it('applies ipRow innermost (identity ipRow is a no-op)', () => {
+		const withIdentityIp = buildWorld(90, [0, 0, 0], [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
+		for (let k = 0; k < 16; k++) {
+			expect(Math.abs(withIdentityIp[k] - rb[k])).toBeLessThan(1e-6);
+		}
+	});
+
+	it('flagCore leaves position unscaled (scale hits geometry, not translation)', () => {
+		const core = flagCore(90, [4, 0, 8]);
+		expect(Math.abs(core[12] - (4 + RB_PLACEMENT_OFS))).toBeLessThan(1e-6);
+		expect(Math.abs(core[14] - (8 + RB_PLACEMENT_OFS))).toBeLessThan(1e-6);
+	});
+});

--- a/tests/renderer/GR2/gr2World.test.js
+++ b/tests/renderer/GR2/gr2World.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildWorld, flagCore, RB_UNIT_SCALE, RB_PLACEMENT_OFS } from 'Renderer/GR2/gr2World.js';
+import { buildWorld, flagCore, computeGroundOffset, RB_UNIT_SCALE, RB_PLACEMENT_OFS } from 'Renderer/GR2/gr2World.js';
 
 // Row-major flat mat4 (v.M): 3x3 linear at [0,1,2 / 4,5,6 / 8,9,10], translation at [12,13,14].
 const rowMag = (m, r) => Math.hypot(m[r * 4], m[r * 4 + 1], m[r * 4 + 2]);
@@ -31,17 +31,19 @@ describe('gr2World.buildWorld — /5 referential (build-7 reconciliation)', () =
 		expect(det3(rb)).toBeGreaterThan(0);
 	});
 
-	it('straddles the cell by -0.4 on X,Z with position fed unchanged', () => {
-		expect(RB_PLACEMENT_OFS).toBe(-0.4);
-		expect(Math.abs(rb[12] - -0.4)).toBeLessThan(1e-6);
+	it('offsets to the cell centre (+0.5 on X,Z) with position fed unchanged', () => {
+		// +0.5 = the cell centre (roBrowser's cell-middle convention: SpriteRenderer.vs / Altitude
+		// / overlay all add +0.5 from the raw corner). Co-locates the GR2 with the 2D sprite/shadow.
+		expect(RB_PLACEMENT_OFS).toBe(0.5);
+		expect(Math.abs(rb[12] - 0.5)).toBeLessThan(1e-6);
 		expect(Math.abs(rb[13] - 0)).toBeLessThan(1e-6);
-		expect(Math.abs(rb[14] - -0.4)).toBeLessThan(1e-6);
+		expect(Math.abs(rb[14] - 0.5)).toBeLessThan(1e-6);
 
-		// Position is left in the caller referential (only geometry + straddle scale) — a mob at
-		// cell (10, 20) translates to (10 - 0.4, 0, 20 - 0.4), NOT (2 - 0.4, ...).
+		// Position is left in the caller referential (only the geometry scales) — a mob at
+		// cell (10, 20) translates to the cell centre (10.5, 0, 20.5), NOT (2.5, ...).
 		const placed = buildWorld(90, [10, 0, 20]);
-		expect(Math.abs(placed[12] - 9.6)).toBeLessThan(1e-6);
-		expect(Math.abs(placed[14] - 19.6)).toBeLessThan(1e-6);
+		expect(Math.abs(placed[12] - 10.5)).toBeLessThan(1e-6);
+		expect(Math.abs(placed[14] - 20.5)).toBeLessThan(1e-6);
 	});
 
 	it('applies ipRow innermost (identity ipRow is a no-op)', () => {
@@ -55,5 +57,27 @@ describe('gr2World.buildWorld — /5 referential (build-7 reconciliation)', () =
 		const core = flagCore(90, [4, 0, 8]);
 		expect(Math.abs(core[12] - (4 + RB_PLACEMENT_OFS))).toBeLessThan(1e-6);
 		expect(Math.abs(core[14] - (8 + RB_PLACEMENT_OFS))).toBeLessThan(1e-6);
+	});
+});
+
+describe('gr2World.computeGroundOffset — grounds in the model IP frame', () => {
+	// One vertex at model (0, 0, 10). Grounding = -(max world-Y over vertices).
+	const mesh = { bind: new Float32Array([0, 0, 10]), vcount: 1 };
+	// 90deg rotation about model X (row-vector), like the treasurebox InitialPlacement.
+	const ipRotX = [1, 0, 0, 0, 0, 0, 1, 0, 0, -1, 0, 0, 0, 0, 0, 1];
+
+	it('null ipRow equals an explicit identity ipRow (backward compatible)', () => {
+		const identity = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+		const off0 = computeGroundOffset([mesh], null);
+		const off1 = computeGroundOffset([mesh], identity);
+		expect(Math.abs(off0 - off1)).toBeLessThan(1e-6);
+	});
+
+	it('a non-identity ipRow changes the grounding (IP is threaded, not ignored)', () => {
+		const offIdentity = computeGroundOffset([mesh], null);
+		const offRotated = computeGroundOffset([mesh], ipRotX);
+		// The IP reorients the mesh before flagCore, so the world-Y extreme differs -> different
+		// heightOffset. Equality here would mean the IP was dropped (the pre-fix bug).
+		expect(Math.abs(offIdentity - offRotated)).toBeGreaterThan(1e-3);
 	});
 });


### PR DESCRIPTION
## Summary

Adds a GPU-skinned Granny3D (`.gr2`) model subsystem so on-map actors that ship a 3D
body — the guild flag, Emperium, guardians, treasure box — render as real 3D meshes
instead of 2D sprites, wired into the existing Entity/Map render path.

- **Loader** — `GR2Loader` decodes `.gr2` buffers via the `granny-ro-js` package
  (Oodle0 + type-tree + skeleton + skinning + animation), packs meshes into per-vertex
  attribute arrays, and reads the model InitialPlacement transform.
- **Renderer** — `GR2ModelRenderer` is a per-type resource cache (one VBO/IBO/VAO/texture
  set per `.gr2` path, refcounted) with N lightweight instances. Poses are cached at the
  40 Hz rag tick so same-type/same-phase actors collapse to a single `poseAt`. Each
  instance frustum-culls on its ground anchor before posing.
- **World matrix** — row-vector (D3D) chain byte-cited from the client 3dmob draw path,
  reconciled to roBrowser's `/5` referential and Y-inverting camera (handedness resolved
  with a single reflection, no double-mirror). Models are centred on their cell and
  grounded in their InitialPlacement frame.
- **Lighting** — byte-decided per-model grayscale diffuse/ambient (not the map light),
  matching the client's fixed shading for these models.
- **Guild emblem** — the flag's `Plane01` submesh binds the live per-guild emblem texture
  (POT-padded A4R4G4B4, per-instance); it renders empty until the emblem is fetched.
- **Animation banks** — external action banks (`3dmob_bone/*.gr2`) stream in on demand,
  prioritised by the current action.
- **Integration** — `EntityView` resolves the `.gr2` body path, `EntityRender`/
  `EntityManager` attach/detach the renderer instance, `MapRenderer` drives it at the
  AnimatedModels seam, and the pick box mirrors the client's base bounding-sphere.

## Test plan

- [x] `npx vitest run` — 242 tests pass (40 files), including dedicated GR2 suites
  (loader, world matrix, pack, actorAction, banks, entity).
- [x] `npm run lint` — 0 errors; `prettier --check` clean on all GR2 sources (CRLF).
- [x] Visual A/B on the live map — guild flag, Emperium, guardians and treasure box
  render, animate and place correctly; guild emblem shows per-guild; empty emblem plane
  until the live emblem loads.
- [x] Reviewer: sanity-check `granny-ro-js` dependency add (`^1.4.1`) and the emblem
  fetch path on a real guild.

## Files changed

New GR2 subsystem (`src/Renderer/GR2/`, `src/Loaders/`):

- `src/Loaders/GR2Loader.js` (+217) — decode `.gr2` → meshes/skeleton/animations/ipRow.
- `src/Renderer/GR2/GR2ModelRenderer.js` (+1090) — per-type cache, 40 Hz pose cache, draw.
- `src/Renderer/GR2/gr2World.js` (+161) — byte-cited world matrix (`/5`, handedness, grounding).
- `src/Renderer/GR2/gr2Pack.js` (+130) — vertex interleave, pose flatten, frustum cull helpers.
- `src/Renderer/GR2/actorAction.js` (+109) — action clock/state machine per instance.
- `src/Renderer/GR2/gr2Banks.js` (+44) — external animation-bank path resolution.
- `src/Renderer/GR2/gr2Math.js` (+28) — shared D3D row-vector helpers.
- `src/Renderer/GR2/GR2Model.vs` / `.fs` (+40 / +46) — GPU-skinning shaders.

Integration into the existing render path:

- `src/Renderer/Entity/EntityView.js` (+32 −…) — resolve the `.gr2` body path.
- `src/Renderer/Entity/EntityRender.js` (+54 −…) — attach instance, GR2 pick box.
- `src/Renderer/EntityManager.js` (+20 −…) — detach on removal.
- `src/Renderer/Entity/Entity.js` (+5) / `src/Renderer/MapRenderer.js` (+3) — seams.
- `package.json` (+1) — add `granny-ro-js ^1.4.1`.

Tests (`tests/`): +795 across loader, world, pack, actorAction, banks, entity suites.
