### PR TITLE
Fixes GUI components sizes

### DIFF
--- a/applications/pwa/index.html
+++ b/applications/pwa/index.html
@@ -36,7 +36,6 @@
 
 		<style type="text/css">
 			html,
-			div,
 			body {
 				margin: 0;
 				padding: 0;
@@ -44,6 +43,10 @@
 				height: 100%;
 				width: 100%;
 				overflow: hidden;
+			}
+			#robrowser {
+				height: 100%;
+				width: 100%;
 			}
 			/* Pre-loader — appears instantly, before any JS */
 			#ro-preloader {


### PR DESCRIPTION
- OS : Linux
- Browser tested : Chromium, Firefox Developer

The bare `div` selector matches every GUIComponent host, turning each UI window into a full-viewport overlay
Made interacting with the world impossible, it kept selecting UI windows

Targets the main container instead fixes it