### PR TITLE
Prevent duplicate renderer callbacks

### DIFF
--- a/src/Renderer/Renderer.js
+++ b/src/Renderer/Renderer.js
@@ -417,7 +417,7 @@ class Renderer {
 	 * Start rendering
 	 */
 	static render(fn) {
-		if (fn) {
+		if (fn && !this.renderCallbacks.includes(fn)) {
 			this.renderCallbacks.push(fn);
 		}
 


### PR DESCRIPTION
Guard `Renderer.render()` so it only registers a callback once. This avoids duplicate entries in `renderCallbacks` when the same function is passed repeatedly, preventing redundant per-frame executions.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mrantares/robrowserlegacy/pull/1418" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->