### PR TITLE
README: add Rust remote client implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Remote Client serves game assets to roBrowser via http by extracting them from t
 Other implementations may arise and when they do we will list them here:
 
 - [roBrowserLegacy-RemoteClient-JS](https://github.com/FranciscoWallison/roBrowserLegacy-RemoteClient-JS)
+- [roBrowserLegacy-RemoteClient-Rust](https://github.com/Flux159/roBrowserLegacy-RemoteClient-Rust)
 
 ## WebSocket Proxy
 


### PR DESCRIPTION
Adds an alternative Rust implementation of the remote client to the list in the README: https://github.com/Flux159/roBrowserLegacy-RemoteClient-Rust