### PR TITLE
Fix joystick restore after local teleport

### DIFF
--- a/src/Renderer/MapRenderer.js
+++ b/src/Renderer/MapRenderer.js
@@ -162,6 +162,7 @@ class MapRenderer {
 		EntityManager.free();
 		Damage.free(gl);
 		EffectManager.free(gl);
+		JoystickUI.onRestore();
 
 		// Basic TP
 		Mouse.intersect = false;

--- a/tests/renderer/MapRenderer.test.js
+++ b/tests/renderer/MapRenderer.test.js
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+	soundManager: { stop: vi.fn() },
+	bgm: { stop: vi.fn() },
+	uiManager: { removeComponents: vi.fn() },
+	background: {
+		remove: vi.fn(callback => callback()),
+		setLoading: vi.fn()
+	},
+	cursor: {
+		ACTION: { DEFAULT: 0 },
+		setType: vi.fn()
+	},
+	mouse: { intersect: true },
+	renderer: {
+		stop: vi.fn(),
+		getContext: vi.fn(() => ({})),
+		render: vi.fn()
+	},
+	entityManager: { free: vi.fn() },
+	effectManager: { free: vi.fn() },
+	sky: { setUpCloudData: vi.fn() },
+	damage: { free: vi.fn() },
+	joystickUI: { onRestore: vi.fn() }
+}));
+
+vi.mock('Core/Thread.js', () => ({ default: {} }));
+vi.mock('Audio/SoundManager.js', () => ({ default: mocks.soundManager }));
+vi.mock('Audio/BGM.js', () => ({ default: mocks.bgm }));
+vi.mock('DB/DBManager.js', () => ({ default: {} }));
+vi.mock('UI/UIManager.js', () => ({ default: mocks.uiManager }));
+vi.mock('UI/Background.js', () => ({ default: mocks.background }));
+vi.mock('UI/CursorManager.js', () => ({ default: mocks.cursor }));
+vi.mock('Engine/SessionStorage.js', () => ({ default: {} }));
+vi.mock('Core/MemoryManager.js', () => ({ default: {} }));
+vi.mock('Controls/MouseEventHandler.js', () => ({ default: mocks.mouse }));
+vi.mock('Renderer/Renderer.js', () => ({ default: mocks.renderer }));
+vi.mock('Renderer/Camera.js', () => ({ default: {} }));
+vi.mock('Renderer/EntityManager.js', () => ({ default: mocks.entityManager }));
+vi.mock('Renderer/Map/GridSelector.js', () => ({ default: {} }));
+vi.mock('Renderer/Map/Ground.js', () => ({ default: {} }));
+vi.mock('Renderer/Map/Altitude.js', () => ({ default: {} }));
+vi.mock('Renderer/Map/Water.js', () => ({ default: {} }));
+vi.mock('Renderer/Map/Models.js', () => ({ default: {} }));
+vi.mock('Renderer/Map/AnimatedModels.js', () => ({ default: {} }));
+vi.mock('Renderer/GR2/GR2ModelRenderer.js', () => ({ default: {} }));
+vi.mock('Renderer/Map/Sounds.js', () => ({ default: {} }));
+vi.mock('Renderer/Map/Effects.js', () => ({ default: {} }));
+vi.mock('Renderer/SpriteRenderer.js', () => ({ default: {} }));
+vi.mock('Renderer/EffectManager.js', () => ({ default: mocks.effectManager }));
+vi.mock('Renderer/SignboardManager.js', () => ({ default: {} }));
+vi.mock('Renderer/ScreenEffectManager.js', () => ({ default: {} }));
+vi.mock('Renderer/Effects/Sky.js', () => ({ default: mocks.sky }));
+vi.mock('Renderer/Effects/Damage.js', () => ({ default: mocks.damage }));
+vi.mock('Preferences/Graphics.js', () => ({ default: {} }));
+vi.mock('Preferences/Map.js', () => ({ default: { useFog: true } }));
+vi.mock('Utils/gl-matrix.js', () => ({ default: { mat4: {} } }));
+vi.mock('Network/PacketVerManager.js', () => ({ default: {} }));
+vi.mock('UI/Components/JoystickUI/JoystickUI.js', () => ({ default: mocks.joystickUI }));
+vi.mock('Renderer/Effects/PostProcess.js', () => ({ default: {} }));
+vi.mock('Renderer/Effects/Shaders/Bloom.js', () => ({ default: {} }));
+vi.mock('Renderer/Effects/Shaders/VerticalFlip.js', () => ({ default: {} }));
+vi.mock('Renderer/Effects/Shaders/GaussianBlur.js', () => ({ default: {} }));
+vi.mock('Renderer/Effects/Shaders/CAS.js', () => ({ default: {} }));
+vi.mock('Renderer/Effects/Shaders/FXAA.js', () => ({ default: {} }));
+vi.mock('Renderer/Effects/Shaders/Vibrance.js', () => ({ default: {} }));
+vi.mock('Renderer/Effects/Shaders/Cartoon.js', () => ({ default: {} }));
+vi.mock('Renderer/Effects/Shaders/Blind.js', () => ({ default: {} }));
+vi.mock('Renderer/Effects/Shaders/Upsampling.js', () => ({ default: {} }));
+vi.mock('Utils/WebGL.js', () => ({ default: {} }));
+
+const { default: MapRenderer } = await import('Renderer/MapRenderer.js');
+
+describe('MapRenderer joystick restoration', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		MapRenderer.loading = false;
+		MapRenderer.currentMap = 'prontera.gat';
+		MapRenderer.onLoad = vi.fn();
+		mocks.mouse.intersect = true;
+	});
+
+	it('restores joystick polling before re-appending UI after a same-map teleport', () => {
+		MapRenderer.setMap('prontera.gat');
+
+		expect(mocks.uiManager.removeComponents).toHaveBeenCalledOnce();
+		expect(mocks.joystickUI.onRestore).toHaveBeenCalledOnce();
+		expect(MapRenderer.onLoad).toHaveBeenCalledOnce();
+		expect(mocks.joystickUI.onRestore.mock.invocationCallOrder[0]).toBeLessThan(
+			MapRenderer.onLoad.mock.invocationCallOrder[0]
+		);
+	});
+
+	it('leaves different-map restoration to the map completion lifecycle', () => {
+		MapRenderer.setMap('geffen.gat');
+
+		expect(mocks.background.setLoading).toHaveBeenCalledOnce();
+		expect(mocks.joystickUI.onRestore).not.toHaveBeenCalled();
+		expect(MapRenderer.onLoad).not.toHaveBeenCalled();
+	});
+});

--- a/tests/ui/JoystickUIRenderer.test.js
+++ b/tests/ui/JoystickUIRenderer.test.js
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+	controls: {
+		joyAutoHide: true
+	},
+	inputService: {
+		active: true
+	}
+}));
+
+vi.mock('UI/Components/ShortCut/ShortCut.js', () => ({ default: {} }));
+vi.mock('UI/Components/Inventory/Inventory.js', () => ({ default: {} }));
+vi.mock('UI/Components/JoystickUI/JoystickSetManager.js', () => ({ default: {} }));
+vi.mock('DB/DBManager.js', () => ({ default: {} }));
+vi.mock('Core/Client.js', () => ({ default: {} }));
+vi.mock('Preferences/Controls.js', () => ({ default: mocks.controls }));
+vi.mock('DB/Items/ItemType.js', () => ({ default: {} }));
+vi.mock('UI/Components/JoystickUI/JoystickShortcutMapper.js', () => ({ default: {} }));
+vi.mock('UI/Components/JoystickUI/JoystickInputService.js', () => ({ default: mocks.inputService }));
+vi.mock('DB/Skills/SkillInfo.js', () => ({ default: {} }));
+
+const { default: JoystickUIRenderer } = await import('UI/Components/JoystickUI/JoystickUIRenderer.js');
+
+function createUI() {
+	const host = document.createElement('div');
+	host.style.display = 'block';
+
+	return {
+		0: host,
+		show: vi.fn(() => {
+			host.style.display = 'block';
+		}),
+		hide: vi.fn(() => {
+			host.style.display = 'none';
+		})
+	};
+}
+
+describe('JoystickUIRenderer mouse auto-hide', () => {
+	afterEach(() => {
+		JoystickUIRenderer.dispose();
+	});
+
+	it('hides on physical mouse movement after attach and reattach', () => {
+		const firstUI = createUI();
+		JoystickUIRenderer.attach(firstUI);
+		mocks.inputService.active = true;
+
+		document.dispatchEvent(new MouseEvent('mousemove', { clientX: 10, clientY: 0 }));
+
+		expect(firstUI.hide).toHaveBeenCalledOnce();
+		expect(mocks.inputService.active).toBe(false);
+
+		JoystickUIRenderer.dispose();
+
+		const restoredUI = createUI();
+		JoystickUIRenderer.attach(restoredUI);
+		mocks.inputService.active = true;
+
+		document.dispatchEvent(new MouseEvent('mousemove', { clientX: 0, clientY: 10 }));
+
+		expect(restoredUI.hide).toHaveBeenCalledOnce();
+		expect(mocks.inputService.active).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

- Restore joystick polling after same-map teleports such as using a Fly Wing.
- Preserve the existing controller-to-mouse UI switching behavior.
- Add regression coverage for local-teleport restoration and mouse auto-hide after UI reattachment.

## Root cause

Map changes remove all UI components, which disposes the joystick polling loop. Full map loads restore it through `JoystickUI.onRestore()`, but the same-map teleport path did not.

**As a result, using a Fly Wing through the controller caused the controller HUD to disappear permanently until returning to character selection.**

## Testing

- Manually tested in Safari on MacOS with a physical PS5 controller (native support):
  - Controller input displays the joystick HUD.
  - Using a Fly Wing performs a same-map teleport.
  - Controller input displays the HUD again afterward.
  - With Auto Hide UI enabled, physical mouse movement immediately hides the HUD.