### PR TITLE
Preserve ground skill placement with Touch Targeting

### DIFF
--- a/src/Controls/MapControl.js
+++ b/src/Controls/MapControl.js
@@ -86,6 +86,11 @@ function onMouseDown(event) {
 		return;
 	}
 
+	if (Mouse.state === Mouse.MOUSE_STATE.USESKILL) {
+		SkillTargetSelection.intersect(event);
+		return;
+	}
+
 	const entityFocus = EntityManager.getFocusEntity();
 	const entityOver = EntityManager.getOverEntity();
 

--- a/src/UI/Components/SkillTargetSelection/SkillTargetSelection.js
+++ b/src/UI/Components/SkillTargetSelection/SkillTargetSelection.js
@@ -176,23 +176,14 @@ SkillTargetSelection.set = function set(skill, target, description) {
 		return;
 	}
 
-	if (Session.TouchTargeting) {
+	if (Session.TouchTargeting && !(_flag & SkillTargetSelection.TYPE.PLACE)) {
 		const entityFocus = EntityManager.getFocusEntity();
 		if (entityFocus) {
-			if (_flag & SkillTargetSelection.TYPE.PLACE) {
-				SkillTargetSelection.onUseSkillToPos(
-					_skill.SKID,
-					_skill.useLevel ? _skill.useLevel : _skill.level,
-					entityFocus.position[0],
-					entityFocus.position[1]
-				);
-			} else {
-				SkillTargetSelection.onUseSkillToId(
-					_skill.SKID,
-					_skill.useLevel ? _skill.useLevel : _skill.level,
-					entityFocus.GID
-				);
-			}
+			SkillTargetSelection.onUseSkillToId(
+				_skill.SKID,
+				_skill.useLevel ? _skill.useLevel : _skill.level,
+				entityFocus.GID
+			);
 			SkillTargetSelection.remove();
 			return;
 		}
@@ -297,12 +288,14 @@ function intersectEntities(event) {
 		return false;
 	}
 
-	if (event.which !== 1) {
+	if (event && event.which !== 1) {
 		return true;
 	}
 
-	event.stopImmediatePropagation();
-	event.preventDefault();
+	if (event) {
+		event.stopImmediatePropagation();
+		event.preventDefault();
+	}
 
 	if (_flag & SkillTargetSelection.TYPE.PLACE) {
 		SkillTargetSelection.onUseSkillToPos(
@@ -327,6 +320,10 @@ function intersectEntities(event) {
 	intersectEntity(entity);
 	return false;
 }
+
+SkillTargetSelection.intersect = function intersect(event) {
+	return intersectEntities(event);
+};
 
 /**
  * Intersect with an entity


### PR DESCRIPTION
Fixes #1394.

Enables the use of Fire Wall, Storm Gust, etc., while using Touch Targeting.

## What changed

- Keep ground-targeted skills in the existing placement mode when Touch Targeting has retained an entity.
- Route touch input during skill placement through the existing targeting handler instead of moving the character.
- Preserve immediate casting for entity-targeted skills with a retained target.

## Root cause

Touch Targeting automatically cast ground-targeted skills at the retained entity’s position. After restoring placement mode, touch input still bypassed its mouse-based handler, causing movement while leaving placement active.

## Validation

- Verified in Chrome in mobile emulation mode

https://github.com/user-attachments/assets/e4b931aa-85c0-4724-8cc6-b54591f79406

Builds on the retained-target behavior fixed in #1271.