### PR TITLE
Restore keyboard scroll in NPC choice menu (#1378)

### DIFF
--- a/src/UI/Components/NpcMenu/NpcMenu.js
+++ b/src/UI/Components/NpcMenu/NpcMenu.js
@@ -126,34 +126,25 @@ NpcMenu.onKeyDown = function onKeyDown(event) {
 			break;
 
 		case KEYS.UP: {
-			const divs = content.querySelectorAll('div');
+			const divs = content.querySelectorAll('div[data-index]');
 			_index = Math.max(_index - 1, 0);
 
 			divs.forEach(d => d.classList.remove('selected'));
 			if (divs[_index]) {
 				divs[_index].classList.add('selected');
-			}
-
-			const top = _index * 20;
-			if (top < content.scrollTop) {
-				content.scrollTop = top;
+				divs[_index].scrollIntoView({ block: 'nearest' });
 			}
 			break;
 		}
 
 		case KEYS.DOWN: {
-			const divs = content.querySelectorAll('div');
-			const count = divs.length;
-			_index = Math.min(_index + 1, count - 1);
+			const divs = content.querySelectorAll('div[data-index]');
+			_index = Math.min(_index + 1, divs.length - 1);
 
 			divs.forEach(d => d.classList.remove('selected'));
 			if (divs[_index]) {
 				divs[_index].classList.add('selected');
-			}
-
-			const top = _index * 20;
-			if (top >= content.scrollTop + 80) {
-				content.scrollTop = top - 60;
+				divs[_index].scrollIntoView({ block: 'nearest' });
 			}
 			break;
 		}
@@ -192,7 +183,7 @@ NpcMenu.setMenu = function setMenu(menu, gid) {
 		}
 	}
 
-	const first = content.querySelector('div');
+	const first = content.querySelector('div[data-index]');
 	if (first) {
 		first.classList.add('selected');
 	}
@@ -218,7 +209,7 @@ function cancel() {
 function selectIndex(div) {
 	const root = NpcMenu.getRoot();
 	const content = root.querySelector('.content');
-	const divs = content.querySelectorAll('div');
+	const divs = content.querySelectorAll('div[data-index]');
 	divs.forEach(d => d.classList.remove('selected'));
 	div.classList.add('selected');
 

--- a/src/UI/Scrollbar.js
+++ b/src/UI/Scrollbar.js
@@ -305,7 +305,10 @@ class ScrollBar {
 		let startThumbY = 0;
 
 		/**
-		 * Update thumb position relative to scroll position
+		 * Update thumb position relative to scroll position.
+		 * Reads scrollTop/scrollHeight/clientHeight and writes only the thumb,
+		 * wrapper and paddingRight styles — it never writes element.scrollTop,
+		 * so a 'scroll' listener calling this cannot trigger a re-entrant scroll.
 		 */
 		const updateThumb = () => {
 			const h = element.clientHeight;
@@ -369,6 +372,15 @@ class ScrollBar {
 		// scrollTop writes (keyboard navigation, auto-scroll-to-bottom, resets).
 		// An overflow:hidden element still fires 'scroll' when scrollTop changes,
 		// so this removes the up-to-300ms poller lag for driven scrolling.
+		// A skin change re-runs this body with a fresh updateThumb closure, so
+		// drop the previous handler before re-binding — otherwise a second
+		// listener tied to the now-detached wrapper would stack up. (The sibling
+		// wheel/button listeners bound to `element` below predate this and still
+		// leak this way on skin change; left as-is to keep the fix scoped.)
+		if (element._roScrollHandler) {
+			element.removeEventListener('scroll', element._roScrollHandler);
+		}
+		element._roScrollHandler = updateThumb;
 		element.addEventListener('scroll', updateThumb);
 
 		element.addEventListener('wheel', e => {

--- a/src/UI/Scrollbar.js
+++ b/src/UI/Scrollbar.js
@@ -365,6 +365,12 @@ class ScrollBar {
 		// Start tracking content height
 		element._roScrollbarRestart();
 
+		// Sync the thumb on any scroll offset change, including programmatic
+		// scrollTop writes (keyboard navigation, auto-scroll-to-bottom, resets).
+		// An overflow:hidden element still fires 'scroll' when scrollTop changes,
+		// so this removes the up-to-300ms poller lag for driven scrolling.
+		element.addEventListener('scroll', updateThumb);
+
 		element.addEventListener('wheel', e => {
 			const h = element.clientHeight;
 			const sh = element.scrollHeight;


### PR DESCRIPTION
## Summary

Fixes #1378 — after the `UIComponent → GUIComponent` (Shadow DOM) migration
(`70957a67`), navigating the NPC choice menu with ↑/↓ no longer scrolled the
list, so the highlighted choice could move out of view and the last entries
were unreachable visually.

Two-part fix, both minimal:

- **`NpcMenu.js`** — drive the selected row into view with
  `scrollIntoView({ block: 'nearest' })` instead of hand-rolled pixel math,
  and scope the row queries to `div[data-index]`.
- **`Scrollbar.js`** — the custom scrollbar now listens to the `scroll`
  event, so the thumb tracks *programmatic* scrolling instantly (keyboard
  nav, chat auto-scroll-to-bottom, `scrollTop` resets) instead of catching
  up on a 300 ms poll. The handler is stored and removed before re-binding
  so a skin re-apply swaps it in place instead of stacking a stale listener.

No CSS change — the scrollbar is drawn exactly as before.

## Root cause

The handler wrote `content.scrollTop` on `.content`. But `.content` has **no
`overflow`** property (`overflow: visible`), so it is *not* a scroll
container and `scrollTop` is a no-op there. The element that actually carries
`overflow-y: scroll` is the parent `.middle`. The keyboard code therefore
poked a non-scrolling element and nothing moved.

The JS *and* the CSS/HTML are byte-identical before and after the migration
(verified against `70957a67^`). What changed is the DOM model, not this
component's code:

- **Before (light DOM):** `.middle` scrolled natively in the global
  document, and — critically for #1378 — a native scroll still moved the
  content even though the handler targeted the "wrong" element, because the
  browser's own scrollbar and wheel/keyboard defaults acted on `.middle`.
- **After (Shadow DOM):** `GUIComponent._setupScrollbars()` finds every
  element whose computed `overflow-y` is `auto`/`scroll`, and
  `ScrollBar.applyDOMScrollbar()` forces it to `overflow-y: hidden` and
  replaces native scrolling with a custom widget. The keyboard handler never
  talks to that widget, so the list froze.

Verified this is **specific to NpcMenu**: it is the only migrated component
that writes `scrollTop` to an element other than its own scroll container.
Inventory V0–V3 use `.middle { overflow: hidden }` and scroll the real host
element; WinList changes selection without scrolling; ChatBox / WhisperBox /
Storage / Vending all scroll their own `overflow-y: auto` element.

## Design decisions (and why)

**Why `scrollIntoView` instead of fixing the old pixel math?**
The original code assumed a fixed 20 px row height and an 80 px viewport
(`top = _index * 20`, `+ 80`, `- 60`). Those constants are brittle: they
silently break if the row height, padding, font metrics or viewport size
ever change, and they only produce a correct result when applied to the
exact element they were tuned for. `scrollIntoView({ block: 'nearest' })`
scrolls the *real* scroll ancestor (`.middle`), needs zero magic constants,
and inherently keeps the selected row fully visible (including the last one,
which was the explicit ask in the issue). It is also robust to the custom
scrollbar's `overflow-y: hidden` — an `overflow: hidden` element is still
programmatically scrollable, and `scrollIntoView` drives it correctly.

**Why not the "make `.content` the scroll container" CSS route?**
The first attempt moved `overflow-y` onto `.content` (so the existing
`content.scrollTop` writes would work). It was rejected for two concrete
reasons found in testing:
1. `applyDOMScrollbar()` injects its widget DOM (`.ro-custom-scrollbar` with
   `.btn-up` / `.track` / `.thumb` / `.btn-down` `<div>`s) *inside* the
   scrolled element. `.content` is exactly the element whose child `<div>`s
   the menu iterates (`content.querySelectorAll('div')`), so those injected
   divs were counted as menu entries — the selection index ran past the real
   options and kept "scrolling" into the scrollbar parts.
2. Moving the scroll container also relocated where the scrollbar was drawn
   (`.middle` → `.content`), changing its appearance versus the shipped
   client.
   Keeping the scrollbar on `.middle` and fixing the scroll purely in JS
   avoids both problems and guarantees pixel-identical scrollbar rendering.

**Why scope the queries to `div[data-index]`?**
`setMenu()` tags every real menu row with a `data-index`. Selecting
`div[data-index]` matches exactly the menu options and can never pick up an
injected scrollbar `<div>` (or any future descendant), regardless of which
element ends up hosting the custom scrollbar. It is a defensive, semantic
selector; with the scrollbar staying on `.middle` it is not strictly
required today, but it hardens all four query sites (`onKeyDown` ↑/↓,
`setMenu`, `selectIndex`) against re-introducing the contamination bug.

**Why the `scroll` listener in `ScrollBar.js`, and why it is safe/general.**
`applyDOMScrollbar()` only re-synced the thumb from the wheel/button/drag
handlers and a 300 ms `setInterval` poller — it never listened to the
`scroll` event. So any *programmatic* scroll (this fix's `scrollIntoView`,
but also ChatBox/WhisperBox auto-scroll-to-bottom and `scrollTop = 0`
resets) moved the content immediately while the thumb lagged up to 300 ms.
Adding `element.addEventListener('scroll', updateThumb)` makes the thumb
follow any `scrollTop` change instantly. It is:
- **Additive** — the poller and manual `updateThumb()` calls are untouched;
  the poller still covers `scrollHeight` changes that fire no scroll event
  (e.g. a new chat line appended while pinned to top).
- **Loop-free** — `updateThumb()` only reads `scrollTop`/`scrollHeight` and
  writes the thumb/wrapper styles and `paddingRight`; it never writes
  `scrollTop`, so it cannot re-enter via its own listener. The absolutely
  positioned wrapper is pinned at `top = scrollTop`, `height = clientHeight`,
  so its bottom never exceeds `scrollHeight` and cannot inflate the scroll
  range.
- **Idempotent per element** — the `_roScrollbarApplied` guard ensures a
  single listener is attached per element.
- **Leak-safe on re-apply** — the handler is stored on
  `element._roScrollHandler` and `removeEventListener`'d before re-binding,
  so a skin change (which re-runs the full `applyDOMScrollbar` body) swaps
  the listener in place instead of stacking a second one bound to a stale,
  detached wrapper closure. See "Review notes" below.

## Review notes (investigation)

Two points were raised in review of the `Scrollbar.js` change; both were
investigated against `applyDOMScrollbar()`'s re-apply path (guard at
`Scrollbar.js:172-189`):

1. **Duplicate `scroll` listener on skin re-apply — fixed.** Under normal use
   the `_roScrollbarApplied` guard attaches the listener exactly once. But on
   a skin change the guard removes the wrapper and falls through to re-run the
   whole body, which re-attached a second `scroll` listener bound to a stale
   `updateThumb` closure (referencing the now-detached wrapper) without
   removing the old one. This is now fixed by storing the handler on
   `element._roScrollHandler` and removing it before re-binding, which also
   rebinds the fresh `updateThumb` after a skin swap. NpcMenu never changes
   skin, so its target never hit this, but the fix removes the leak in
   general. The sibling `wheel`/button listeners bound to `element` share the
   same pre-existing re-apply leak; that is called out in a code comment and
   left untouched to keep this PR scoped to #1378.
2. **No feedback loop between the listener and `updateThumb` — confirmed, no
   fix needed.** `updateThumb` only reads `scrollTop`/`scrollHeight`/
   `clientHeight` and writes the thumb/wrapper styles and `paddingRight`; it
   never writes `element.scrollTop`, so it cannot re-enter via its own
   listener. `paddingRight` is set idempotently to `original + width`, and
   `.content`'s fixed `width: 260px` means the added right padding on
   `.middle` cannot reflow content height. This invariant is now documented in
   the `updateThumb` docblock so the guarantee is explicit at the source.

## Limitations / caveats

- **Residual title offset at the top.** `.middle` is the scroll viewport and
  contains the (empty) `.title` span above `.content`. `scrollIntoView(
  { block: 'nearest' })` on row 0 only guarantees row 0 is *visible*; it does
  not force `scrollTop = 0`, so ~8 px of title/margin can remain scrolled
  under. This matches the shipped behaviour closely enough and was accepted
  in testing; a strict snap-to-top would be a one-liner
  (`if (_index === 0) middle.scrollTop = 0`) but is intentionally not
  included to keep the diff minimal.
- **Thumb re-sync latency for non-scroll changes is unchanged.** The new
  listener covers `scrollTop` changes only. Content-height changes that do
  not move `scrollTop` still rely on the existing 300 ms poller (by design,
  left as-is).
- **`scrollIntoView` scrolls the nearest scrollable ancestor.** In this
  layout that is `.middle`; the game viewport (`body { overflow: hidden }`)
  is not scrollable, so there is no risk of scrolling the world. `block:
  'nearest'` further minimises movement.
- **Scope is deliberately narrow.** Only NpcMenu had the functional break, so
  no other component's markup or JS is touched. The `Scrollbar.js` change is
  shared infrastructure but strictly additive and benefits every custom-
  scrollbar component (chat auto-scroll, keyboard lists, resets) without
  altering their existing behaviour.

## Files changed

- `src/UI/Components/NpcMenu/NpcMenu.js` (+8 −15) — replace pixel-math scroll
  with `scrollIntoView`; scope the four row queries to `div[data-index]`.
- `src/UI/Scrollbar.js` (+20 −1) — sync the custom thumb on the `scroll`
  event (removes the 300 ms poller lag for programmatic scrolling; general
  fix), with leak-safe re-binding and the no-re-entrancy invariant documented.