### PR TITLE
Align skill action timing with attack motion

### DIFF
--- a/src/DB/Skills/SkillAction.js
+++ b/src/DB/Skills/SkillAction.js
@@ -12,38 +12,56 @@ import SK from './SkillConst.js';
 
 const SkillAction = {};
 
-//Default skill action
-SkillAction['DEFAULT'] = function (entity, tick) {
-	return {
-		action: entity.ACTION.SKILL,
-		frame: 0,
-		repeat: false,
-		play: true,
-		next: {
-			action: entity.ACTION.IDLE,
+const makeAttackSkillAction = (actionProp = 'ATTACK') =>
+	function (entity, tick, pkt) {
+		const holdDelay = pkt && pkt.attackMT ? Math.max(pkt.attackMT, 400) : 400;
+		const nextAction =
+			entity && entity.ACTION && entity.ACTION.READYFIGHT !== undefined
+				? entity.ACTION.READYFIGHT
+				: (entity && entity.ACTION && entity.ACTION.IDLE) || 0;
+		return {
+			action: entity.ACTION[actionProp],
 			frame: 0,
-			repeat: true,
+			repeat: false,
 			play: true,
-			next: false
-		}
+			next: {
+				delay: (tick || Date.now()) + holdDelay,
+				action: nextAction,
+				frame: 0,
+				repeat: true,
+				play: true,
+				next: false
+			}
+		};
 	};
-};
 
-SkillAction['DEFAULT_DORAM'] = function (entity, tick) {
-	return {
-		action: entity.ACTION.ATTACK2,
-		frame: 0,
-		repeat: false,
-		play: true,
-		next: {
-			action: entity.ACTION.IDLE,
+const makeGenericSkillAction = (actionProp = 'SKILL', nextActionProp = 'IDLE') =>
+	function (entity, tick, pkt) {
+		const holdDelay = pkt && pkt.attackMT ? Math.max(pkt.attackMT, 400) : 400;
+		const nextAction =
+			entity && entity.ACTION && entity.ACTION[nextActionProp] !== undefined
+				? entity.ACTION[nextActionProp]
+				: (entity && entity.ACTION && entity.ACTION.IDLE) || 0;
+		return {
+			action: entity.ACTION[actionProp],
 			frame: 0,
-			repeat: true,
+			repeat: false,
 			play: true,
-			next: false
-		}
+			next: {
+				delay: (tick || Date.now()) + holdDelay,
+				action: nextAction,
+				frame: 0,
+				repeat: true,
+				play: true,
+				next: false
+			}
+		};
 	};
-};
+
+//Default skill action
+SkillAction['DEFAULT'] = makeGenericSkillAction('SKILL');
+
+SkillAction['DEFAULT_DORAM'] = makeGenericSkillAction('ATTACK2');
 
 //Skill action overrides
 
@@ -145,21 +163,7 @@ SkillAction[SK.SM_BASH] =
 	SkillAction[SK.SR_TIGERCANNON] =
 	SkillAction[SK.SR_CRESCENTELBOW] =
 	SkillAction[SK.SR_GATEOFHELL] =
-		function (entity, tick) {
-			return {
-				action: entity.ACTION.ATTACK,
-				frame: 0,
-				repeat: false,
-				play: true,
-				next: {
-					action: entity.ACTION.IDLE,
-					frame: 0,
-					repeat: true,
-					play: true,
-					next: false
-				}
-			};
-		};
+		makeAttackSkillAction('ATTACK');
 
 //ATTACK1 - Throwing attack without visible weapon
 SkillAction[SK.KN_SPEARBOOMERANG] =
@@ -178,42 +182,14 @@ SkillAction[SK.KN_SPEARBOOMERANG] =
 	SkillAction[SK.PA_SHIELDCHAIN] =
 	SkillAction[SK.NC_AXEBOOMERANG] =
 	SkillAction[SK.GN_SLINGITEM] =
-		function (entity, tick) {
-			return {
-				action: entity.ACTION.ATTACK1,
-				frame: 0,
-				repeat: false,
-				play: true,
-				next: {
-					action: entity.ACTION.IDLE,
-					frame: 0,
-					repeat: true,
-					play: true,
-					next: false
-				}
-			};
-		};
+		makeAttackSkillAction('ATTACK1');
 
 //ATTACK2 - Normal attack without visible weapon
 SkillAction[SK.TF_POISON] =
 	SkillAction[SK.MC_MAMMONITE] =
 	SkillAction[SK.MC_CARTREVOLUTION] =
 	SkillAction[SK.GN_CART_TORNADO] =
-		function (entity, tick) {
-			return {
-				action: entity.ACTION.ATTACK2,
-				frame: 0,
-				repeat: false,
-				play: true,
-				next: {
-					action: entity.ACTION.IDLE,
-					frame: 0,
-					repeat: true,
-					play: true,
-					next: false
-				}
-			};
-		};
+		makeAttackSkillAction('ATTACK2');
 
 // The attack action that shows the weapon, which is per job and per weapon.
 // Resolved in EntityAction.setAction through DB.getWeaponAction, the same way
@@ -225,21 +201,7 @@ SkillAction[SK.AC_DOUBLE] =
 	SkillAction[SK.RA_ARROWSTORM] =
 	SkillAction[SK.RA_AIMEDBOLT] =
 	SkillAction[SK.SC_TRIANGLESHOT] =
-		function (entity, tick) {
-			return {
-				action: entity.ACTION.ATTACK,
-				frame: 0,
-				repeat: false,
-				play: true,
-				next: {
-					action: entity.ACTION.IDLE,
-					frame: 0,
-					repeat: true,
-					play: true,
-					next: false
-				}
-			};
-		};
+		makeAttackSkillAction('ATTACK3');
 
 //PICKUP
 SkillAction[SK.HT_LANDMINE] =
@@ -262,21 +224,7 @@ SkillAction[SK.HT_LANDMINE] =
 	SkillAction[SK.RA_VERDURETRAP] =
 	SkillAction[SK.RA_FIRINGTRAP] =
 	SkillAction[SK.RA_ICEBOUNDTRAP] =
-		function (entity, tick) {
-			return {
-				action: entity.ACTION.PICKUP,
-				frame: 0,
-				repeat: false,
-				play: true,
-				next: {
-					action: entity.ACTION.IDLE,
-					frame: 0,
-					repeat: true,
-					play: true,
-					next: false
-				}
-			};
-		};
+		makeGenericSkillAction('PICKUP');
 
 //Stay in PICKUP
 SkillAction[SK.NJ_TATAMIGAESHI] = SkillAction[SK.SR_EARTHSHAKER] = function (entity, tick) {
@@ -290,21 +238,7 @@ SkillAction[SK.NJ_TATAMIGAESHI] = SkillAction[SK.SR_EARTHSHAKER] = function (ent
 };
 
 //ACTION
-SkillAction[SK.SN_SIGHT] = function (entity, tick) {
-	return {
-		action: entity.ACTION.ACTION,
-		frame: 0,
-		repeat: false,
-		play: true,
-		next: {
-			action: entity.ACTION.IDLE,
-			frame: 0,
-			repeat: true,
-			play: true,
-			next: false
-		}
-	};
-};
+SkillAction[SK.SN_SIGHT] = makeGenericSkillAction('ACTION');
 
 //EXTRA
 //DANCE/PLAY
@@ -343,24 +277,11 @@ SkillAction[SK.DC_WINKCHARM] =
 		};
 
 //ENDURE
-SkillAction[SK.SM_ENDURE] = function (entity, tick) {
-	return {
-		action: entity.ACTION.READYFIGHT,
-		frame: 0,
-		repeat: false,
-		play: true,
-		next: {
-			action: entity.ACTION.IDLE,
-			frame: 0,
-			repeat: true,
-			play: true,
-			next: false
-		}
-	};
-};
+SkillAction[SK.SM_ENDURE] = makeGenericSkillAction('READYFIGHT');
 
 //ARROW SHOWER
-SkillAction[SK.AC_SHOWER] = function (entity, tick) {
+SkillAction[SK.AC_SHOWER] = function (entity, tick, pkt) {
+	const holdDelay = pkt && pkt.attackMT ? Math.max(pkt.attackMT, 400) : 400;
 	return {
 		action: entity.ACTION.ATTACK,
 		frame: 0,
@@ -368,6 +289,7 @@ SkillAction[SK.AC_SHOWER] = function (entity, tick) {
 		speed: 50,
 		play: true,
 		next: {
+			delay: (tick || Date.now()) + holdDelay,
 			action: entity.ACTION.READYFIGHT,
 			frame: 0,
 			repeat: true,

--- a/src/DB/Skills/SkillAction.js
+++ b/src/DB/Skills/SkillAction.js
@@ -195,13 +195,15 @@ SkillAction[SK.TF_POISON] =
 // Resolved in EntityAction.setAction through DB.getWeaponAction, the same way
 // the ordinary attack resolves it.
 SkillAction[SK.AC_DOUBLE] =
-	SkillAction[SK.ASC_BREAKER] =
 	SkillAction[SK.HT_PHANTASMIC] =
 	SkillAction[SK.SN_SHARPSHOOTING] =
 	SkillAction[SK.RA_ARROWSTORM] =
 	SkillAction[SK.RA_AIMEDBOLT] =
 	SkillAction[SK.SC_TRIANGLESHOT] =
-		makeAttackSkillAction('ATTACK3');
+		makeAttackSkillAction('ATTACK');
+
+//ATTACK3 - Specific attack motion
+SkillAction[SK.ASC_BREAKER] = makeAttackSkillAction('ATTACK3');
 
 //PICKUP
 SkillAction[SK.HT_LANDMINE] =

--- a/src/Engine/MapEngine/Entity.js
+++ b/src/Engine/MapEngine/Entity.js
@@ -1432,13 +1432,13 @@ function onEntityUseSkill(pkt) {
 			if (pkt.SKID in SkillActionTable) {
 				const action = SkillActionTable[pkt.SKID];
 				if (action) {
-					srcEntity.setAction(action(srcEntity, Renderer.tick));
+					srcEntity.setAction(action(srcEntity, Renderer.tick, pkt));
 				}
 			} else {
 				if (DB.isDoram(srcEntity.job)) {
-					srcEntity.setAction(SkillActionTable['DEFAULT_DORAM'](srcEntity, Renderer.tick));
+					srcEntity.setAction(SkillActionTable['DEFAULT_DORAM'](srcEntity, Renderer.tick, pkt));
 				} else {
-					srcEntity.setAction(SkillActionTable['DEFAULT'](srcEntity, Renderer.tick));
+					srcEntity.setAction(SkillActionTable['DEFAULT'](srcEntity, Renderer.tick, pkt));
 				}
 			}
 		}
@@ -1574,10 +1574,10 @@ function onEntityUseSkillToAttack(pkt) {
 			if (pkt.SKID in SkillActionTable) {
 				const action = SkillActionTable[pkt.SKID];
 				if (action) {
-					srcEntity.setAction(action(srcEntity, Renderer.tick));
+					srcEntity.setAction(action(srcEntity, Renderer.tick, pkt));
 				}
 			} else {
-				srcEntity.setAction(SkillActionTable['DEFAULT'](srcEntity, Renderer.tick));
+				srcEntity.setAction(SkillActionTable['DEFAULT'](srcEntity, Renderer.tick, pkt));
 			}
 
 			//Pet Talk

--- a/src/Renderer/Entity/EntityAction.js
+++ b/src/Renderer/Entity/EntityAction.js
@@ -80,55 +80,60 @@ function setAction(option) {
 	const anim = this.animation;
 
 	if (option.delay) {
-		anim.delay = option.delay + 0;
+		const targetDelay = option.delay < 1000000000 ? Date.now() + option.delay : option.delay;
+		if (targetDelay > Date.now()) {
+			anim.delay = targetDelay;
+			option.delay = 0;
+			anim.save = option;
+			anim.next = false;
+			return;
+		}
 		option.delay = 0;
-		anim.save = option;
-	} else {
-		// Know attack frame based on weapon type
-		if (option.action === this.ACTION.ATTACK) {
-			if (this.objecttype === this.constructor.TYPE_PC) {
-				const attack = DB.getWeaponAction(this.weapon, this._job, this._sex);
-				option.action = [this.ACTION.ATTACK1, this.ACTION.ATTACK2, this.ACTION.ATTACK3][attack];
-			}
-
-			// No action loaded yet
-			if (option.action === -2) {
-				option.action = this.ACTION.ATTACK1;
-			}
-		}
-
-		// FIX: Detect the walk animation change and reset pathfinding route
-		const wasWalking = this.action === this.ACTION.WALK;
-		const newAction =
-			option.action === -1 || typeof option.action === 'undefined' ? this.ACTION.IDLE : option.action;
-		const willWalk = newAction === this.ACTION.WALK;
-
-		if (
-			wasWalking &&
-			!willWalk &&
-			!this.isFastMoving &&
-			this.walk &&
-			this.walk.total > 0 &&
-			this.objecttype !== this.constructor.TYPE_FALCON &&
-			this.objecttype !== this.constructor.TYPE_WUG
-		) {
-			this.resetRoute();
-		}
-
-		this.action = newAction;
-		anim.tick = Date.now() + 0;
-		anim.delay = 0;
-		anim.frame = option.frame || 0;
-		anim.speed = option.speed || false;
-		anim.length = option.length || false;
-		anim.repeat = option.repeat || false;
-		anim.play = typeof option.play !== 'undefined' ? option.play : true;
-		anim.next = option.next || false;
-		anim.save = false;
-
-		// Reset sounds
-		this.sound.free();
 	}
+	// Know attack frame based on weapon type
+	if (option.action === this.ACTION.ATTACK) {
+		if (this.objecttype === this.constructor.TYPE_PC) {
+			const attack = DB.getWeaponAction(this.weapon, this._job, this._sex);
+			option.action = [this.ACTION.ATTACK1, this.ACTION.ATTACK2, this.ACTION.ATTACK3][attack];
+		}
+
+		// No action loaded yet
+		if (option.action === -2) {
+			option.action = this.ACTION.ATTACK1;
+		}
+	}
+
+	// FIX: Detect the walk animation change and reset pathfinding route
+	const wasWalking = this.action === this.ACTION.WALK;
+	const newAction =
+		option.action === -1 || typeof option.action === 'undefined' ? this.ACTION.IDLE : option.action;
+	const willWalk = newAction === this.ACTION.WALK;
+
+	if (
+		wasWalking &&
+		!willWalk &&
+		!this.isFastMoving &&
+		this.walk &&
+		this.walk.total > 0 &&
+		this.objecttype !== this.constructor.TYPE_FALCON &&
+		this.objecttype !== this.constructor.TYPE_WUG
+	) {
+		this.resetRoute();
+	}
+
+	this.action = newAction;
+	anim.tick = Date.now() + 0;
+	anim.delay = 0;
+	anim.frame = option.frame || 0;
+	anim.speed = option.speed || false;
+	anim.length = option.length || false;
+	anim.repeat = option.repeat || false;
+	anim.play = typeof option.play !== 'undefined' ? option.play : true;
+	anim.next = option.next || false;
+	anim.save = false;
+
+	// Reset sounds
+	this.sound.free();
 }
 
 /**

--- a/src/Renderer/Entity/EntityRender.js
+++ b/src/Renderer/Entity/EntityRender.js
@@ -28,7 +28,6 @@ import SpriteRenderer from 'Renderer/SpriteRenderer.js';
 import Ground from 'Renderer/Map/Ground.js';
 import Altitude from 'Renderer/Map/Altitude.js';
 import Session from 'Engine/SessionStorage.js';
-import JobId from 'DB/Jobs/JobConst.js';
 import DB from 'DB/DBManager.js';
 import GraphicsSettings from 'Preferences/Graphics.js';
 import GR2ModelRenderer from 'Renderer/GR2/GR2ModelRenderer.js';
@@ -882,17 +881,25 @@ function getAnimationDelay(type, entity, act) {
 		return (act.delay / 150) * entity.walk.speed;
 	}
 
-	// Delay on attack
+	// Delay on attack (fallback when animation.speed is not explicitly set)
+	// Uses the ACT file delay directly (matching official C++ client m_motionSpeed = actRes->GetDelay(action)).
+	// Player normal attacks already provide animation.speed = pkt.attackMT / m_attackMotion in onEntityAttack.
 	if (
 		entity.action === entity.ACTION.ATTACK ||
 		entity.action === entity.ACTION.ATTACK1 ||
 		entity.action === entity.ACTION.ATTACK2 ||
 		entity.action === entity.ACTION.ATTACK3
 	) {
-		return entity.attack_speed / act.animations.length;
+		if (act && act.delay && act.delay > 0) {
+			return act.delay;
+		}
+		if (entity.attack_speed && act && act.animations && act.animations.length > 0) {
+			return Math.max(entity.attack_speed / act.animations.length, 100);
+		}
+		return 150;
 	}
 
-	return act.delay;
+	return (act && act.delay) || 150;
 }
 
 /**


### PR DESCRIPTION
Refactors skill action definitions to shared factories and threads packet data (`pkt.attackMT`) through skill-use handlers so combat/skill animations hold for a minimum motion window before transitioning (typically to `READYFIGHT`/`IDLE`). It also updates `EntityAction.setAction` delay handling to support relative vs absolute delays safely, applies expired delays immediately, and improves attack animation delay fallback logic in rendering to prefer ACT delays with defensive defaults.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mrantares/robrowserlegacy/pull/1417" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->