### PR TITLE
Project the picking rectangle at the height the sprite is drawn

### DIFF
--- a/src/Renderer/Entity/EntityRender.js
+++ b/src/Renderer/Entity/EntityRender.js
@@ -112,6 +112,7 @@ const renderGUI = (function renderGUIClosure() {
 	const vec4 = glMatrix.vec4;
 	const _matrix = mat4.create();
 	const _vector = vec4.create();
+	const _pickMatrix = mat4.create();
 
 	return function _renderGUI(entity, modelView, projection) {
 		// Move to camera
@@ -135,7 +136,22 @@ const renderGUI = (function renderGUIClosure() {
 		mat4.multiply(_matrix, projection, _matrix);
 
 		if (entity.effectColor[3] && entity._job !== 139) {
-			calculateBoundingRect(entity, _matrix);
+			// Same billboard as above, lifted the way the sprite itself is.
+			_vector[0] = entity.position[0] + 0.5;
+			_vector[1] = -(entity.position[2] + SPRITE_LIFT);
+			_vector[2] = entity.position[1] + 0.5;
+			mat4.translate(_pickMatrix, modelView, _vector);
+			_pickMatrix[0] = 1.0;
+			_pickMatrix[1] = 0.0;
+			_pickMatrix[2] = 0.0;
+			_pickMatrix[4] = 0.0;
+			_pickMatrix[5] = 1.0;
+			_pickMatrix[6] = 0.0;
+			_pickMatrix[8] = 0.0;
+			_pickMatrix[9] = 0.0;
+			_pickMatrix[10] = 1.0;
+			mat4.multiply(_pickMatrix, projection, _pickMatrix);
+			calculateBoundingRect(entity, _pickMatrix);
 		}
 
 		// Get depth for rendering order
@@ -175,6 +191,12 @@ const renderGUI = (function renderGUIClosure() {
  * @param {Entity}
  * @param {mat4}
  */
+/**
+ * Vertical lift renderEntity applies to every sprite before drawing it.
+ * The picking rectangle has to use it too, or it lands below the sprite.
+ */
+const SPRITE_LIFT = 0.2;
+
 const calculateBoundingRect = (function calculateBoundingRectClosure() {
 	const vec4 = glMatrix.vec4;
 	const size = glMatrix.vec2.create();


### PR DESCRIPTION
renderEntity lifts every sprite before drawing it -- every branch of its objecttype switch, the default included, does position[2] += 0.2 -- while the matrix renderGUI builds for calculateBoundingRect does not. The rectangle the mouse is tested against therefore sits 0.2 world units below the sprite, and everything has to be clicked slightly under itself.

The offset is constant in world units, so it is a larger share of a small sprite: on a monster it is a fraction of the body and passes unnoticed, on an item dropped on the ground it is most of the sprite.

Measured by drawing entity.boundingRect on screen in a running client: the box tracked the sprite's size correctly at every zoom level and only its centre was wrong, which is the signature of a constant offset. The minSize clamp was ruled out the same way, since it recentres on the projected midpoint and so preserves the centre it is given.

A second matrix rather than lifting the existing one: that one also places the name, lifebar, dialog and cast bar, and moving those is a visual change this fix has no reason to make.