### PR TITLE
Fix right click trigger actions

### DIFF
--- a/src/Controls/MapControl.js
+++ b/src/Controls/MapControl.js
@@ -163,29 +163,27 @@ function onMouseDown(event) {
 				} else {
 					AIDriver.setmsg(Session.homunId, '1,' + Mouse.world.x + ',' + Mouse.world.y);
 				}
-			} else {
-				if (
-					entityOver &&
-					entityOver != Session.Entity &&
-					entityOver.objecttype != Entity.TYPE_EFFECT &&
-					entityOver.objecttype != Entity.TYPE_TRAP
-				) {
-					if (KEYS.SHIFT) {
-						// Shift + Right click on an entity
-						Session.autoFollowTarget = entityOver;
-						Session.autoFollow = true;
-						onAutoFollow();
-					}
-
-					// Right click on a NPC/Mob/Unit
-					entityOver.onMouseDown();
-					entityOver.onFocus();
-					EntityManager.setFocusEntity(entityOver);
+		} else {
+			if (
+				entityOver &&
+				entityOver != Session.Entity &&
+				entityOver.objecttype != Entity.TYPE_EFFECT &&
+				entityOver.objecttype != Entity.TYPE_TRAP
+			) {
+				if (KEYS.SHIFT) {
+					// Shift + Right click on an entity
+					Session.autoFollowTarget = entityOver;
+					Session.autoFollow = true;
+					onAutoFollow();
 				}
-
-				Cursor.setType(Cursor.ACTION.ROTATE);
-				Camera.rotate(true);
 			}
+
+			// Right click only rotates the camera here. Attacks/dialogs with
+			// NPCs/Mobs are triggered on mouseup via onContextMenu() (when the
+			// cursor hasn't moved), matching the official client behavior.
+			Cursor.setType(Cursor.ACTION.ROTATE);
+			Camera.rotate(true);
+		}
 			break;
 	}
 }

--- a/src/Controls/MapControl.js
+++ b/src/Controls/MapControl.js
@@ -163,27 +163,25 @@ function onMouseDown(event) {
 				} else {
 					AIDriver.setmsg(Session.homunId, '1,' + Mouse.world.x + ',' + Mouse.world.y);
 				}
-		} else {
-			if (
-				entityOver &&
-				entityOver != Session.Entity &&
-				entityOver.objecttype != Entity.TYPE_EFFECT &&
-				entityOver.objecttype != Entity.TYPE_TRAP
-			) {
-				if (KEYS.SHIFT) {
-					// Shift + Right click on an entity
-					Session.autoFollowTarget = entityOver;
-					Session.autoFollow = true;
-					onAutoFollow();
+			} else {
+				if (
+					entityOver &&
+					entityOver != Session.Entity &&
+					entityOver.objecttype != Entity.TYPE_EFFECT &&
+					entityOver.objecttype != Entity.TYPE_TRAP
+				) {
+					if (KEYS.SHIFT) {
+						// Shift + Right click on an entity
+						Session.autoFollowTarget = entityOver;
+						Session.autoFollow = true;
+						onAutoFollow();
+					}
 				}
-			}
 
-			// Right click only rotates the camera here. Attacks/dialogs with
-			// NPCs/Mobs are triggered on mouseup via onContextMenu() (when the
-			// cursor hasn't moved), matching the official client behavior.
-			Cursor.setType(Cursor.ACTION.ROTATE);
-			Camera.rotate(true);
-		}
+				// Right click only rotates the camera here.
+				Cursor.setType(Cursor.ACTION.ROTATE);
+				Camera.rotate(true);
+			}
 			break;
 	}
 }


### PR DESCRIPTION
This fixes right-clicking triggering attack actions/talk to npc actions which is not default ragnarok behaviour.
Right-clicking on players still toggle the context menu.