### PR TITLE
Use the equipped weapon's attack action for ranged skills

### DIFF
--- a/src/DB/Skills/SkillAction.js
+++ b/src/DB/Skills/SkillAction.js
@@ -215,7 +215,9 @@ SkillAction[SK.TF_POISON] =
 			};
 		};
 
-//ATTACK3 - Ranged attack with visible weapon
+// The attack action that shows the weapon, which is per job and per weapon.
+// Resolved in EntityAction.setAction through DB.getWeaponAction, the same way
+// the ordinary attack resolves it.
 SkillAction[SK.AC_DOUBLE] =
 	SkillAction[SK.ASC_BREAKER] =
 	SkillAction[SK.HT_PHANTASMIC] =
@@ -225,7 +227,7 @@ SkillAction[SK.AC_DOUBLE] =
 	SkillAction[SK.SC_TRIANGLESHOT] =
 		function (entity, tick) {
 			return {
-				action: entity.ACTION.ATTACK3,
+				action: entity.ACTION.ATTACK,
 				frame: 0,
 				repeat: false,
 				play: true,


### PR DESCRIPTION
SkillAction hardcodes ACTION.ATTACK3 for AC_DOUBLE and the six skills that share its entry, under a comment describing it as the ranged attack with the weapon visible. Which of the three attack actions shows the weapon is per job and per weapon, though, which is why the ordinary attack resolves it through DB.getWeaponAction instead of assuming.

DB/Jobs/WeaponAction.js disagrees with the constant on the class the first of those skills is named after:

    ARCHER: BOW = 1 -> ATTACK2, SHORTSWORD = 2 -> ATTACK3
    HUNTER: BOW = 2 -> ATTACK3, SHORTSWORD = 1 -> ATTACK2

So ATTACK3 is correct on a Hunter and wrong on an Archer, where it plays the dagger swing and the bow leaves the character's hands for the duration of the skill. The basic attack looks right throughout, which is what makes it read as a skill problem rather than an animation-table one.

ACTION.ATTACK is resolved in EntityAction.setAction, so every job whose bow already maps to 2 keeps the animation it has today.