### PR TITLE
fix(render): sky clouds draw the ground atlas from a leaked active texture unit

### DIFF
--- a/src/Renderer/Map/Altitude.js
+++ b/src/Renderer/Map/Altitude.js
@@ -77,7 +77,19 @@ class Altitude {
 	 * @return {Array} cell
 	 */
 	static getCell(x, y) {
-		const index = (Math.floor(x) + Math.floor(y) * Altitude.width) * 5;
+		const cx = Math.floor(x);
+		const cy = Math.floor(y);
+
+		// Outside the map the index either runs past the array (undefined, which
+		// becomes NaN once written into a Float32Array vertex buffer) or, for a
+		// negative x with a positive y, wraps into a valid but wrong cell. Both
+		// produce garbage geometry. See intersect() for how we get here.
+		if (!_cells || cx < 0 || cy < 0 || cx >= Altitude.width || cy >= Altitude.height) {
+			tmp[0] = tmp[1] = tmp[2] = tmp[3] = tmp[4] = 0.0;
+			return tmp;
+		}
+
+		const index = (cx + cy * Altitude.width) * 5;
 
 		tmp[0] = _cells[index + 0];
 		tmp[1] = _cells[index + 1];
@@ -96,6 +108,10 @@ class Altitude {
 	 * @return {number} cell type
 	 */
 	static getCellType(x, y) {
+		if (!_types || x < 0 || y < 0 || x >= Altitude.width || y >= Altitude.height) {
+			return Altitude.TYPE.NONE;
+		}
+
 		return _types[x + y * Altitude.width];
 	}
 
@@ -116,7 +132,15 @@ class Altitude {
 		x += 0.5;
 		y += 0.5;
 
-		const index = (Math.floor(x) + Math.floor(y) * Altitude.width) * 5;
+		const cx = Math.floor(x);
+		const cy = Math.floor(y);
+
+		// Unbounded, this read NaN or a wrapped cell outside the map
+		if (cx < 0 || cy < 0 || cx >= Altitude.width || cy >= Altitude.height) {
+			return 0.0;
+		}
+
+		const index = (cx + cy * Altitude.width) * 5;
 
 		x %= 1.0;
 		y %= 1.0;
@@ -182,6 +206,16 @@ class Altitude {
 			_from[1] += _unit[1];
 			_from[2] += _unit[2];
 
+			// The ray leaves the map on any map whose ground does not fill the
+			// view - airplane_01, the Valkyrie realm, anything floating in sky.
+			// Without this the march kept sampling cells outside the map and
+			// could report a "hit" there, which put a bogus cell into
+			// Mouse.world (walk packets read it) and drew the grid selector on
+			// garbage geometry.
+			if (_from[0] < 0 || _from[2] < 0 || _from[0] >= Altitude.width || _from[2] >= Altitude.height) {
+				continue;
+			}
+
 			if (Math.abs(Altitude.getCellHeight(_from[0], _from[2]) + _from[1]) < 0.5) {
 				out[0] = _from[0];
 				out[1] = _from[2];
@@ -234,42 +268,53 @@ class Altitude {
 
 		for (x = -middle; x <= middle; ++x) {
 			for (y = -middle; y <= middle; ++y, i += 30) {
-				index = (pos_x + x + (pos_y + y) * Altitude.width) * 5;
+				const gx = pos_x + x;
+				const gy = pos_y + y;
+				const oob = gx < 0 || gy < 0 || gx >= Altitude.width || gy >= Altitude.height;
+
+				// Effects near a map edge overlap cells that do not exist; an
+				// unguarded read puts undefined -> NaN into the vertex buffer.
+				index = oob ? -1 : (gx + gy * Altitude.width) * 5;
+
+				const h0 = oob ? 0.0 : _cells[index + 0];
+				const h1 = oob ? 0.0 : _cells[index + 1];
+				const h2 = oob ? 0.0 : _cells[index + 2];
+				const h3 = oob ? 0.0 : _cells[index + 3];
 
 				// Triangle 1
 				buffer[i + 0] = pos_x + x + 0;
-				buffer[i + 1] = _cells[index + 0];
+				buffer[i + 1] = h0;
 				buffer[i + 2] = pos_y + y + 0;
 				buffer[i + 3] = (x + 0 + middle) / size;
 				buffer[i + 4] = (y + 0 + middle) / size;
 
 				buffer[i + 5] = pos_x + x + 1;
-				buffer[i + 6] = _cells[index + 1];
+				buffer[i + 6] = h1;
 				buffer[i + 7] = pos_y + y + 0;
 				buffer[i + 8] = (x + 1 + middle) / size;
 				buffer[i + 9] = (y + 0 + middle) / size;
 
 				buffer[i + 10] = pos_x + x + 1;
-				buffer[i + 11] = _cells[index + 3];
+				buffer[i + 11] = h3;
 				buffer[i + 12] = pos_y + y + 1;
 				buffer[i + 13] = (x + 1 + middle) / size;
 				buffer[i + 14] = (y + 1 + middle) / size;
 
 				// Triangle 2
 				buffer[i + 15] = pos_x + x + 1;
-				buffer[i + 16] = _cells[index + 3];
+				buffer[i + 16] = h3;
 				buffer[i + 17] = pos_y + y + 1;
 				buffer[i + 18] = (x + 1 + middle) / size;
 				buffer[i + 19] = (y + 1 + middle) / size;
 
 				buffer[i + 20] = pos_x + x + 0;
-				buffer[i + 21] = _cells[index + 2];
+				buffer[i + 21] = h2;
 				buffer[i + 22] = pos_y + y + 1;
 				buffer[i + 23] = (x + 0 + middle) / size;
 				buffer[i + 24] = (y + 1 + middle) / size;
 
 				buffer[i + 25] = pos_x + x + 0;
-				buffer[i + 26] = _cells[index + 0];
+				buffer[i + 26] = h0;
 				buffer[i + 27] = pos_y + y + 0;
 				buffer[i + 28] = (x + 0 + middle) / size;
 				buffer[i + 29] = (y + 0 + middle) / size;

--- a/src/Renderer/Map/Ground.js
+++ b/src/Renderer/Map/Ground.js
@@ -141,6 +141,14 @@ function render(gl, modelView, projection, normalMat, fog, light) {
 	gl.disableVertexAttribArray(attribute.aTextureCoord);
 	gl.disableVertexAttribArray(attribute.aLightmapCoord);
 	gl.disableVertexAttribArray(attribute.aTileColorCoord);
+
+	// Restore the active texture unit. The lightmap and tile-color binds above
+	// leave it on TEXTURE2, and every later pass that calls bindTexture without
+	// selecting a unit first then binds to 2 while its shader samples 0 - which
+	// still holds _textureAtlas. That is why sky clouds rendered as the map's
+	// own ground textures, and why hovering walkable ground hid it: GridSelector
+	// sets TEXTURE0 itself, and only runs when the mouse hits the ground.
+	gl.activeTexture(gl.TEXTURE0);
 }
 
 /**

--- a/src/Renderer/SpriteRenderer.js
+++ b/src/Renderer/SpriteRenderer.js
@@ -474,7 +474,11 @@ class SpriteRenderer {
 		gl.uniform1f(uniform.uFogFar, fog.far);
 		gl.uniform3fv(uniform.uFogColor, fog.color);
 
-		// Textures
+		// Textures. Select unit 0 explicitly: uDiffuse samples it, but a previous
+		// pass may have left the active unit elsewhere, and only the palette path
+		// below happens to reset it - so palette-less sprites (clouds) would bind
+		// their texture to whatever unit was current.
+		gl.activeTexture(gl.TEXTURE0);
 		gl.uniform1i(uniform.uDiffuse, 0);
 		gl.uniform1i(uniform.uPalette, 1);
 

--- a/tests/renderer/Altitude.test.js
+++ b/tests/renderer/Altitude.test.js
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('Utils/PathFinding.js', () => ({ default: { setGat: vi.fn(), updateGat: vi.fn() } }));
+vi.mock('Controls/MouseEventHandler.js', () => ({ default: { screen: { x: 0, y: 0, width: 800, height: 600 } } }));
+vi.mock('Renderer/Effects/Shaders/VerticalFlip.js', () => ({ default: { isActive: () => false } }));
+
+const { default: Altitude } = await import('Renderer/Map/Altitude.js');
+
+const WIDTH = 4;
+const HEIGHT = 4;
+
+/**
+ * Build a synthetic altitude grid.
+ *
+ * Cells are 5 floats: four corner heights then the type. Loaders/Altitude.js
+ * stores an already-mapped TYPE bitmask in that last slot, not a raw GAT code,
+ * so seed it the same way. Cell n gets height -(n + 1), which makes every cell
+ * distinguishable and lets a wrapped read be identified by the value it returns.
+ *
+ * @param {number} width
+ * @param {number} height
+ * @return {Float32Array} cells
+ */
+function buildCells(width, height) {
+	const cells = new Float32Array(width * height * 5);
+	const walkable = Altitude.TYPE.WALKABLE | Altitude.TYPE.SNIPABLE;
+
+	for (let i = 0; i < width * height; ++i) {
+		cells[i * 5 + 0] = cells[i * 5 + 1] = cells[i * 5 + 2] = cells[i * 5 + 3] = -(i + 1);
+		cells[i * 5 + 4] = walkable;
+	}
+
+	return cells;
+}
+
+describe('Renderer/Map/Altitude bounds handling', () => {
+	beforeEach(() => {
+		Altitude.init({ cells: buildCells(WIDTH, HEIGHT), width: WIDTH, height: HEIGHT });
+	});
+
+	describe('in-bounds lookups are unaffected', () => {
+		it('returns interpolated cell heights', () => {
+			expect(Altitude.getCellHeight(0, 0)).toBe(1);
+			expect(Altitude.getCellHeight(3, 3)).toBe(16);
+		});
+
+		it('reports walkable cells as walkable', () => {
+			expect(Altitude.getCellType(0, 0) & Altitude.TYPE.WALKABLE).not.toBe(0);
+		});
+
+		it('returns the raw corner heights', () => {
+			expect(Altitude.getCell(2, 1)[0]).toBe(-7);
+		});
+
+		it('builds a plane from the real cell heights', () => {
+			const plane = Altitude.generatePlane(2, 2, 1);
+
+			expect(plane[1]).toBe(-11);
+			expect(plane[6]).toBe(-11);
+		});
+	});
+
+	describe('out-of-bounds lookups', () => {
+		// A negative x with a positive y lands on a valid index belonging to a
+		// different cell: (-1, 2) computes (-1 + 2 * 4) * 5 = 35, which is cell
+		// (3, 1). Unguarded, that reports a plausible height for a position that
+		// is not on the map at all.
+		it('does not wrap a negative x into a neighbouring row', () => {
+			expect(Altitude.getCellHeight(-1, 2)).toBe(0);
+			expect(Altitude.getCellType(-1, 2) & Altitude.TYPE.WALKABLE).toBe(0);
+		});
+
+		it.each([
+			[99, 0],
+			[0, 99],
+			[-5, -5],
+			[WIDTH, 0],
+			[0, HEIGHT]
+		])('returns a height of 0 rather than NaN at (%i, %i)', (x, y) => {
+			const height = Altitude.getCellHeight(x, y);
+
+			expect(Number.isNaN(height)).toBe(false);
+			expect(height).toBe(0);
+		});
+
+		it('does not report an off-map cell as walkable', () => {
+			expect(Altitude.getCellType(99, 99) & Altitude.TYPE.WALKABLE).toBe(0);
+		});
+
+		it('returns a zeroed cell instead of undefined values', () => {
+			expect(Array.from(Altitude.getCell(-3, 99))).toEqual([0, 0, 0, 0, 0]);
+		});
+	});
+
+	describe('generatePlane near the map edge', () => {
+		// Reads past the array yield undefined, which becomes NaN once written
+		// into the Float32Array vertex buffer, and a NaN vertex rasterises as
+		// undefined geometry.
+		it.each([
+			['a corner', 0, 0, 5],
+			['past the far edge', 3, 3, 7]
+		])('emits no NaN vertices at %s', (_label, x, y, size) => {
+			const plane = Altitude.generatePlane(x, y, size);
+
+			expect(plane).not.toBeNull();
+			expect(Array.from(plane).some(Number.isNaN)).toBe(false);
+		});
+	});
+});


### PR DESCRIPTION
Fixes texture corruption on maps whose ground does not fill the view
(`airplane_01`, `yuno`, the Valkyrie realm), plus two related GL state bugs
found alongside it.

## The bug

Hovering the mouse over empty sky makes the clouds render the current map's own
ground textures. It persists while the cursor stays on sky and stops the moment
it moves back onto walkable ground.

**Cause:** `Ground.render` binds three textures, stepping the active texture unit
up to `TEXTURE2`, and never resets it. It returns with the active unit on 2 while
unit 0 still holds `_textureAtlas`. Any later pass that binds a texture without
selecting a unit first therefore binds to 2 while its shader samples 0 — and so
draws the ground atlas.

Every symptom follows from that:

| Observation | Explanation |
| --- | --- |
| Textures are always from the current map, never random | It is literally `_textureAtlas`; each 500-unit cloud quad samples it across 0..1 UV, which is why it looks like a grid of map tiles |
| Only while hovering empty sky | `GridSelector.render` calls `activeTexture(TEXTURE0)` itself, but only runs when `Altitude.intersect` hits walkable ground |
| Stops on moving back to ground | Same reason, in reverse |
| Only clouds, never entity sprites | The palette path in `RenderCanvas3D` does `TEXTURE1` → `TEXTURE0` before the diffuse bind, so palette sprites incidentally repair the unit. Clouds set `image.palette = null` and skip it |

Fixed at the leak, plus `SpriteRenderer.bind3DContext` now selects unit 0
explicitly so sprite rendering is correct regardless of what any other pass
leaves behind.

## Also included

**`Altitude` bounds checks.** `getCell`, `getCellHeight`, `getCellType` and
`generatePlane` index their arrays unguarded. On a sky map the mouse ray marches
off the map edge, where reads either run past the array (`undefined`, which
becomes `NaN` in a `Float32Array` vertex buffer) or, for a negative x with a
positive y, wrap into a valid but wrong cell — so `intersect` reports a hit
outside the map. That also puts a garbage cell into `Mouse.world`, which
`EntityControl` reads for `pkt.dest`, sending bad walk destinations to the
server. In-bounds behaviour is unchanged.

## Testing

- The active-unit fix is **confirmed in game** on `yuno` and `airplane_01`.
- The `Altitude` guards are covered by `tests/renderer/Altitude.test.js`, added
  here: the wrap case, every off-edge direction, `generatePlane` emitting no NaN
  vertices at a corner and past the far edge, and in-bounds lookups returning
  unchanged values. Nine of its fourteen tests fail without the bounds commit.
  Full suite passes (44 files, 268 tests).

Also checked that these changes cannot affect other effect renderers: the only
files that bind a texture without selecting a unit are `Damage`, `PoisonEffect`,
`PokJukWeatherEffect` and `PostProcess`, none of which draws map effects.

`npm run lint` and `npm run format:check` are clean on the changed files.
