### PR TITLE
Fix skill tree prerequisite allocation

### DIFF
--- a/src/UI/Components/SkillList/SkillListCommon.js
+++ b/src/UI/Components/SkillList/SkillListCommon.js
@@ -24,6 +24,11 @@ import SkillDescription from 'UI/Components/SkillDescription/SkillDescription.js
 import SkillInfo from 'DB/Skills/SkillInfo.js';
 import SkillTargetSelection from 'UI/Components/SkillTargetSelection/SkillTargetSelection.js';
 import SkillTreeView from 'DB/Skills/SkillTreeView.js';
+import {
+	createSkillUpgradeOrder,
+	resolveSkillRequirements,
+	stageSkillPlan
+} from 'UI/Components/SkillList/SkillRequirements.js';
 import UIManager from 'UI/UIManager.js';
 
 function _escapeHTML(text) {
@@ -41,10 +46,8 @@ export function createSkillList({
 	htmlText,
 	cssText,
 	hasTabs = false,
-	needSkillListKey = '_NeedSkillList',
 	showDescOnMiniHover = false,
 	touchDrag = false,
-	incrementalRemember = false,
 	guardMissingJob = false,
 	readdSkillOnUpdate = false,
 	listOnly = false,
@@ -77,7 +80,8 @@ export function createSkillList({
 	let _lArrow, _rArrow;
 	let skillPosition = [];
 	const skillDependencyTree = [];
-	let rememberChoice = [];
+	let skillJobId = null;
+	let rememberChoice = new Map();
 	const hasSkills = [];
 	let _justDragged = false;
 
@@ -106,6 +110,7 @@ export function createSkillList({
 			onResize(e, this);
 		});
 		root.querySelector('.titlebar .close')?.addEventListener('click', () => {
+			onResetChoice(this);
 			this.ui.hide();
 		});
 		root.querySelector('.titlebar .mini')?.addEventListener('click', () => {
@@ -342,6 +347,7 @@ export function createSkillList({
 
 	Component.toggle = function toggle() {
 		if (this.ui.is(':visible')) {
+			onResetChoice(this);
 			this.ui.hide();
 			if (_btnLevelUp && _btnLevelUp.parentNode) {
 				_btnLevelUp.remove();
@@ -358,7 +364,6 @@ export function createSkillList({
 				this.toggle();
 				break;
 		}
-		onResetChoice(this);
 	};
 
 	Component.setSkills = function setSkills(skills) {
@@ -385,9 +390,10 @@ export function createSkillList({
 
 		// The skill tree follows the real job, never a transformation/disguise
 		const entity = Session.Entity;
-		const skillJobId = entity ? entity._job || entity.job : 0;
+		skillJobId = entity ? entity._job || entity.job : 0;
 
 		skillPosition = getSkillPosition(skillJobId);
+		skillDependencyTree.length = 0;
 		createSkillDependencyTree();
 
 		for (let i = 0, count = _list.length; i < count; ++i) {
@@ -395,6 +401,7 @@ export function createSkillList({
 		}
 
 		_list.length = 0;
+		hasSkills.length = 0;
 		if (hasTabs) {
 			root.querySelectorAll('.content table').forEach(t => {
 				t.innerHTML = '';
@@ -459,11 +466,9 @@ export function createSkillList({
 							MaxLv: sk.MaxLv
 						};
 
-						if (sk?.[needSkillListKey] !== undefined) {
-							sk[needSkillListKey].forEach(item => {
-								skillDependencyTree[skid]['dependency'][item[0]] = item[1];
-							});
-						}
+						resolveSkillRequirements(sk, skillJobId, SkillTreeView).forEach(item => {
+							skillDependencyTree[skid]['dependency'][item[0]] = item[1];
+						});
 					} else {
 						console.error('Something wrong with this skill: %d', skid);
 					}
@@ -475,45 +480,42 @@ export function createSkillList({
 						MaxLv: sk.MaxLv
 					};
 
-					if (sk?.[needSkillListKey] !== undefined) {
-						sk[needSkillListKey].forEach(item => {
-							skillDependencyTree[skid]['dependency'][item[0]] = item[1];
-						});
-					}
+					resolveSkillRequirements(sk, skillJobId, SkillTreeView).forEach(item => {
+						skillDependencyTree[skid]['dependency'][item[0]] = item[1];
+					});
 				}
 			});
 		});
 	}
 
-	function specifyRequirements(skillId, count, root) {
-		const showAll = true;
-		const skdt = skillDependencyTree[skillId];
-
-		if (skdt?.dependency || count != null) {
-			skillPosition.forEach((items, list) => {
-				if (items[skillId] !== undefined) {
-					const skillbox = root.querySelector(`#positionSkills${list} .s${items[skillId]}`);
-					if (skillbox) {
-						const child = skillbox.querySelector('.disabled');
-						if (child || showAll) {
-							skillbox.classList.add('needleSkill');
-							if (count !== null && count !== undefined) {
-								const counterEl = document.createElement('div');
-								counterEl.className = 'counterSkill';
-								counterEl.textContent = count;
-								skillbox.appendChild(counterEl);
-							}
-						}
+	function highlightNecessarySkill(skillId, count, root) {
+		skillPosition.forEach((items, list) => {
+			if (items[skillId] !== undefined) {
+				const skillbox = root.querySelector(`#positionSkills${list} .s${items[skillId]}`);
+				if (skillbox) {
+					skillbox.classList.add('needleSkill');
+					if (count !== null && count !== undefined) {
+						const counterEl = document.createElement('div');
+						counterEl.className = 'counterSkill';
+						counterEl.textContent = count;
+						skillbox.appendChild(counterEl);
 					}
 				}
-			});
+			}
+		});
+	}
+
+	function collectNecessarySkills(skillId, requirements, visiting = new Set()) {
+		if (visiting.has(skillId)) {
+			return;
 		}
 
-		if (skdt?.dependency) {
-			skdt.dependency.forEach((item, key) => {
-				specifyRequirements(key, item, root);
-			});
-		}
+		visiting.add(skillId);
+		skillDependencyTree[skillId]?.dependency.forEach((level, requiredSkillId) => {
+			requirements.set(requiredSkillId, Math.max(requirements.get(requiredSkillId) ?? 0, level));
+			collectNecessarySkills(requiredSkillId, requirements, visiting);
+		});
+		visiting.delete(skillId);
 	}
 
 	function onRememberChoice(target, root) {
@@ -525,112 +527,49 @@ export function createSkillList({
 			main = main.parentElement;
 		}
 		const skillId = parseInt(main.getAttribute('data-index'), 10);
+		const result = stageSkillPlan({
+			plan: rememberChoice,
+			skillId,
+			ownedSkills: hasSkills,
+			skillInfo: SkillInfo,
+			skillTreeView: SkillTreeView,
+			jobId: skillJobId,
+			availablePoints: _points
+		});
+		if (!result) {
+			return;
+		}
 
-		rememberChoice = setRememberChoice(skillId);
+		rememberChoice = result.plan;
+		totalCounter = result.cost;
+		renderRememberChoice(root);
+	}
 
-		rememberChoice.forEach((item, skId) => {
-			if (!rememberChoice[skId]['isQuest'] && totalCounter < _points) {
-				const sk = skillDependencyTree[skId];
-				if (!sk) {
-					return;
-				}
-				const skillbox = root.querySelector(`#positionSkills${sk.list} .s${sk.position}`);
-				if (skillbox) {
-					const currentEl = skillbox.querySelector('.current');
-					if (incrementalRemember) {
-						if (
-							currentEl &&
-							currentEl.textContent !== String(sk.MaxLv) &&
-							currentEl.textContent !== String(item.count)
-						) {
-							const level = currentEl.textContent;
-							let diff = 0;
-							if (item.count > level) {
-								diff = item.count - level;
-							}
-							totalCounter += diff;
-							skillbox.querySelectorAll('.skill').forEach(el => el.classList.remove('disabled'));
-							const levelEl = skillbox.querySelector('.level');
-							if (levelEl) {
-								levelEl.style.display = '';
-							}
-							if (currentEl) {
-								currentEl.textContent = rememberChoice[skId]['count'];
-							}
-							const maxEl = skillbox.querySelector('.max');
-							if (maxEl) {
-								maxEl.textContent = rememberChoice[skId]['count'];
-							}
-						}
-					} else {
-						if (currentEl && currentEl.textContent !== String(sk.MaxLv)) {
-							totalCounter += rememberChoice[skId]['count'];
-							const disabledEl = skillbox.querySelector('.disabled');
-							if (disabledEl) {
-								disabledEl.classList.remove('disabled');
-							}
-							const levelEl = skillbox.querySelector('.level');
-							if (levelEl) {
-								levelEl.style.display = '';
-							}
-							if (currentEl) {
-								currentEl.textContent = rememberChoice[skId]['count'];
-							}
-							const maxEl = skillbox.querySelector('.max');
-							if (maxEl) {
-								maxEl.textContent = rememberChoice[skId]['count'];
-							}
-						}
-					}
-				}
+	function renderRememberChoice(root) {
+		rememberChoice.forEach((choice, skillId) => {
+			if (choice.isQuest) {
+				return;
 			}
+
+			const skill = hasSkills[skillId];
+			root.querySelectorAll(`.skill.id${skillId}`).forEach(element => {
+				element.classList.remove('active', 'passive', 'disabled');
+				element.classList.add(skill?.type ? 'active' : 'passive');
+
+				const levelEl = element.querySelector('.level');
+				if (levelEl) {
+					levelEl.style.display = '';
+				}
+				element.querySelectorAll('.current, .max').forEach(level => {
+					level.textContent = choice.count;
+				});
+			});
 		});
 
 		const skpointsEl = root.querySelector('.skpoints_count');
 		if (skpointsEl) {
 			skpointsEl.textContent = `${_points - totalCounter}/${_points}`;
 		}
-	}
-
-	function setRememberChoice(skillId, count = null, isQuest = false) {
-		const sk = SkillInfo[skillId];
-
-		if (!isQuest && sk['Type'] === 'Quest') {
-			const skill = getSkillById(skillId);
-			isQuest = !skill?.level || skill?.level <= 0;
-		}
-
-		rememberChoice[skillId] = rememberChoice[skillId] ?? {
-			count: hasSkills?.[skillId]?.level ?? 0,
-			list: null,
-			isQuest: isQuest
-		};
-
-		if (!isQuest) {
-			if (count) {
-				if (count > rememberChoice[skillId]['count']) {
-					rememberChoice[skillId]['count'] = count;
-				}
-			} else {
-				if (sk['MaxLv'] > rememberChoice[skillId]['count']) {
-					rememberChoice[skillId]['count']++;
-				}
-			}
-		}
-
-		if (sk[needSkillListKey] !== undefined) {
-			sk[needSkillListKey].forEach(item => {
-				rememberChoice[skillId][item[0]] = setRememberChoice(item[0], item[1], isQuest)[item[0]];
-			});
-
-			Object.entries(rememberChoice[skillId]).forEach(([key, value]) => {
-				if (_isNumeric(key) && value.isQuest) {
-					rememberChoice[skillId]['isQuest'] = value.isQuest;
-				}
-			});
-		}
-
-		return rememberChoice;
 	}
 
 	function getSkillPosition(JobId) {
@@ -1209,62 +1148,54 @@ export function createSkillList({
 	}
 
 	function onApplyChoice(comp) {
-		const applyArr = [];
-		rememberChoice.forEach((item, skillId) => {
-			applyArr[skillId] = 0;
-			const level = hasSkills?.[skillId]?.level ?? 0;
-
-			if (item.count > level) {
-				applyArr[skillId] = item.count - level;
-			} else {
-				applyArr[skillId] = item.count;
-			}
+		const order = createSkillUpgradeOrder({
+			plan: rememberChoice,
+			ownedSkills: hasSkills,
+			skillInfo: SkillInfo,
+			skillTreeView: SkillTreeView,
+			jobId: skillJobId,
+			availablePoints: _points
 		});
-
-		applyArr.forEach((c, k) => {
-			for (let i = 0; i < c; i++) {
-				Component.onIncreaseSkill(parseInt(k, 10));
-			}
-		});
-
-		totalCounter = 0;
-		const root = comp.getRoot();
-		const skpointsEl = root.querySelector('.skpoints_count');
-		if (skpointsEl) {
-			skpointsEl.textContent = `${_points - totalCounter}`;
+		if (!order) {
+			onResetChoice(comp);
+			return;
 		}
-		rememberChoice = [];
+
+		order.forEach(skillId => Component.onIncreaseSkill(skillId));
+		onResetChoice(comp);
 	}
 
 	function onResetChoice(comp) {
 		const root = comp.getRoot();
-		rememberChoice.forEach((_count, skillId) => {
-			if (!skillDependencyTree[skillId]) {
-				return;
-			}
-			const skillbox = root.querySelector(`.skillCol.s${skillDependencyTree[skillId].position}`);
-			if (skillbox) {
-				if (!hasSkills?.[skillId]?.level) {
-					skillbox.querySelectorAll('.skill').forEach(el => el.classList.add('disabled'));
-				}
-				const selectable = skillbox.querySelector('.selectable');
+		rememberChoice.forEach((_choice, skillId) => {
+			const skill = hasSkills[skillId];
+			const level = skill?.level ?? 0;
+
+			root.querySelectorAll(`.skill.id${skillId}`).forEach(element => {
+				element.classList.remove('active', 'passive', 'disabled');
+				element.classList.add(level ? (skill?.type ? 'active' : 'passive') : 'disabled');
+
+				const selectable = element.querySelector('.selectable');
 				if (selectable) {
 					selectable.style.display = '';
 				}
-				skillbox.querySelectorAll('.current').forEach(el => {
-					el.textContent = hasSkills?.[skillId]?.level ?? 0;
+				element.querySelectorAll('.current, .max').forEach(value => {
+					value.textContent = level;
 				});
-				skillbox.querySelectorAll('.max').forEach(el => {
-					el.textContent = hasSkills?.[skillId]?.level ?? 0;
-				});
-			}
+
+				const levelEl = element.querySelector('.level');
+				if (levelEl) {
+					levelEl.style.display =
+						!level && element.parentElement?.classList.contains('skillCol') ? 'none' : '';
+				}
+			});
 		});
 		totalCounter = 0;
 		const skpointsEl = root.querySelector('.skpoints_count');
 		if (skpointsEl) {
 			skpointsEl.textContent = _points;
 		}
-		rememberChoice = [];
+		rememberChoice = new Map();
 	}
 
 	function onNecessarySkills(target, root) {
@@ -1273,7 +1204,12 @@ export function createSkillList({
 			main = main.parentElement;
 		}
 		const skillId = parseInt(main.getAttribute('data-index'), 10);
-		specifyRequirements(skillId, null, root);
+		const requirements = new Map();
+		collectNecessarySkills(skillId, requirements);
+		highlightNecessarySkill(skillId, null, root);
+		requirements.forEach((level, requiredSkillId) => {
+			highlightNecessarySkill(requiredSkillId, level, root);
+		});
 	}
 
 	function _resolveSkillID(el) {

--- a/src/UI/Components/SkillList/SkillListV2/SkillListV2.js
+++ b/src/UI/Components/SkillList/SkillListV2/SkillListV2.js
@@ -18,10 +18,8 @@ export default createSkillList({
 	htmlText: htmlText,
 	cssText: cssText,
 	hasTabs: true,
-	needSkillListKey: '_NeedSkillList',
 	showDescOnMiniHover: false,
 	touchDrag: true,
-	incrementalRemember: true,
 	guardMissingJob: true,
 	readdSkillOnUpdate: true,
 	dragFrom: 'SkillList'

--- a/src/UI/Components/SkillList/SkillRequirements.js
+++ b/src/UI/Components/SkillList/SkillRequirements.js
@@ -1,0 +1,213 @@
+function getOwnedSkill(ownedSkills, skillId) {
+	return ownedSkills?.get?.(skillId) ?? ownedSkills?.[skillId] ?? null;
+}
+
+function getOwnedLevel(ownedSkills, skillId) {
+	return getOwnedSkill(ownedSkills, skillId)?.level ?? 0;
+}
+
+function getJobLineage(jobId, skillTreeView) {
+	const lineage = [];
+	const visited = new Set();
+	let currentJobId = jobId;
+
+	while (currentJobId != null && !visited.has(currentJobId)) {
+		visited.add(currentJobId);
+		lineage.push(currentJobId);
+
+		const tree = skillTreeView[currentJobId];
+		if (!tree || tree.beforeJob == null) {
+			break;
+		}
+		currentJobId = tree.beforeJob;
+	}
+
+	return lineage;
+}
+
+/**
+ * Resolve the requirements that apply to a skill for the active character job.
+ * Job-specific entries override the generic list, including explicit empty
+ * overrides. Aliased jobs in SkillTreeView share the same tree object, so an
+ * alias can inherit the canonical job's override.
+ */
+export function resolveSkillRequirements(skill, jobId, skillTreeView) {
+	if (!skill) {
+		return [];
+	}
+
+	const jobRequirements = skill.NeedSkillList;
+	if (jobRequirements) {
+		const requirementJobs = Object.keys(jobRequirements);
+
+		for (const lineageJobId of getJobLineage(jobId, skillTreeView)) {
+			if (Object.hasOwn(jobRequirements, lineageJobId)) {
+				return jobRequirements[lineageJobId];
+			}
+
+			const lineageTree = skillTreeView[lineageJobId];
+			if (!lineageTree) {
+				continue;
+			}
+
+			const canonicalJobId = requirementJobs.find(requirementJobId => {
+				return skillTreeView[requirementJobId] === lineageTree;
+			});
+			if (canonicalJobId !== undefined) {
+				return jobRequirements[canonicalJobId];
+			}
+		}
+	}
+
+	return skill._NeedSkillList ?? [];
+}
+
+function clonePlan(plan) {
+	return new Map(Array.from(plan, ([skillId, choice]) => [skillId, { ...choice }]));
+}
+
+function calculatePlanCost(plan, ownedSkills) {
+	let cost = 0;
+	for (const [skillId, choice] of plan) {
+		if (!choice.isQuest) {
+			cost += Math.max(0, choice.count - getOwnedLevel(ownedSkills, skillId));
+		}
+	}
+	return cost;
+}
+
+function getPlannedLevel(plan, ownedSkills, skillId) {
+	return Math.max(plan.get(skillId)?.count ?? 0, getOwnedLevel(ownedSkills, skillId));
+}
+
+/**
+ * Build a complete candidate plan for one more level of skillId. The input
+ * plan is never mutated. A null result means the complete prerequisite chain
+ * is invalid or cannot be afforded.
+ */
+export function stageSkillPlan({ plan, skillId, ownedSkills, skillInfo, skillTreeView, jobId, availablePoints }) {
+	const candidate = clonePlan(plan);
+	const visiting = new Set();
+
+	const stage = (currentSkillId, requiredLevel = null) => {
+		const info = skillInfo[currentSkillId];
+		if (!info || visiting.has(currentSkillId)) {
+			return false;
+		}
+
+		const ownedLevel = getOwnedLevel(ownedSkills, currentSkillId);
+		const isUnownedQuest = info.Type === 'Quest' && ownedLevel <= 0;
+		if (isUnownedQuest) {
+			return requiredLevel == null;
+		}
+
+		const currentLevel = Math.max(candidate.get(currentSkillId)?.count ?? 0, ownedLevel);
+		const targetLevel =
+			requiredLevel == null ? Math.min(currentLevel + 1, info.MaxLv) : Math.max(currentLevel, requiredLevel);
+		if (targetLevel > info.MaxLv) {
+			return false;
+		}
+
+		candidate.set(currentSkillId, {
+			count: targetLevel,
+			isQuest: false
+		});
+
+		visiting.add(currentSkillId);
+		for (const [requiredSkillId, level] of resolveSkillRequirements(info, jobId, skillTreeView)) {
+			if (!stage(requiredSkillId, level)) {
+				visiting.delete(currentSkillId);
+				return false;
+			}
+		}
+		visiting.delete(currentSkillId);
+		return true;
+	};
+
+	if (!stage(skillId)) {
+		return null;
+	}
+
+	const cost = calculatePlanCost(candidate, ownedSkills);
+	if (cost > availablePoints) {
+		return null;
+	}
+
+	return { plan: candidate, cost };
+}
+
+function validateSkillPlan({ plan, ownedSkills, skillInfo, skillTreeView, jobId, availablePoints }) {
+	if (calculatePlanCost(plan, ownedSkills) > availablePoints) {
+		return false;
+	}
+
+	for (const [skillId, choice] of plan) {
+		const info = skillInfo[skillId];
+		const ownedLevel = getOwnedLevel(ownedSkills, skillId);
+		if (!info || choice.count < ownedLevel || choice.count > info.MaxLv) {
+			return false;
+		}
+
+		for (const [requiredSkillId, requiredLevel] of resolveSkillRequirements(info, jobId, skillTreeView)) {
+			if (getPlannedLevel(plan, ownedSkills, requiredSkillId) < requiredLevel) {
+				return false;
+			}
+		}
+	}
+
+	return true;
+}
+
+/**
+ * Return one skill id per upgrade packet, ordered so every prerequisite is
+ * upgraded before its dependants. A null result means the staged plan is no
+ * longer valid against the authoritative skill state.
+ */
+export function createSkillUpgradeOrder(options) {
+	if (!validateSkillPlan(options)) {
+		return null;
+	}
+
+	const { plan, ownedSkills, skillInfo, skillTreeView, jobId } = options;
+	const order = [];
+	const visited = new Set();
+	const visiting = new Set();
+
+	const visit = skillId => {
+		if (visited.has(skillId)) {
+			return true;
+		}
+		if (visiting.has(skillId)) {
+			return false;
+		}
+
+		const info = skillInfo[skillId];
+		if (!info) {
+			return false;
+		}
+
+		visiting.add(skillId);
+		for (const [requiredSkillId] of resolveSkillRequirements(info, jobId, skillTreeView)) {
+			if (plan.has(requiredSkillId) && !visit(requiredSkillId)) {
+				return false;
+			}
+		}
+		visiting.delete(skillId);
+		visited.add(skillId);
+
+		const count = plan.get(skillId)?.count ?? getOwnedLevel(ownedSkills, skillId);
+		const upgrades = Math.max(0, count - getOwnedLevel(ownedSkills, skillId));
+		for (let i = 0; i < upgrades; i++) {
+			order.push(skillId);
+		}
+		return true;
+	};
+
+	for (const skillId of plan.keys()) {
+		if (!visit(skillId)) {
+			return null;
+		}
+	}
+
+	return order;
+}

--- a/tests/ui/SkillListV2.test.js
+++ b/tests/ui/SkillListV2.test.js
@@ -1,0 +1,310 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+	const ids = {
+		NOVICE: 0,
+		CRUSADER: 14,
+		DIVINE_PROTECTION: 22,
+		DEMON_BANE: 23,
+		HEAL: 28,
+		CURE: 35,
+		FAITH: 248
+	};
+
+	const skillInfo = {
+		[ids.FAITH]: {
+			Name: 'CR_TRUST',
+			SkillName: 'Faith',
+			MaxLv: 10,
+			bSeperateLv: false
+		},
+		[ids.DEMON_BANE]: {
+			Name: 'AL_DEMONBANE',
+			SkillName: 'Demon Bane',
+			MaxLv: 10,
+			bSeperateLv: false,
+			_NeedSkillList: [[ids.DIVINE_PROTECTION, 3]]
+		},
+		[ids.CURE]: {
+			Name: 'AL_CURE',
+			SkillName: 'Cure',
+			MaxLv: 1,
+			bSeperateLv: false,
+			NeedSkillList: {
+				[ids.CRUSADER]: [[ids.FAITH, 5]]
+			}
+		},
+		[ids.DIVINE_PROTECTION]: {
+			Name: 'AL_DP',
+			SkillName: 'Divine Protection',
+			MaxLv: 10,
+			bSeperateLv: false,
+			NeedSkillList: {
+				[ids.CRUSADER]: [[ids.CURE, 1]]
+			}
+		},
+		[ids.HEAL]: {
+			Name: 'AL_HEAL',
+			SkillName: 'Heal',
+			MaxLv: 10,
+			bSeperateLv: true,
+			NeedSkillList: {
+				[ids.CRUSADER]: [
+					[ids.FAITH, 10],
+					[ids.DEMON_BANE, 5]
+				]
+			}
+		}
+	};
+
+	const skillTreeView = {
+		[ids.NOVICE]: {
+			list: 1,
+			beforeJob: null
+		},
+		[ids.CRUSADER]: {
+			list: 2,
+			beforeJob: ids.NOVICE,
+			[ids.FAITH]: 0,
+			[ids.CURE]: 7,
+			[ids.DIVINE_PROTECTION]: 14,
+			[ids.DEMON_BANE]: 21,
+			[ids.HEAL]: 28
+		}
+	};
+
+	class MockGUIComponent {
+		constructor() {
+			this._host = document.createElement('div');
+			this.ui = {
+				show: vi.fn(() => {
+					this._host.style.display = 'block';
+				}),
+				hide: vi.fn(() => {
+					this._host.style.display = 'none';
+				}),
+				is: vi.fn(() => this._host.style.display !== 'none')
+			};
+		}
+
+		getRoot() {
+			return this._host;
+		}
+
+		draggable() {}
+
+		focus() {}
+
+		parseHTML() {}
+	}
+
+	return {
+		ids,
+		skillInfo,
+		skillTreeView,
+		MockGUIComponent,
+		session: {
+			Character: { job: ids.CRUSADER },
+			Entity: { _job: ids.CRUSADER }
+		}
+	};
+});
+
+vi.mock('DB/DBManager.js', () => ({ default: { INTERFACE_PATH: 'data/texture/À¯ÀúÀÎÅÍÆäÀÌ½º/' } }));
+vi.mock('DB/Skills/SkillInfo.js', () => ({ default: mocks.skillInfo }));
+vi.mock('DB/Skills/SkillTreeView.js', () => ({ default: mocks.skillTreeView }));
+vi.mock('Engine/SessionStorage.js', () => ({ default: mocks.session }));
+vi.mock('Core/Client.js', () => ({
+	default: {
+		loadFile(_path, callback) {
+			callback?.('data:image/gif;base64,R0lGODlhAQABAIAAAAUEBA==');
+		}
+	}
+}));
+vi.mock('Core/Preferences.js', () => ({
+	default: {
+		get() {
+			return {
+				x: 0,
+				y: 0,
+				width: 17,
+				height: 12,
+				show: true,
+				mini: false,
+				skillInfo: false,
+				save: vi.fn()
+			};
+		}
+	}
+}));
+vi.mock('Renderer/Renderer.js', () => ({ default: { width: 1200, height: 800 } }));
+vi.mock('Controls/MouseEventHandler.js', () => ({ default: { screen: { x: 0, y: 0 } } }));
+vi.mock('UI/GUIComponent.js', () => ({ default: mocks.MockGUIComponent }));
+vi.mock('UI/UIManager.js', () => ({
+	default: {
+		addComponent(component) {
+			component.getRoot().innerHTML = component.render();
+			component.init();
+			return component;
+		}
+	}
+}));
+vi.mock('UI/Elements/Elements.js', () => ({}));
+vi.mock('UI/Components/SkillTargetSelection/SkillTargetSelection.js', () => ({
+	default: {
+		TYPE: { SELF: 1, TARGET: 2 },
+		append: vi.fn(),
+		set: vi.fn()
+	}
+}));
+vi.mock('UI/Components/SkillDescription/SkillDescription.js', () => ({
+	default: {
+		uid: null,
+		append: vi.fn(),
+		remove: vi.fn(),
+		setSkill: vi.fn()
+	}
+}));
+
+const { createSkillList } = await import('UI/Components/SkillList/SkillListCommon.js');
+
+function getFixtureHTML() {
+	const cells = positions => positions.map(position => `<div class="skillCol s${position}"></div>`).join('');
+
+	return `
+		<div id="SkillListV2Test">
+			<div class="titlebar">
+				<button class="base"></button>
+				<span class="text"></span>
+				<button class="base mini"></button>
+				<button class="base close"></button>
+				<input type="checkbox" class="view_skill_info" />
+			</div>
+			<div class="content">
+				<button class="btn levelup"></button>
+				<table id="minitab1"></table>
+				<table id="minitab2"></table>
+			</div>
+			<div class="contentbig">
+				<input type="radio" id="tab-1" class="tab-switch" checked />
+				<input type="radio" id="tab-2" class="tab-switch" />
+				<div id="positionSkills1">${cells([0, 7, 14, 21, 28])}</div>
+				<div id="positionSkills2">${cells([0, 7, 14, 21, 28])}</div>
+			</div>
+			<div class="footer">
+				<span class="skpoints_count"></span>
+				<button class="btn apply"></button>
+				<button class="btn reset"></button>
+				<div class="extend"></div>
+			</div>
+		</div>`;
+}
+
+function createComponent({ faith = 10, points = 10 } = {}) {
+	const component = createSkillList({
+		name: 'SkillListV2Test',
+		htmlText: getFixtureHTML(),
+		cssText: '',
+		hasTabs: true,
+		guardMissingJob: true,
+		readdSkillOnUpdate: true
+	});
+
+	component.setSkills([
+		{ SKID: mocks.ids.FAITH, level: faith, type: 0, upgradable: faith < 10, spcost: 0 },
+		{ SKID: mocks.ids.CURE, level: 0, type: 1, upgradable: true, spcost: 15 },
+		{ SKID: mocks.ids.DIVINE_PROTECTION, level: 0, type: 0, upgradable: true, spcost: 0 },
+		{ SKID: mocks.ids.DEMON_BANE, level: 0, type: 0, upgradable: true, spcost: 0 },
+		{ SKID: mocks.ids.HEAL, level: 0, type: 1, upgradable: true, spcost: 13 }
+	]);
+	component.setPoints(points);
+	return component;
+}
+
+function getTreeSkill(root, skillId) {
+	return root.querySelector(`#positionSkills2 .skill.id${skillId}`);
+}
+
+describe('SkillListV2 prerequisite planning', () => {
+	beforeEach(() => {
+		document.body.innerHTML = '';
+	});
+
+	it('shows and transactionally stages the complete Heal chain', () => {
+		const component = createComponent();
+		const root = component.getRoot();
+		const heal = getTreeSkill(root, mocks.ids.HEAL);
+
+		heal.querySelector('.icon').dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+
+		expect(root.querySelector('#positionSkills2 .s0 .counterSkill').textContent).toBe('10');
+		expect(root.querySelector('#positionSkills2 .s7 .counterSkill').textContent).toBe('1');
+		expect(root.querySelector('#positionSkills2 .s14 .counterSkill').textContent).toBe('3');
+		expect(root.querySelector('#positionSkills2 .s21 .counterSkill').textContent).toBe('5');
+
+		heal.querySelector('.icon').click();
+
+		expect(getTreeSkill(root, mocks.ids.FAITH).querySelector('.current').textContent).toBe('10');
+		expect(getTreeSkill(root, mocks.ids.CURE).querySelector('.current').textContent).toBe('1');
+		expect(getTreeSkill(root, mocks.ids.DIVINE_PROTECTION).querySelector('.current').textContent).toBe('3');
+		expect(getTreeSkill(root, mocks.ids.DEMON_BANE).querySelector('.current').textContent).toBe('5');
+		expect(getTreeSkill(root, mocks.ids.HEAL).querySelector('.current').textContent).toBe('1');
+		expect(root.querySelector('.skpoints_count').textContent).toBe('0/10');
+	});
+
+	it('leaves the tree unchanged when the complete chain is unaffordable', () => {
+		const component = createComponent({ points: 6 });
+		const root = component.getRoot();
+
+		getTreeSkill(root, mocks.ids.HEAL).querySelector('.icon').click();
+
+		expect(getTreeSkill(root, mocks.ids.DEMON_BANE).querySelector('.current').textContent).toBe('0');
+		expect(getTreeSkill(root, mocks.ids.HEAL).querySelector('.current').textContent).toBe('0');
+		expect(root.querySelector('.skpoints_count').textContent).toBe('6');
+	});
+
+	it('applies prerequisites first and immediately restores authoritative levels', () => {
+		const component = createComponent();
+		const root = component.getRoot();
+		component.onIncreaseSkill = vi.fn();
+
+		getTreeSkill(root, mocks.ids.HEAL).querySelector('.icon').click();
+		root.querySelector('.apply').click();
+
+		expect(component.onIncreaseSkill.mock.calls.map(([skillId]) => skillId)).toEqual([
+			mocks.ids.CURE,
+			...Array(3).fill(mocks.ids.DIVINE_PROTECTION),
+			...Array(5).fill(mocks.ids.DEMON_BANE),
+			mocks.ids.HEAL
+		]);
+		expect(getTreeSkill(root, mocks.ids.CURE).querySelector('.current').textContent).toBe('0');
+		expect(getTreeSkill(root, mocks.ids.DIVINE_PROTECTION).querySelector('.current').textContent).toBe('0');
+		expect(getTreeSkill(root, mocks.ids.DEMON_BANE).querySelector('.current').textContent).toBe('0');
+		expect(getTreeSkill(root, mocks.ids.HEAL).querySelector('.current').textContent).toBe('0');
+		expect(root.querySelector('.skpoints_count').textContent).toBe('10');
+	});
+
+	it('resets the correct tab and discards the plan on close and reopen', () => {
+		const component = createComponent();
+		const root = component.getRoot();
+		const stageHeal = () => getTreeSkill(root, mocks.ids.HEAL).querySelector('.icon').click();
+
+		stageHeal();
+		root.querySelector('.reset').click();
+
+		expect(getTreeSkill(root, mocks.ids.DEMON_BANE).querySelector('.current').textContent).toBe('0');
+		expect(getTreeSkill(root, mocks.ids.HEAL).querySelector('.current').textContent).toBe('0');
+		expect(root.querySelector('.skpoints_count').textContent).toBe('10');
+		expect(root.querySelector('#positionSkills1 .s28').children).toHaveLength(0);
+
+		stageHeal();
+		root.querySelector('.close').click();
+
+		expect(component.ui.hide).toHaveBeenCalledOnce();
+		expect(getTreeSkill(root, mocks.ids.HEAL).querySelector('.current').textContent).toBe('0');
+		expect(root.querySelector('.skpoints_count').textContent).toBe('10');
+
+		component.toggle();
+		expect(getTreeSkill(root, mocks.ids.HEAL).querySelector('.current').textContent).toBe('0');
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #975

- resolve the correct job-specific skill prerequisites, including inherited and aliased job trees, explicit empty overrides, and generic fallback requirements
- stage prerequisite chains transactionally so unaffordable or invalid chains cannot leave partial bogus allocations behind
- validate and send upgrades in dependency-first order, then restore the server-confirmed display while acknowledgements arrive
- discard unapplied allocations on Reset and every close/hide path
- restore skills by ID rather than grid position, avoiding collisions between tabs

## Testing

<img width="920" height="680" alt="Screenshot 2026-08-23 at 20 44 36" src="https://github.com/user-attachments/assets/8d08c951-fe43-415b-9668-0d827d4d7e9f" />
<img width="920" height="680" alt="Screenshot 2026-08-23 at 20 44 43" src="https://github.com/user-attachments/assets/cccded3d-6e0d-4033-a291-9d6c62738aef" />


- manually tested in-game across different jobs; the other tested jobs work well
- Super Novice still retains some odd Skill Tree behavior, but it is less broken than before this change

Fixes #975