### PR TITLE
Fix monk combo animations and attack slicing

### DIFF
--- a/src/DB/DBManager.js
+++ b/src/DB/DBManager.js
@@ -930,6 +930,22 @@ class DB {
 		return (jobid >= 4217 && jobid <= 4220) || jobid === 4308 || jobid === 4315;
 	}
 
+	static isMonk(jobid) {
+		switch (jobid) {
+			case JobId.MONK:
+			case JobId.MONK_H:
+			case JobId.MONK_B:
+			case JobId.SURA:
+			case JobId.SURA_H:
+			case JobId.SURA_B:
+			case JobId.SURA_2ND:
+			case JobId.INQUISITOR:
+			case JobId.INQUISITOR_RIDING:
+				return true;
+		}
+		return false;
+	}
+
 	/**
 	 * Is character id a baby ?
 	 *
@@ -2221,6 +2237,36 @@ class DB {
 		}
 
 		return 0;
+	}
+
+	/**
+	 * @return {{frame: number, length: number}|null} attack slice for jobs with combined action sheets
+	 * @param {number} job
+	 * @param {number} weapon
+	 */
+	static getAttackSlice(job, weapon) {
+		const type = DB.getWeaponType(weapon, true);
+		switch (job) {
+			case JobId.MONK:
+			case JobId.MONK_H:
+			case JobId.MONK_B:
+			case JobId.SURA:
+			case JobId.SURA_H:
+			case JobId.SURA_B:
+			case JobId.SURA_2ND:
+			case JobId.INQUISITOR:
+			case JobId.INQUISITOR_RIDING:
+				if (type === WeaponType.KNUKLE || type === WeaponType.NONE) {
+					return { frame: 0, length: 5 };
+				}
+				break;
+			case JobId.DO_SUMMONER:
+			case JobId.DO_SUMMONER_B:
+			case JobId.SPIRIT_HANDLER:
+			case JobId.SPIRIT_HANDLER_RIDING1:
+				return { frame: 0, length: 4 };
+		}
+		return null;
 	}
 
 	static mountWeapon(weaponID, shieldID) {

--- a/src/DB/DBManager.js
+++ b/src/DB/DBManager.js
@@ -930,22 +930,6 @@ class DB {
 		return (jobid >= 4217 && jobid <= 4220) || jobid === 4308 || jobid === 4315;
 	}
 
-	static isMonk(jobid) {
-		switch (jobid) {
-			case JobId.MONK:
-			case JobId.MONK_H:
-			case JobId.MONK_B:
-			case JobId.SURA:
-			case JobId.SURA_H:
-			case JobId.SURA_B:
-			case JobId.SURA_2ND:
-			case JobId.INQUISITOR:
-			case JobId.INQUISITOR_RIDING:
-				return true;
-		}
-		return false;
-	}
-
 	/**
 	 * Is character id a baby ?
 	 *
@@ -1022,6 +1006,7 @@ class DB {
 		JobId.MONK_H,
 		JobId.SURA,
 		JobId.SURA_H,
+		JobId.SURA_2ND,
 		JobId.INQUISITOR,
 
 		JobId.MONK_B,

--- a/src/DB/Skills/SkillAction.js
+++ b/src/DB/Skills/SkillAction.js
@@ -8,6 +8,7 @@
  *
  */
 
+import DB from 'DB/DBManager.js';
 import SK from './SkillConst.js';
 
 const SkillAction = {};
@@ -67,10 +68,15 @@ const makeSliceAttackAction = (actionProp = 'ATTACK', startFrame = 0, length = 0
 				: entity && entity.ACTION && entity.ACTION.READYFIGHT !== undefined
 					? entity.ACTION.READYFIGHT
 					: (entity && entity.ACTION && entity.ACTION.IDLE) || 0;
+
+		const job = entity && (typeof entity._job !== 'undefined' ? entity._job : entity.job);
+		const weapon = entity && (typeof entity.weapon !== 'undefined' ? entity.weapon : 0);
+		const hasSlice = job !== undefined ? DB.getAttackSlice(job, weapon) : true;
+
 		return {
-			action: entity.ACTION[actionProp],
-			frame: startFrame,
-			length: length > 0 ? length : false,
+			action: entity && entity.ACTION && entity.ACTION[actionProp] !== undefined ? entity.ACTION[actionProp] : 0,
+			frame: hasSlice ? startFrame : 0,
+			length: hasSlice && length > 0 ? length : false,
 			repeat: false,
 			play: true,
 			next: {

--- a/src/DB/Skills/SkillAction.js
+++ b/src/DB/Skills/SkillAction.js
@@ -58,23 +58,77 @@ const makeGenericSkillAction = (actionProp = 'SKILL', nextActionProp = 'IDLE') =
 		};
 	};
 
+const makeSliceAttackAction = (actionProp = 'ATTACK', startFrame = 0, length = 0, nextActionProp = 'READYFIGHT') =>
+	function (entity, tick, pkt) {
+		const holdDelay = pkt && pkt.attackMT ? Math.max(pkt.attackMT, 400) : 400;
+		const nextAction =
+			entity && entity.ACTION && entity.ACTION[nextActionProp] !== undefined
+				? entity.ACTION[nextActionProp]
+				: entity && entity.ACTION && entity.ACTION.READYFIGHT !== undefined
+					? entity.ACTION.READYFIGHT
+					: (entity && entity.ACTION && entity.ACTION.IDLE) || 0;
+		return {
+			action: entity.ACTION[actionProp],
+			frame: startFrame,
+			length: length > 0 ? length : false,
+			repeat: false,
+			play: true,
+			next: {
+				delay: (tick || Date.now()) + holdDelay,
+				action: nextAction,
+				frame: 0,
+				repeat: true,
+				play: true,
+				next: false
+			}
+		};
+	};
+
 //Default skill action
 SkillAction['DEFAULT'] = makeGenericSkillAction('SKILL');
+
+SkillAction['DEFAULT_MONK'] = makeGenericSkillAction('IDLE', 'IDLE');
 
 SkillAction['DEFAULT_DORAM'] = makeGenericSkillAction('ATTACK2');
 
 //Skill action overrides
 
-//IDLE
-SkillAction[SK.ST_CHASEWALK] = SkillAction[SK.CH_SOULCOLLECT] = function (entity, tick) {
-	return {
-		action: entity.ACTION.IDLE,
-		frame: 0,
-		repeat: true,
-		play: true,
-		next: false
-	};
-};
+//IDLE - Stance/buff skills for Monk, evolutions, and specific skills
+SkillAction[SK.AL_INCAGI] =
+	SkillAction[SK.CASH_INCAGI] =
+	SkillAction[SK.ST_CHASEWALK] =
+	SkillAction[SK.CH_SOULCOLLECT] =
+	SkillAction[SK.MO_CALLSPIRITS] =
+	SkillAction[SK.MO_ABSORBSPIRITS] =
+	SkillAction[SK.MO_BODYRELOCATION] =
+	SkillAction[SK.MO_STEELBODY] =
+	SkillAction[SK.MO_EXPLOSIONSPIRITS] =
+	SkillAction[SK.MO_KITRANSLATION] =
+	SkillAction[SK.SR_CURSEDCIRCLE] =
+	SkillAction[SK.SR_LIGHTNINGWALK] =
+	SkillAction[SK.SR_RAISINGDRAGON] =
+	SkillAction[SK.SR_GENTLETOUCH] =
+	SkillAction[SK.SR_ASSIMILATEPOWER] =
+	SkillAction[SK.SR_POWERVELOCITY] =
+	SkillAction[SK.SR_GENTLETOUCH_QUIET] =
+	SkillAction[SK.SR_GENTLETOUCH_CURE] =
+	SkillAction[SK.SR_GENTLETOUCH_ENERGYGAIN] =
+	SkillAction[SK.SR_GENTLETOUCH_CHANGE] =
+	SkillAction[SK.SR_GENTLETOUCH_REVITALIZE] =
+		function (entity, tick) {
+			return {
+				action: entity.ACTION.IDLE,
+				frame: 0,
+				repeat: true,
+				play: true,
+				next: false
+			};
+		};
+
+//SKILL - Explicit invocation skill action
+SkillAction[SK.AL_BLESSING] =
+	SkillAction[SK.CASH_BLESSING] =
+		makeGenericSkillAction('SKILL');
 
 //ATTACK - Normal attack with visible weapon
 SkillAction[SK.SM_BASH] =
@@ -92,14 +146,9 @@ SkillAction[SK.SM_BASH] =
 	SkillAction[SK.RG_INTIMIDATE] =
 	SkillAction[SK.CR_SHIELDCHARGE] =
 	SkillAction[SK.CR_HOLYCROSS] =
-	SkillAction[SK.MO_CHAINCOMBO] =
-	SkillAction[SK.MO_COMBOFINISH] =
 	SkillAction[SK.BA_MUSICALSTRIKE] =
 	SkillAction[SK.DC_THROWARROW] =
 	SkillAction[SK.NPC_DARKCROSS] =
-	SkillAction[SK.CH_PALMSTRIKE] =
-	SkillAction[SK.CH_TIGERFIST] =
-	SkillAction[SK.CH_CHAINCRUSH] =
 	SkillAction[SK.LK_SPIRALPIERCE] =
 	SkillAction[SK.LK_HEADCRUSH] =
 	SkillAction[SK.LK_JOINTBEAT] =
@@ -157,13 +206,38 @@ SkillAction[SK.SM_BASH] =
 	SkillAction[SK.LG_OVERBRAND] =
 	SkillAction[SK.LG_RAYOFGENESIS] =
 	SkillAction[SK.LG_EARTHDRIVE] =
-	SkillAction[SK.SR_DRAGONCOMBO] =
-	SkillAction[SK.SR_SKYNETBLOW] =
-	SkillAction[SK.SR_FALLENEMPIRE] =
-	SkillAction[SK.SR_TIGERCANNON] =
-	SkillAction[SK.SR_CRESCENTELBOW] =
-	SkillAction[SK.SR_GATEOFHELL] =
 		makeAttackSkillAction('ATTACK');
+
+// Monk & Evolutions (Champion, Sura) combo and attack slices
+// Triple Attack (Raging Trifecta Blow) - 3 hits
+SkillAction[SK.MO_TRIPLEATTACK] = makeSliceAttackAction('ATTACK', 5, 4);
+
+// Chain Combo (Raging Quadruple Blow) - 4 hits
+SkillAction[SK.MO_CHAINCOMBO] = makeSliceAttackAction('ATTACK', 9, 4);
+
+// Combo Finish (Raging Thrust) - finisher strike
+SkillAction[SK.MO_COMBOFINISH] = makeSliceAttackAction('ATTACK', 13, 2);
+
+// Champion combos
+SkillAction[SK.CH_PALMSTRIKE] = makeSliceAttackAction('ATTACK', 13, 2);
+SkillAction[SK.CH_TIGERFIST] = makeSliceAttackAction('ATTACK', 9, 4);
+SkillAction[SK.CH_CHAINCRUSH] = makeSliceAttackAction('ATTACK', 5, 8);
+
+// Sura combos & strike skills
+SkillAction[SK.SR_DRAGONCOMBO] = makeSliceAttackAction('ATTACK', 5, 4);
+SkillAction[SK.SR_SKYNETBLOW] = makeSliceAttackAction('ATTACK', 0, 5);
+SkillAction[SK.SR_FALLENEMPIRE] = makeSliceAttackAction('ATTACK', 13, 2);
+SkillAction[SK.SR_TIGERCANNON] = makeSliceAttackAction('ATTACK', 9, 4);
+SkillAction[SK.SR_CRESCENTELBOW] = makeSliceAttackAction('ATTACK', 13, 2);
+SkillAction[SK.SR_GATEOFHELL] = makeSliceAttackAction('ATTACK', 13, 2);
+
+// Summoner / Spirit Handler strike slices (extensible for Doram skills)
+if (SK.SH_CHUL_HO_SONIC_CLAW) {
+	SkillAction[SK.SH_CHUL_HO_SONIC_CLAW] = makeSliceAttackAction('ATTACK', 0, 4);
+}
+if (SK.SH_HOGOGONG_STRIKE) {
+	SkillAction[SK.SH_HOGOGONG_STRIKE] = makeSliceAttackAction('ATTACK', 0, 4);
+}
 
 //ATTACK1 - Throwing attack without visible weapon
 SkillAction[SK.KN_SPEARBOOMERANG] =
@@ -341,15 +415,7 @@ SkillAction[SK.MO_INVESTIGATE] = SkillAction[SK.MO_FINGEROFFENSIVE] = function (
 	};
 };
 
-SkillAction[SK.MO_EXTREMITYFIST] = function (entity, tick) {
-	return {
-		action: entity.ACTION.ATTACK,
-		delay: tick + 100,
-		frame: 0,
-		repeat: false,
-		play: true
-	};
-};
+SkillAction[SK.MO_EXTREMITYFIST] = makeSliceAttackAction('ATTACK', 13, 2);
 
 //9hit
 SkillAction[SK.CG_ARROWVULCAN] = function (entity, tick) {

--- a/src/Engine/MapEngine/Entity.js
+++ b/src/Engine/MapEngine/Entity.js
@@ -1437,6 +1437,8 @@ function onEntityUseSkill(pkt) {
 			} else {
 				if (DB.isDoram(srcEntity.job)) {
 					srcEntity.setAction(SkillActionTable['DEFAULT_DORAM'](srcEntity, Renderer.tick, pkt));
+				} else if (DB.isMonk(srcEntity.job)) {
+					srcEntity.setAction(SkillActionTable['DEFAULT_MONK'](srcEntity, Renderer.tick, pkt));
 				} else {
 					srcEntity.setAction(SkillActionTable['DEFAULT'](srcEntity, Renderer.tick, pkt));
 				}
@@ -1577,7 +1579,13 @@ function onEntityUseSkillToAttack(pkt) {
 					srcEntity.setAction(action(srcEntity, Renderer.tick, pkt));
 				}
 			} else {
-				srcEntity.setAction(SkillActionTable['DEFAULT'](srcEntity, Renderer.tick, pkt));
+				if (DB.isDoram(srcEntity.job)) {
+					srcEntity.setAction(SkillActionTable['DEFAULT_DORAM'](srcEntity, Renderer.tick, pkt));
+				} else if (DB.isMonk(srcEntity.job)) {
+					srcEntity.setAction(SkillActionTable['DEFAULT_MONK'](srcEntity, Renderer.tick, pkt));
+				} else {
+					srcEntity.setAction(SkillActionTable['DEFAULT'](srcEntity, Renderer.tick, pkt));
+				}
 			}
 
 			//Pet Talk

--- a/src/Renderer/Entity/EntityAction.js
+++ b/src/Renderer/Entity/EntityAction.js
@@ -95,6 +95,16 @@ function setAction(option) {
 		if (this.objecttype === this.constructor.TYPE_PC) {
 			const attack = DB.getWeaponAction(this.weapon, this._job, this._sex);
 			option.action = [this.ACTION.ATTACK1, this.ACTION.ATTACK2, this.ACTION.ATTACK3][attack];
+
+			if (!option.length) {
+				const slice = DB.getAttackSlice(this._job, this.weapon);
+				if (slice) {
+					if (typeof option.frame === 'undefined' || option.frame === 0) {
+						option.frame = slice.frame;
+					}
+					option.length = slice.length;
+				}
+			}
 		}
 
 		// No action loaded yet

--- a/src/Renderer/Entity/EntityRender.js
+++ b/src/Renderer/Entity/EntityRender.js
@@ -1022,17 +1022,17 @@ function calcAnimation(entity, act, type, tick) {
 	}
 
 	// No repeat
-	anim = Math.min((tick / delay) | 0, animCount || animCount - 1); // Avoid an error if animation = 0, search for -1 :(
+	anim = Math.min((tick / delay) | 0, animCount ? animCount - 1 : 0);
 
 	anim %= animCount;
 	anim += animCount * headDir; // get rid of doridori
 	anim += animation.frame; // previous frame
 	anim %= animSize; // avoid overflow
 
-	const lastFrame = animation.frame + animSize - 1;
+	const lastFrame = animation.frame + animCount - 1;
 
-	if (type === 'body' && anim >= lastFrame) {
-		animation.frame = anim = lastFrame;
+	if (type === 'body' && ((tick / delay) | 0) >= animCount - 1) {
+		animation.frame = anim = Math.min(lastFrame, animSize - 1);
 		animation.play = false;
 		if (animation.next) {
 			entity.setAction(animation.next);

--- a/tests/db/SkillAction.test.js
+++ b/tests/db/SkillAction.test.js
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.hoisted(() => {
+	if (typeof globalThis.localStorage === 'undefined' || typeof globalThis.localStorage.getItem !== 'function') {
+		const store = {};
+		globalThis.localStorage = {
+			getItem: (key) => (key in store ? store[key] : null),
+			setItem: (key, val) => {
+				store[key] = String(val);
+			},
+			removeItem: (key) => {
+				delete store[key];
+			},
+			clear: () => {
+				for (const k in store) delete store[k];
+			}
+		};
+	}
+});
+
+import DB from 'DB/DBManager.js';
+import JobId from 'DB/Jobs/JobConst.js';
+import WeaponType from 'DB/Items/WeaponType.js';
+import SK from 'DB/Skills/SkillConst.js';
+import SkillAction from 'DB/Skills/SkillAction.js';
+
+describe('SkillAction & Attack Slices', () => {
+	it('identifies Monk jobs correctly in DB.isMonk', () => {
+		expect(DB.isMonk(JobId.MONK)).toBe(true);
+		expect(DB.isMonk(JobId.MONK_H)).toBe(true);
+		expect(DB.isMonk(JobId.MONK_B)).toBe(true);
+		expect(DB.isMonk(JobId.SURA)).toBe(true);
+		expect(DB.isMonk(JobId.SURA_H)).toBe(true);
+		expect(DB.isMonk(JobId.SURA_B)).toBe(true);
+		expect(DB.isMonk(JobId.INQUISITOR)).toBe(true);
+
+		expect(DB.isMonk(JobId.KNIGHT)).toBe(false);
+		expect(DB.isMonk(JobId.PRIEST)).toBe(false);
+	});
+
+	it('returns correct attack slice for Monk / Champion / Sura with knuckles or bare-handed', () => {
+		const knuckleSlice = DB.getAttackSlice(JobId.MONK, WeaponType.KNUKLE);
+		expect(knuckleSlice).toEqual({ frame: 0, length: 5 });
+
+		const bareHandedSlice = DB.getAttackSlice(JobId.MONK_H, WeaponType.NONE);
+		expect(bareHandedSlice).toEqual({ frame: 0, length: 5 });
+
+		const suraSlice = DB.getAttackSlice(JobId.SURA, WeaponType.KNUKLE);
+		expect(suraSlice).toEqual({ frame: 0, length: 5 });
+	});
+
+	it('returns correct attack slice for Doram / Summoner', () => {
+		const doramSlice = DB.getAttackSlice(JobId.DO_SUMMONER, WeaponType.NONE);
+		expect(doramSlice).toEqual({ frame: 0, length: 4 });
+	});
+
+	it('returns null for standard single-sheet attack classes', () => {
+		const knightSlice = DB.getAttackSlice(JobId.KNIGHT, WeaponType.SWORD);
+		expect(knightSlice).toBeNull();
+
+		const priestSlice = DB.getAttackSlice(JobId.PRIEST, WeaponType.MACE);
+		expect(priestSlice).toBeNull();
+	});
+
+	it('defaults Monk generic skills to IDLE via DEFAULT_MONK and mapped IDLE skills', () => {
+		const mockEntity = {
+			ACTION: { ATTACK: 5, READYFIGHT: 4, IDLE: 0, SKILL: 12 }
+		};
+
+		const defaultMonkAction = SkillAction['DEFAULT_MONK'](mockEntity, 1000);
+		expect(defaultMonkAction.action).toBe(0);
+
+		// Monk buff/stance skills stay in IDLE
+		const callSpirits = SkillAction[SK.MO_CALLSPIRITS](mockEntity, 1000);
+		expect(callSpirits.action).toBe(0);
+
+		const absorbSpirits = SkillAction[SK.MO_ABSORBSPIRITS](mockEntity, 1000);
+		expect(absorbSpirits.action).toBe(0);
+
+		const steelBody = SkillAction[SK.MO_STEELBODY](mockEntity, 1000);
+		expect(steelBody.action).toBe(0);
+
+		const snap = SkillAction[SK.MO_BODYRELOCATION](mockEntity, 1000);
+		expect(snap.action).toBe(0);
+
+		const fury = SkillAction[SK.MO_EXPLOSIONSPIRITS](mockEntity, 1000);
+		expect(fury.action).toBe(0);
+
+		const risingDragon = SkillAction[SK.SR_RAISINGDRAGON](mockEntity, 1000);
+		expect(risingDragon.action).toBe(0);
+	});
+
+	it('maps AL_INCAGI to IDLE and AL_BLESSING to SKILL per canonical C++ client source', () => {
+		const mockEntity = {
+			ACTION: { ATTACK: 5, READYFIGHT: 4, IDLE: 0, SKILL: 12 }
+		};
+
+		const incAgi = SkillAction[SK.AL_INCAGI](mockEntity, 1000);
+		expect(incAgi.action).toBe(0); // ACTION.IDLE
+
+		const blessing = SkillAction[SK.AL_BLESSING](mockEntity, 1000);
+		expect(blessing.action).toBe(12); // ACTION.SKILL
+	});
+
+	it('defines correct motion slices for Monk combo skills', () => {
+		const mockEntity = {
+			ACTION: { ATTACK: 5, READYFIGHT: 4, IDLE: 0 }
+		};
+
+		const tripleAtk = SkillAction[SK.MO_TRIPLEATTACK](mockEntity, 1000);
+		expect(tripleAtk.frame).toBe(5);
+		expect(tripleAtk.length).toBe(4);
+		expect(tripleAtk.action).toBe(5);
+
+		const chainCombo = SkillAction[SK.MO_CHAINCOMBO](mockEntity, 1000);
+		expect(chainCombo.frame).toBe(9);
+		expect(chainCombo.length).toBe(4);
+
+		const comboFinish = SkillAction[SK.MO_COMBOFINISH](mockEntity, 1000);
+		expect(comboFinish.frame).toBe(13);
+		expect(comboFinish.length).toBe(2);
+
+		const extremityFist = SkillAction[SK.MO_EXTREMITYFIST](mockEntity, 1000);
+		expect(extremityFist.frame).toBe(13);
+		expect(extremityFist.length).toBe(2);
+	});
+});


### PR DESCRIPTION
Add Monk/Sura/Inquisitor job detection and centralized attack-slice metadata in DB, then use it when selecting PC attack actions so combined action sheets play the correct frame ranges. Update skill action mappings with Monk/Champion/Sura combo-specific slice attacks, Monk idle fallback behavior, and Doram-safe defaults in skill-use paths. Also fix non-repeating animation frame clamping in EntityRender to stop at the correct last frame based on animation count.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mrantares/robrowserlegacy/pull/1419" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->