### PR TITLE
fix rotation bug on uis

### DIFF
--- a/src/Controls/MapControl.js
+++ b/src/Controls/MapControl.js
@@ -73,7 +73,26 @@ class MapControl {
 
 		window.addEventListener('mousedown', onMouseDown.bind(this));
 		window.addEventListener('mouseup', onMouseUp.bind(this));
+
+		// A mouseup released over a UI element can be swallowed by the element's
+		// own handler (e.g. scrollbars call stopPropagation), so the bubbling
+		// 'mouseup' above never fires and the camera would keep rotating.
+		// Listen in the capture phase to always catch the release.
+		window.addEventListener('mouseup', onMouseUpCapture, true);
 	}
+}
+
+/**
+ * Stop the camera rotation when the right button is released, even if the
+ * release happens over a UI element that swallows the bubbling mouseup event.
+ */
+function onMouseUpCapture(event) {
+	if (event.which !== 3 || !Camera.action.active) {
+		return;
+	}
+
+	Cursor.setType(Cursor.ACTION.DEFAULT);
+	Camera.rotate(false);
 }
 
 /**


### PR DESCRIPTION
Fix a bug where you lifted right-click (rotation) over UI's it would keep rotating even without clicks until you started rotating again.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mrantares/robrowserlegacy/pull/1405" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->