### PR TITLE
Add bulk transfers to trade and NPC selling

### DIFF
--- a/src/UI/Components/Inventory/InventoryCommon.js
+++ b/src/UI/Components/Inventory/InventoryCommon.js
@@ -45,6 +45,7 @@ import EnchantGrade from 'UI/Components/EnchantGrade/EnchantGrade.js';
 import EnchantUI from 'UI/Components/Enchant/Enchant.js';
 import Mail from 'UI/Components/Mail/Mail.js';
 import WriteRodex from 'UI/Components/Rodex/WriteRodex.js';
+import { transferInventoryItemStack } from './InventoryItemTransfer.js';
 
 function _sanitizeHtml(str) {
 	const whitelist = ['font', 'i', 'b'];
@@ -1293,6 +1294,10 @@ export function createInventory(config) {
 	 * Alt Right Click Request Transfer
 	 */
 	function transferItemToOtherUI(item) {
+		if (transferInventoryItemStack(item, UIManager.components)) {
+			return true;
+		}
+
 		const storageUI = Storage.getUI();
 		const isStorageOpen = storageUI._host ? storageUI._host.style.display !== 'none' : false;
 		const isCartOpen = CartItems._host ? CartItems._host.style.display !== 'none' : false;

--- a/src/UI/Components/Inventory/InventoryItemTransfer.js
+++ b/src/UI/Components/Inventory/InventoryItemTransfer.js
@@ -1,0 +1,40 @@
+/**
+ * Priorities for windows that receive full inventory stacks.
+ * Modal interaction windows take precedence over secondary inventory windows.
+ */
+export const InventoryItemTransferPriority = Object.freeze({
+	TRADE: 300,
+	NPC_STORE: 400
+});
+
+/**
+ * Transfer an inventory item stack to the highest-priority active receiver.
+ * Once selected, the receiver owns the request even if it declines the item.
+ *
+ * @param {object} item Inventory item
+ * @param {object} components Registered UI components
+ * @returns {boolean} Whether an active receiver handled the request
+ */
+export function transferInventoryItemStack(item, components) {
+	if (!item || !components) {
+		return false;
+	}
+
+	const receiver = Object.values(components)
+		.filter(component => {
+			return (
+				component?.__active &&
+				component._host?.isConnected &&
+				component._host.style.display !== 'none' &&
+				typeof component.receiveInventoryItemStack === 'function'
+			);
+		})
+		.sort((a, b) => (b.inventoryTransferPriority || 0) - (a.inventoryTransferPriority || 0))[0];
+
+	if (!receiver) {
+		return false;
+	}
+
+	receiver.receiveInventoryItemStack(item);
+	return true;
+}

--- a/src/UI/Components/NpcStore/NpcStore.js
+++ b/src/UI/Components/NpcStore/NpcStore.js
@@ -25,6 +25,7 @@ import ItemInfo from 'UI/Components/ItemInfo/ItemInfo.js';
 import InputBox from 'UI/Components/InputBox/InputBox.js';
 import ChatBox from 'UI/Components/ChatBox/ChatBox.js';
 import Inventory from 'UI/Components/Inventory/Inventory.js';
+import { InventoryItemTransferPriority } from 'UI/Components/Inventory/InventoryItemTransfer.js';
 import htmlText from './NpcStore.html?raw';
 import cssText from './NpcStore.css?raw';
 
@@ -999,7 +1000,7 @@ const transferItem = (function () {
 /**
  * Request move item from box to another
  */
-function requestMoveItem(index, fromContent, toContent, isAdding) {
+function requestMoveItem(index, fromContent, toContent, isAdding, transferAll = false) {
 	let count;
 	const item = isAdding ? _input[index] : _output[index];
 	const isStackable =
@@ -1020,7 +1021,7 @@ function requestMoveItem(index, fromContent, toContent, isAdding) {
 		}
 	}
 
-	if (item.count === 1 || (_type === NpcStore.Type.SELL && _preferences.select_all) || !isStackable) {
+	if (transferAll || item.count === 1 || (_type === NpcStore.Type.SELL && _preferences.select_all) || !isStackable) {
 		transferItem(fromContent, toContent, isAdding, index, isFinite(item.count) ? item.count : 1);
 		return false;
 	}
@@ -1034,6 +1035,27 @@ function requestMoveItem(index, fromContent, toContent, isAdding) {
 		}
 	};
 }
+
+function transferSellItemStack(index) {
+	if (_type !== NpcStore.Type.SELL || !_input[index]) {
+		return false;
+	}
+
+	const root = NpcStore.getRoot();
+	requestMoveItem(
+		index,
+		root.querySelector('.InputWindow .content'),
+		root.querySelector('.OutputWindow .content'),
+		true,
+		true
+	);
+	return true;
+}
+
+NpcStore.inventoryTransferPriority = InventoryItemTransferPriority.NPC_STORE;
+NpcStore.receiveInventoryItemStack = function receiveInventoryItemStack(item) {
+	return item ? transferSellItemStack(item.index) : false;
+};
 
 /**
  * Drop an input in the InputWindow or OutputWindow
@@ -1076,6 +1098,12 @@ function onItemInfo(event) {
 	event.stopImmediatePropagation();
 
 	if (!item) {
+		return false;
+	}
+
+	const inputWindow = NpcStore.getRoot().querySelector('.InputWindow');
+	if (_type === NpcStore.Type.SELL && event.altKey && event.which === 3 && inputWindow.contains(this)) {
+		transferSellItemStack(index);
 		return false;
 	}
 

--- a/src/UI/Components/Trade/Trade.js
+++ b/src/UI/Components/Trade/Trade.js
@@ -17,6 +17,7 @@ import InputBox from 'UI/Components/InputBox/InputBox.js';
 import ItemInfo from 'UI/Components/ItemInfo/ItemInfo.js';
 import Inventory from 'UI/Components/Inventory/Inventory.js';
 import ChatBox from 'UI/Components/ChatBox/ChatBox.js';
+import { InventoryItemTransferPriority } from 'UI/Components/Inventory/InventoryItemTransfer.js';
 import htmlText from './Trade.html?raw';
 import cssText from './Trade.css?raw';
 
@@ -357,6 +358,17 @@ function onRequestAddItem(index, count) {
 	_tmpCount[index] = count;
 	Trade.reqAddItem(index, count);
 }
+
+Trade.inventoryTransferPriority = InventoryItemTransferPriority.TRADE;
+Trade.receiveInventoryItemStack = function receiveInventoryItemStack(item) {
+	const sendBox = Trade.getRoot().querySelector('.box.send');
+	if (!item || !sendBox || sendBox.classList.contains('disabled')) {
+		return false;
+	}
+
+	onRequestAddItem(item.index, item.count || 1);
+	return true;
+};
 
 /**
  * Conclude a part of the trade


### PR DESCRIPTION
## Summary

Closes #1300

- extend Option/Alt+right-click full-stack transfers from Inventory to the Trade window
- add the same shortcut from Inventory to NPC Sell
- allow full-stack transfers from NPC Sell's Available Items list to Selling Items
- preserve existing Storage and Cart transfer behavior

## Verification

Tested seven alt/option+Right Click scenarios on Mac in Chrome:
<img width="1017" height="680" alt="1" src="https://github.com/user-attachments/assets/e38c88bc-ab5a-4244-9599-cb85867dd610" />
<img width="1038" height="688" alt="2" src="https://github.com/user-attachments/assets/15aa2e44-60d7-4532-bbb9-4fc264088f91" />
<img width="1708" height="688" alt="3" src="https://github.com/user-attachments/assets/f6e43321-593c-4bb2-8408-96a76182f6ab" />
<img width="1038" height="688" alt="4" src="https://github.com/user-attachments/assets/f768fa4e-3b49-4a17-8a08-fb9a0fb218ab" />
<img width="1038" height="688" alt="5 6" src="https://github.com/user-attachments/assets/6b4ce1d7-a2bd-4fec-8167-e179e483eb1a" />
<img width="1038" height="688" alt="7" src="https://github.com/user-attachments/assets/046c97d7-870a-4657-80bf-6bec19c431b5" />

Verified normal right click behaviour in Inventory, NPC Sell interface, etc. No regression found.

