### PR TITLE
Fix #1379: window text too small — remove 10px font fallback + cross-OS base

### DIFF
--- a/src/App/PreLoader.js
+++ b/src/App/PreLoader.js
@@ -29,6 +29,7 @@ const PRELOADER_CSS = `
 	}  
 	#ro-preloader .pre-text {  
 		font-family: serif;  
+		font-size-adjust: none; /* keep serif's native x-height, outside body's Arial normalization */  
 		font-size: 16px;  
 		letter-spacing: 3px;  
 		text-transform: uppercase;  

--- a/src/DB/DBManager.js
+++ b/src/DB/DBManager.js
@@ -4040,12 +4040,12 @@ function loadFontFromClient(fontPath) {
 						`;
 					document.head.appendChild(style);
 				},
-				function (error) {
+				function () {
 					console.warn('[loadFontFromClient] - Failed to load client font:', fontPath);
 				}
 			);
 		},
-		function (error) {
+		function () {
 			console.warn('[loadFontFromClient] - Failed to load client font:', fontPath);
 		}
 	);

--- a/src/DB/DBManager.js
+++ b/src/DB/DBManager.js
@@ -4041,16 +4041,12 @@ function loadFontFromClient(fontPath) {
 					document.head.appendChild(style);
 				},
 				function (error) {
-					console.warn('[loadFontFromClient] - Failed loading client font:', fontPath, '- Using Arial');
-					document.body.style.fontFamily = 'Arial, Helvetica, sans-serif';
-					document.body.style.fontSize = '10px';
+					console.warn('[loadFontFromClient] - Failed to load client font:', fontPath);
 				}
 			);
 		},
 		function (error) {
-			console.warn('[loadFontFromClient] - Failed loading client font:', fontPath, '- Using Arial');
-			document.body.style.fontFamily = 'Arial, Helvetica, sans-serif';
-			document.body.style.fontSize = '10px';
+			console.warn('[loadFontFromClient] - Failed to load client font:', fontPath);
 		}
 	);
 }

--- a/src/UI/Common.css
+++ b/src/UI/Common.css
@@ -40,7 +40,10 @@ body {
 	   Gulim/Arial face table). Liberation Sans / Arimo provide Arial metrics on Linux. */
 	font-family: 'SCDream', Arial, 'Liberation Sans', Arimo, sans-serif;
 	/* Normalize any resolved font's x-height to Arial's (sxHeight 1062 / unitsPerEm 2048 = 0.5186),
-	   so text keeps Arial's apparent size on every OS/font. */
+	   so text keeps Arial's apparent size on every OS/font. It's inherited and crosses Shadow DOM
+	   hosts, so it also rescales elements that use a non-Arial face; those opt out with
+	   `font-size-adjust: none` on the selector declaring that font (Intro, GrfViewer, JoystickUI
+	   header). SCDream, when a server serves it, is normalized to Arial on purpose. */
 	font-size-adjust: 0.5186;
 	overflow: hidden;
 	-webkit-user-select: none;

--- a/src/UI/Common.css
+++ b/src/UI/Common.css
@@ -43,7 +43,10 @@ body {
 	   so text keeps Arial's apparent size on every OS/font. It's inherited and crosses Shadow DOM
 	   hosts, so it also rescales elements that use a non-Arial face; those opt out with
 	   `font-size-adjust: none` on the selector declaring that font (Intro, GrfViewer, JoystickUI
-	   header). SCDream, when a server serves it, is normalized to Arial on purpose. */
+	   header). SCDream, when a server serves it, is normalized to Arial on purpose.
+	   Progressive enhancement: engines that don't support the numeric form ignore it
+	   and render at the resolved font's native x-height (no JS fallback needed — Arial
+	   / Liberation Sans already carry correct metrics, only annex fonts degrade). */
 	font-size-adjust: 0.5186;
 	overflow: hidden;
 	-webkit-user-select: none;

--- a/src/UI/Common.css
+++ b/src/UI/Common.css
@@ -34,7 +34,14 @@ canvas {
 body {
 	background-color: black;
 	font-size: 12px;
-	font-family: 'SCDream', Arial, Helvetica, sans-serif;
+	/* 'SCDream' first: wins only when the server actually serves the client font (loaded via
+	   @font-face in DBManager). When it isn't served it resolves to Arial — the official client's
+	   window UI font for intl/america servicetype (Ragexe draws window text with CreateFontA on the
+	   Gulim/Arial face table). Liberation Sans / Arimo provide Arial metrics on Linux. */
+	font-family: 'SCDream', Arial, 'Liberation Sans', Arimo, sans-serif;
+	/* Normalize any resolved font's x-height to Arial's (sxHeight 1062 / unitsPerEm 2048 = 0.5186),
+	   so text keeps Arial's apparent size on every OS/font. */
+	font-size-adjust: 0.5186;
 	overflow: hidden;
 	-webkit-user-select: none;
 	user-select: none;

--- a/src/UI/Components/GrfViewer/GrfViewer.css
+++ b/src/UI/Components/GrfViewer/GrfViewer.css
@@ -7,6 +7,9 @@
 
 #grfviewer {
 	font-family: Times;
+	/* Opt out of Common.css's font-size-adjust: Times' x-height is smaller than Arial's, so
+	   normalizing would rescale this viewer's text (~+15%). Keep its native metrics. */
+	font-size-adjust: none;
 	margin-top: 60px;
 }
 

--- a/src/UI/Components/Intro/Intro.css
+++ b/src/UI/Components/Intro/Intro.css
@@ -42,6 +42,10 @@
 	transform-origin: center center;
 	backface-visibility: hidden;
 	font-family: 'Inter', sans-serif;
+	/* Opt out of Common.css's font-size-adjust: this whole screen renders in Inter/Cinzel, whose
+	   x-height differs from Arial's — normalizing would rescale its headings (Cinzel ~+18%). All
+	   descendants inherit this reset, keeping the pre-normalization rendering. */
+	font-size-adjust: none;
 	color: var(--text-light);
 }
 

--- a/src/UI/Components/JoystickUI/JoystickUI.css
+++ b/src/UI/Components/JoystickUI/JoystickUI.css
@@ -57,6 +57,9 @@
 	background: rgba(255, 255, 255, 0.1);
 	color: #e0e0e0;
 	font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+	/* Opt out of Common.css's font-size-adjust: keep Segoe UI's native x-height. Scoped to this
+	   header only — the .set-btn above uses generic sans-serif and stays normalized. */
+	font-size-adjust: none;
 	font-size: 14px;
 	font-weight: bold;
 	text-align: center;


### PR DESCRIPTION
## Summary

Fixes #1379 (ChatBox, NPC dialog, ItemInfo, SkillList text renders too small).

**Root cause — not the Shadow DOM migration** the issue suspected. `loadFontFromClient` (DBManager)
has a SCDream-load-failure fallback that hardcodes `document.body.style.fontSize = '10px'`. The
bundled SCDream OTF is a loose `System/Font/` file, and a share of deployments don't serve it.
Wherever it isn't served, the fallback fires and drops the whole UI base to **10px** — inherited by
the light DOM and across every shadow root. Measured (`getComputedStyle`): the shadow-DOM build reads `font-size: 10px`
on ChatBox log / NpcMenu and `11px` on SkillList, vs `12px` on a pre-migration build. Same rendered
font-family in both — the *size* is the variable, and it comes from this fallback.

**Fix**
- `DBManager.js` — remove the inline `body.style.fontFamily/fontSize = 10px` overrides in both
  loadFontFromClient fail paths (and the now-unused `error` param they carried), so `Common.css` is
  the single source of truth (base `12px`).
- `Common.css` — add `font-size-adjust: 0.5186` (Arial's OS/2 x-height ratio, sxHeight 1062 /
  unitsPerEm 2048) so any resolved font renders at Arial's apparent size on every OS; extend the
  stack with the Arial-metric Linux clones (Liberation Sans, Arimo) and drop the dead `Helvetica`.
  `'SCDream'` stays **first** — a server that serves the client font still gets it; otherwise it
  resolves to Arial. `font-size` (12px) and `line-height` (1.2) unchanged.

## Why Arial is the correct fallback base (RE of the official client)

The official Ragexe client draws window UI text via GDI `CreateFontA` on its Gulim/Arial face table:
`servicetype america`/international (iRO, most non-Korean servers) → **Arial**; `korea` → Gulim.
`SCDream` is **not** the window font and **not** a chat-font option — in the 2022 client it was the
servicetype-gated **default UI font for specific Korean service types** (font-cache slot
`0x1d`, registered process-wide via `AddFontResourceExA`), and it was removed in the 2026 client.
So for international servers Arial is the faithful base; keeping `'SCDream'` first preserves a
server's ability to opt in by serving the font (matches #1357's intent) while defaulting to Arial
when it isn't served.

## Fonts used in the UI

`font-size-adjust` is inherited and propagates through Shadow DOM hosts, so it normalizes the whole
UI — right for the Arial/SCDream interface, which is the vast majority. A few components deliberately
use a different, size-tuned face: left normalized, faces with a smaller x-height than Arial get scaled
up, so each opts out with `font-size-adjust: none` on the exact selector that declares its font (their
generic `sans-serif`/Arial parts stay normalized).

| Scope (selector) | Font | Where in the client | `font-size-adjust` |
|---|---|---|---|
| Global (`body`) | SCDream → Arial → Liberation Sans / Arimo | All window UI — ChatBox, NPC dialog, ItemInfo, SkillList… (the vast majority) | `0.5186` (normalize to Arial) |
| Intro (`.intro`) | Inter (body) + Cinzel (titles) | Pre-game landing / server-select screen | `none` |
| GrfViewer (`#grfviewer`) | Times | Dev GRF-browser tool | `none` |
| JoystickUI (`.group-header`) | Segoe UI | Mobile joystick header (buttons stay `sans-serif`, normalized) | `none` |

SCDream itself, when a server serves it, is normalized to Arial's ratio on purpose.

## Browser support

`font-size-adjust` (numeric form) is a progressive enhancement: engines that don't support it
ignore the property and render at the resolved font's native x-height — no JS fallback, no
functional break. Because the stack already prioritises Arial / Liberation Sans (correct
metrics), only annex fonts degrade on unsupporting engines. Cross-browser baseline for the
numeric form: Firefox (always), Safari 16.4 (Mar 2023), Chromium 127 (Jul 2024).

## Files changed

- `src/DB/DBManager.js` (+4 -8) — drop the 10px inline font fallback (Common.css owns the base font); trim the now-stale `- Using Arial` warn tail and the unused `error` param.
- `src/UI/Common.css` (+13 -1) — `font-size-adjust: 0.5186` + Arial-metric Linux fallbacks (SCDream still first); documents the inheritance / opt-out scope.
- `src/UI/Components/Intro/Intro.css` (+4) — `font-size-adjust: none` on `.intro` (keeps Inter/Cinzel native metrics).
- `src/UI/Components/GrfViewer/GrfViewer.css` (+3) — `font-size-adjust: none` on `#grfviewer` (keeps Times native metrics).
- `src/UI/Components/JoystickUI/JoystickUI.css` (+3) — `font-size-adjust: none` on the Segoe UI `.group-header`.
