### PR TITLE
Fix mobile touch target activation and retention

### DIFF
--- a/src/Controls/MapControl.js
+++ b/src/Controls/MapControl.js
@@ -207,11 +207,11 @@ function onMouseUp(event) {
 				ET = entity.constructor;
 				entity.onMouseUp();
 
-				// Entity lock is only on MOB type (except when Touch Targeting is active)
+				// Touch Targeting retains any selected entity independently of /nc.
 				if (
-					Preferences.noctrl === false ||
-					(![ET.TYPE_MOB, ET.TYPE_NPC_ABR, ET.TYPE_NPC_BIONIC].includes(entity.objecttype) &&
-						!Session.TouchTargeting)
+					!Session.TouchTargeting &&
+					(Preferences.noctrl === false ||
+						![ET.TYPE_MOB, ET.TYPE_NPC_ABR, ET.TYPE_NPC_BIONIC].includes(entity.objecttype))
 				) {
 					EntityManager.setFocusEntity(null);
 					entity.onFocusEnd();

--- a/src/UI/Components/MobileUI/MobileUI.js
+++ b/src/UI/Components/MobileUI/MobileUI.js
@@ -95,6 +95,11 @@ function bindButton(root, selector, handler) {
 			ignoreClickUntil = Date.now() + C_TOUCH_CLICK_GUARD;
 			handler(event);
 		});
+		const rearmGuard = () => {
+			ignoreClickUntil = Date.now() + C_TOUCH_CLICK_GUARD;
+		};
+		el.addEventListener('touchend', rearmGuard);
+		el.addEventListener('touchcancel', rearmGuard);
 	}
 }
 

--- a/src/UI/Components/MobileUI/MobileUI.js
+++ b/src/UI/Components/MobileUI/MobileUI.js
@@ -64,6 +64,7 @@ const _preferences = Preferences.get(
 let showButtons = false;
 let autoTargetTimer;
 const C_AUTOTARGET_DELAY = 500;
+const C_TOUCH_CLICK_GUARD = 750;
 
 let centerX, centerY;
 let maxDistance = 0;
@@ -80,8 +81,20 @@ let _joystickThumb = null;
 function bindButton(root, selector, handler) {
 	const el = root.querySelector(selector);
 	if (el) {
-		el.addEventListener('click', handler);
-		el.addEventListener('touchstart', handler);
+		let ignoreClickUntil = 0;
+
+		el.addEventListener('click', event => {
+			if (Date.now() < ignoreClickUntil) {
+				event.preventDefault();
+				event.stopImmediatePropagation();
+				return;
+			}
+			handler(event);
+		});
+		el.addEventListener('touchstart', event => {
+			ignoreClickUntil = Date.now() + C_TOUCH_CLICK_GUARD;
+			handler(event);
+		});
 	}
 }
 


### PR DESCRIPTION
Fixes #1271.

## What changed

- Prevent compatibility clicks following `touchstart` from toggling Mobile UI controls twice.
- Keep the selected entity focused while Touch Targeting is active, regardless of `/nc`.
- Preserve existing mouse, attack-button, and Auto Targeting behavior.

## Root cause

Some touch environments emit both `touchstart` and a compatibility `click`, immediately switching Touch Targeting back off. Additionally, `/nc` could override Touch Targeting and clear the selected entity on release.

## Validation

https://github.com/user-attachments/assets/bd9b03d6-87e0-4bd1-a224-ecc8d7574d25

Verified in macOS Chrome emulating touch interface (see video), on iOS Safari and iOS Chrome.

## Follow-up

Opened #1394 to expand the touch UI for Fire Wall and Storm Gust-like skills aiming on the ground.