### PR TITLE
Fix Guild and Clan window sizing

### DIFF
--- a/src/UI/Components/Clan/Clan.css
+++ b/src/UI/Components/Clan/Clan.css
@@ -43,10 +43,12 @@
 }
 
 #Clan .content {
+	position: relative;
+	box-sizing: border-box;
 	overflow-y: auto;
 	padding: 2px;
 	border-top: 1px solid #c6c6c6;
-	height: 238px;
+	height: 250px;
 }
 
 #Clan .tabs {

--- a/src/UI/Components/Guild/Guild.css
+++ b/src/UI/Components/Guild/Guild.css
@@ -39,10 +39,12 @@
 	padding-right: 2px;
 }
 #Guild .content {
+	position: relative;
+	box-sizing: border-box;
 	overflow-y: auto;
 	padding: 2px;
 	border-top: 1px solid #c6c6c6;
-	height: 238px;
+	height: 250px;
 }
 
 #Guild .tabs {


### PR DESCRIPTION
Fixes #1283 

Give Guild and Clan content panels a stable 250px border-box matching their 317px windows. This removes unnecessary scrollbars and prevents resizing between Guild tabs.

<img width="406" height="325" alt="Screenshot 2026-08-07 at 19 11 47" src="https://github.com/user-attachments/assets/0320b58d-1787-4d3c-9a02-d10c68b417d1" />